### PR TITLE
fix: n_expected algorithm inputs

### DIFF
--- a/subset.sh
+++ b/subset.sh
@@ -15,7 +15,7 @@ else
     aoi="$(ls input/*)"
 
     n_actual=${#}
-    n_expected=4
+    n_expected=6
 
     if test ${n_actual} -gt 0 -a ${n_actual} -ne ${n_expected}; then
         echo "Expected ${n_expected} inputs, but got ${n_actual}:$(printf " '%b'" "$@")" >&2


### PR DESCRIPTION
[Fix Bug in Version 0.3.0 #31](https://github.com/MAAP-Project/gedi-subsetter/issues/31)
[#347 in the active maap sprint](https://github.com/NASA-IMPACT/active-maap-sprint/issues/347)

Closed previous merge requests to clean up commit history, need to open and merge these requests one at a time
