### PR TITLE
Use NASA CMR, not MAAP CMR

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
   python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -19,26 +19,26 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v2.0.0
+    rev: v2.1.1
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         # optional: list of Conventional Commits types to allow e.g. [feat, fix, ci, chore, test]
         args: []
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.3.0
     hooks:
       - id: black-jupyter
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.8.0
+    rev: v0.9.0
     hooks:
       - id: shellcheck
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+## [0.5.0] - 2023-04-11
+
+### Changed
+
+- [#36](https://github.com/MAAP-Project/gedi-subsetter/issues/36): All CMR
+  queries now use the NASA CMR, because the MAAP CMR is being retired.  If you
+  wish to query the MAAP CMR until it is taken down, you may still use an
+  earlier version of this algorithm (ideally, 0.4.0).
+
 ## [0.4.0] - 2022-11-14
 
 ### Added
+
 - [#6](https://github.com/MAAP-Project/gedi-subsetter/issues/6): Allow user to
   specify which BEAMs to subset
 

--- a/algorithm_config.yaml
+++ b/algorithm_config.yaml
@@ -1,6 +1,6 @@
 description: Subset GEDI L1B, L2A, L2B, or L4A granules within an area of interest (AOI)
 algo_name: gedi-subset
-version: 0.4.0
+version: 0.5.0
 environment: ubuntu
 repository_url: https://repo.ops.maap-project.org/data-team/gedi-subsetter.git
 docker_url: mas.dit.maap-project.org/root/maap-workspaces/base_images/r:dit

--- a/build.sh
+++ b/build.sh
@@ -24,15 +24,15 @@ esac
 conda create -y -n gedi_subset --file "${basedir}/environment/conda-${platform}-64.lock"
 
 # Install maap-py, since it cannot be specified in the lock file
-conda env update -n gedi_subset --file "${basedir}/environment/environment-maappy.yml"
+PIP_REQUIRE_VENV=0 conda env update -n gedi_subset --file "${basedir}/environment/environment-maappy.yml"
 
 # Install development environment dependencies if the --dev flag is set
 # Running build.sh in gedi-subset directory with --dev
 if [[ "${1:-}" == "--dev" ]]; then
-    conda env update -n gedi_subset --file "${basedir}/environment/environment-dev.yml"
+   PIP_REQUIRE_VENV=0 conda env update -n gedi_subset --file "${basedir}/environment/environment-dev.yml"
 fi
 
-conda run --no-capture-output -n gedi_subset pip install -e "${basedir}"
+conda run --no-capture-output -n gedi_subset PIP_REQUIRE_VENV=0 python -m pip install -e "${basedir}"
 
 # Fail build if finicky mix of fiona and gdal isn't correct, so that we don't
 # have to wait to execute a DPS job to find out.

--- a/environment/environment-dev.yml
+++ b/environment/environment-dev.yml
@@ -21,7 +21,7 @@ dependencies:
   # - mypy=0.950
   - mypy=0.971
   - pandas-stubs
-  - pip
+  - pip=23.0.1
   - pre-commit=2.20.0
   - pytest=7.1.3
   - types-cachetools=5.2.1

--- a/environment/environment-maappy.yml
+++ b/environment/environment-maappy.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pip
+  - pip=23.0.1
   - pip:
-    - git+https://github.com/MAAP-Project/maap-py.git@hotfixes#egg=maappy
+    - git+https://github.com/MAAP-Project/maap-py.git@d0f34e3440bf1121882892a5fe0b20484b413d43#egg=maappy

--- a/notebooks/subset.ipynb
+++ b/notebooks/subset.ipynb
@@ -83,7 +83,6 @@
     "\n",
     "# @timecall\n",
     "def spatial_filter(beam, aoi):\n",
-    "\n",
     "    lat = beam[\"lat_lowestmode\"][:]\n",
     "    lon = beam[\"lon_lowestmode\"][:]\n",
     "    i = np.arange(0, len(lat), 1)  # index\n",
@@ -1144,7 +1143,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/src/gedi_subset/subset.py
+++ b/src/gedi_subset/subset.py
@@ -5,7 +5,6 @@ import multiprocessing
 import os
 import os.path
 from dataclasses import dataclass
-from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, NoReturn, Optional, Sequence, Tuple
 
@@ -38,15 +37,6 @@ from gedi_subset.gedi_utils import (
     subset_hdf5,
 )
 from gedi_subset.maapx import download_granule, find_collection
-
-
-class CMRHost(str, Enum):
-    maap = "cmr.maap-project.org"
-    nasa = "cmr.earthdata.nasa.gov"
-
-    def __str__(self) -> str:
-        return self.value
-
 
 logical_dois = {
     "L1B": "10.5067/GEDI/GEDI01_B.002",
@@ -286,10 +276,6 @@ def main(
             f" names: {', '.join(logical_dois)}"
         ),
     ),
-    cmr_host: CMRHost = typer.Option(
-        CMRHost.maap,
-        help="CMR hostname",
-    ),
     lat: str = typer.Option(
         ..., help=("Latitude dataset used in the geometry of the dataframe")
     ),
@@ -345,6 +331,7 @@ def main(
     osx.remove(dest)
 
     maap = MAAP("api.ops.maap-project.org")
+    cmr_host = "cmr.earthdata.nasa.gov"
 
     IOResult.do(
         subsets


### PR DESCRIPTION
- Remove `--cmr-host` CLI option and hardcode use of NASA CMR hostname
- Pin `pip` and `maap-py`
- Set `PIP_REQUIRE_VENV` to `0` to allow `conda` to `pip install` without an active virtualenv
- Update pre-commit config to latest repo versions to resolve isort failure during pre-commit execution
- Bump algorithm version