### PR TITLE
fix: use latest version of maap-py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+## [0.6.2] - 2023-12-05
+
+### Fixed
+
+- Updated to use v3.1.3 of maap-py in environment-maappy.yml. Previous versions
+  of maap-py were using the deprecated MAAP Query Service API endpoint.
+
 ## [0.6.1] - 2023-09-26
 
 ### Fixed

--- a/environment/environment-maappy.yml
+++ b/environment/environment-maappy.yml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - pip=23.0.1
   - pip:
-    - git+https://github.com/MAAP-Project/maap-py.git@d0f34e3440bf1121882892a5fe0b20484b413d43#egg=maappy
+    - git+https://github.com/MAAP-Project/maap-py.git@v3.1.3#egg=maappy


### PR DESCRIPTION
## Fixes
- Updated to use v3.1.3 of maap-py in environment-maappy.yml. Previous versions of maap-py were using the deprecated MAAP Query Service API endpoint.