### PR TITLE
fix: n_expected algorithm inputs

### DIFF
--- a/subset.sh
+++ b/subset.sh
@@ -15,7 +15,7 @@ else
     aoi="$(ls input/*)"
 
     n_actual=${#}
-    n_expected=4
+    n_expected=6
 
     if test ${n_actual} -gt 0 -a ${n_actual} -ne ${n_expected}; then
         echo "Expected ${n_expected} inputs, but got ${n_actual}:$(printf " '%b'" "$@")" >&2


### PR DESCRIPTION
Fixing version 0.3.0 through hotfix
https://github.com/NASA-IMPACT/active-maap-sprint/issues/347

PR retains the "7" expected algorithm inputs but adds the commit to the develop branch