### PR TITLE
Capture stderr to gedi-subset.log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ The format is based on [Keep a Changelog], and this project adheres to
 - [#57](https://github.com/MAAP-Project/gedi-subsetter/issues/57) Users may
   choose to profile their jobs by specifying command-line options for the
   `scalene` profiling tool. See `docs/MAAP_USAGE.md` for more information.
+- [#44](https://github.com/MAAP-Project/gedi-subsetter/issues/44) Granule
+  download failures are now retried up to 10 times to reduce the likelihood that
+  subsetting will fail due to a download failure.
+- [#56](https://github.com/MAAP-Project/gedi-subsetter/issues/56) The
+  `bin/subset` script now captures output to `stderr` and writes it to the log
+  file named `gedi-subset.log`.  When a job succeeds, the log file will appear
+  in the job's output directory.  Otherwise, it will appear in the jobs triage
+  directory.
 
 ## 0.6.2 (2023-12-05)
 

--- a/bin/subset
+++ b/bin/subset
@@ -64,4 +64,17 @@ fi
 
 set -x
 mkdir -p "${output_dir}"
-"${CONDA_EXE:-conda}" run --live-stream --name gedi_subset "${command[@]}"
+
+# Capture stderr and write to a log file in the current working directory so
+# that if the job fails, the log file is copied to the triage directory (all
+# "${PWD}/*.log" files are copied to the triage directory by the DPS system).
+# Note that we chose to capture stderr rather than configuring Python logging
+# to write directly to a file because it is a tricky feat to coordinate logging
+# from multiple processes into a single file.
+logfile="${PWD}/gedi-subset.log"
+"${CONDA_EXE:-conda}" run --live-stream --name gedi_subset "${command[@]}" 2>"${logfile}"
+
+# If we get here, the command above succeeded (otherwise this script would have
+# exited with a non-zero status).  We can now move the log file to the output
+# directory so that is included in the final output directory for the user.
+mv "${logfile}" "${output_dir}"


### PR DESCRIPTION
Aside from capturing stderr to a log file and adding the appropriate changelog entry, I also added a missing changelog entry.

Fixes #56