### PR TITLE
Support alternate output formats

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
   autofix_prs: false
 
 default_language_version:
-  python: python3.11
+  python: python3.12
 repos:
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,18 +8,6 @@ ci:
 default_language_version:
   python: python3.12
 repos:
-  - repo: local
-    hooks:
-      # Make sure the conda-lock.yml file is up to date if the conda environment
-      # files have been changed.  We don't want to commit an outdated lock file.
-      # Since `conda` is not installed on the pre-commit.ci, this will simply
-      # fail the CI build if the lock file is outdated.
-      - id: conda-lock
-        name: update conda-lock.yml file
-        language: system
-        entry: make lock
-        pass_filenames: false
-        files: "^(environment.*.yml|bin/lock)$"
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Valid values for the `output` option have changed such that a file extension
+  is required, whereas previously this was optional since `.gpkg` was the only
+  supported output format.  However, in addition to `.gpkg`, it is now possible
+  to specify other file extensions to infer the desired output file format.
+  (([#97](https://github.com/MAAP-Project/gedi-subsetter/issues/97))
+
 ## [0.9.0] (2024-10-09)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Valid values for the `output` option have changed such that a file extension
   is required, whereas previously this was optional since `.gpkg` was the only
   supported output format.  However, in addition to `.gpkg`, it is now possible
-  to specify other file extensions to infer the desired output file format.
+  to specify the extensions `.parquet` for (Geo)Parquet format, and `.fgb` for
+  FlatGeobuf format.
   (([#97](https://github.com/MAAP-Project/gedi-subsetter/issues/97))
 
 ## [0.9.0] (2024-10-09)

--- a/bin/install
+++ b/bin/install
@@ -13,35 +13,16 @@ bin=$(dirname "$(readlink -f "$0")")
 basedir=$(dirname "${bin}")
 run="${bin}/run"
 
-# Install dev dependencies by default.  Pass --no-dev to disable.
-dev=1
-conda_env_name="gedi_subset"
-
-# All arguments are passed to conda lock install, but if --no-dev is specified,
-# we want to make sure we do NOT install the environment as a Jupyter kernel.
-while ((${#})); do
-    [[ "${1}" == "--no-dev" ]] && dev=
-    conda_lock_args+=("${1}")
-    shift
-done
-
 # Install dependencies from the conda lock file for speed and reproducibility.
 # Since there is at least one package (maap-py) that is not available on conda,
 # we need to use pip to install it (conda does this for us), so we must set
 # PIP_REQUIRE_VENV=0 to avoid complaints about installing packages outside of a
 # virtual environment.
-PIP_REQUIRE_VENV=0 "${run}" conda lock install "${conda_lock_args[@]}" \
-    --name "${conda_env_name}" "${basedir}/conda-lock.yml"
+PIP_REQUIRE_VENV=0 "${run}" conda lock install "$@" \
+    --name "gedi_subset" "${basedir}/conda-lock.yml"
 
 # pip install gedi-subsetter in editable mode.
 PIP_REQUIRE_VENV=0 "${run}" python -m pip install -e "${basedir}" --no-deps
-
-# If development dependencies were installed, let's also install the conda
-# environment as a Jupyter kernel.
-if [[ -n "${dev}" ]]; then
-    "${run}" python -Xfrozen_modules=off -m ipykernel install --user \
-        --name "${conda_env_name}" --display-name "GEDI Subsetter"
-fi
 
 # Fail build if finicky mix of fiona and gdal isn't correct, so that we don't
 # have to wait to execute a DPS job to find out.

--- a/bin/subset.sh
+++ b/bin/subset.sh
@@ -43,7 +43,8 @@ else
     [[ -n "${6}" ]] && args+=(--temporal "${6}")
     [[ -n "${7}" ]] && args+=(--beams "${7}")
     [[ -n "${8}" ]] && args+=(--limit "${8}")
-    [[ -n "${9}" ]] && args+=(--output "${9}")
+    # always specify output dir, even if user doesn't specify output file
+    args+=(--output "${output_dir}/${9}")
     [[ -n "${10}" ]] && args+=(--fsspec-kwargs "${10}")
     [[ -n "${11}" ]] && args+=(--processes "${11}")
     # Split the last argument into an array of arguments to pass to scalene.

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -1249,8 +1249,8 @@ package:
   hash:
     md5: a38b801f2bcc12af80c2e02a9e4ce7d9
     sha256: f334115c6b0c6c2cd0d28595365f205ec7eaa60bcc5ff91a75d7245f728be820
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: backoff
   version: 2.2.1
   manager: conda
@@ -1261,8 +1261,8 @@ package:
   hash:
     md5: a38b801f2bcc12af80c2e02a9e4ce7d9
     sha256: f334115c6b0c6c2cd0d28595365f205ec7eaa60bcc5ff91a75d7245f728be820
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: backoff
   version: 2.2.1
   manager: conda
@@ -1273,8 +1273,8 @@ package:
   hash:
     md5: a38b801f2bcc12af80c2e02a9e4ce7d9
     sha256: f334115c6b0c6c2cd0d28595365f205ec7eaa60bcc5ff91a75d7245f728be820
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: backports
   version: '1.0'
   manager: conda
@@ -1574,7 +1574,7 @@ package:
   category: main
   optional: false
 - name: boto3-stubs
-  version: 1.36.13
+  version: 1.36.15
   manager: conda
   platform: linux-64
   dependencies:
@@ -1582,14 +1582,14 @@ package:
     python: ''
     types-s3transfer: ''
     typing-extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.36.13-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.36.15-pyhd8ed1ab_0.conda
   hash:
-    md5: 78361c879809a699abfe318de2df610e
-    sha256: 850727752368a6c3d598b4df1dd8e551ccc7b2b40b1045c1cf95f997e4f3a34a
+    md5: c04645cd9b9d0c7a74de53ff5d9ae5d4
+    sha256: b654b80f195f62feff5f783943ff93e22b5b234559fe9a7a3bbe77f45a4e426a
   category: dev
   optional: true
 - name: boto3-stubs
-  version: 1.36.13
+  version: 1.36.15
   manager: conda
   platform: osx-64
   dependencies:
@@ -1597,14 +1597,14 @@ package:
     botocore-stubs: ''
     types-s3transfer: ''
     typing-extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.36.13-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.36.15-pyhd8ed1ab_0.conda
   hash:
-    md5: 78361c879809a699abfe318de2df610e
-    sha256: 850727752368a6c3d598b4df1dd8e551ccc7b2b40b1045c1cf95f997e4f3a34a
+    md5: c04645cd9b9d0c7a74de53ff5d9ae5d4
+    sha256: b654b80f195f62feff5f783943ff93e22b5b234559fe9a7a3bbe77f45a4e426a
   category: dev
   optional: true
 - name: boto3-stubs
-  version: 1.36.13
+  version: 1.36.15
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1612,18 +1612,18 @@ package:
     botocore-stubs: ''
     types-s3transfer: ''
     typing-extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.36.13-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.36.15-pyhd8ed1ab_0.conda
   hash:
-    md5: 78361c879809a699abfe318de2df610e
-    sha256: 850727752368a6c3d598b4df1dd8e551ccc7b2b40b1045c1cf95f997e4f3a34a
+    md5: c04645cd9b9d0c7a74de53ff5d9ae5d4
+    sha256: b654b80f195f62feff5f783943ff93e22b5b234559fe9a7a3bbe77f45a4e426a
   category: dev
   optional: true
 - name: boto3-stubs-essential
-  version: 1.36.13
+  version: 1.36.15
   manager: conda
   platform: linux-64
   dependencies:
-    boto3-stubs: 1.36.13
+    boto3-stubs: 1.36.15
     mypy-boto3-s3: ''
     mypy_boto3_cloudformation: ''
     mypy_boto3_dynamodb: ''
@@ -1631,14 +1631,14 @@ package:
     mypy_boto3_lambda: ''
     mypy_boto3_rds: ''
     mypy_boto3_sqs: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-essential-1.36.13-hd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-essential-1.36.15-hd8ed1ab_0.conda
   hash:
-    md5: 37e2a960e55c344a79df520122d06017
-    sha256: cfd10a7e2d3cd3d3d43aadede190c6c0479d8fca6f070b17408f6704682e0862
+    md5: 306d87d3e91e06cdc7940023d588b935
+    sha256: e17b0694575649297c98c933c7a5a4952716a6b3d884b46d4c03c92a3d436371
   category: dev
   optional: true
 - name: boto3-stubs-essential
-  version: 1.36.13
+  version: 1.36.15
   manager: conda
   platform: osx-64
   dependencies:
@@ -1649,15 +1649,15 @@ package:
     mypy_boto3_lambda: ''
     mypy_boto3_cloudformation: ''
     mypy_boto3_sqs: ''
-    boto3-stubs: 1.36.13
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-essential-1.36.13-hd8ed1ab_0.conda
+    boto3-stubs: 1.36.15
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-essential-1.36.15-hd8ed1ab_0.conda
   hash:
-    md5: 37e2a960e55c344a79df520122d06017
-    sha256: cfd10a7e2d3cd3d3d43aadede190c6c0479d8fca6f070b17408f6704682e0862
+    md5: 306d87d3e91e06cdc7940023d588b935
+    sha256: e17b0694575649297c98c933c7a5a4952716a6b3d884b46d4c03c92a3d436371
   category: dev
   optional: true
 - name: boto3-stubs-essential
-  version: 1.36.13
+  version: 1.36.15
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1668,15 +1668,15 @@ package:
     mypy_boto3_lambda: ''
     mypy_boto3_cloudformation: ''
     mypy_boto3_sqs: ''
-    boto3-stubs: 1.36.13
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-essential-1.36.13-hd8ed1ab_0.conda
+    boto3-stubs: 1.36.15
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-essential-1.36.15-hd8ed1ab_0.conda
   hash:
-    md5: 37e2a960e55c344a79df520122d06017
-    sha256: cfd10a7e2d3cd3d3d43aadede190c6c0479d8fca6f070b17408f6704682e0862
+    md5: 306d87d3e91e06cdc7940023d588b935
+    sha256: e17b0694575649297c98c933c7a5a4952716a6b3d884b46d4c03c92a3d436371
   category: dev
   optional: true
 - name: botocore
-  version: 1.36.14
+  version: 1.36.15
   manager: conda
   platform: linux-64
   dependencies:
@@ -1684,14 +1684,14 @@ package:
     python: '>=3.10'
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.14-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.15-pyge310_1234567_0.conda
   hash:
-    md5: e6688d833f6cb38c3d4e18fe62d19f08
-    sha256: 64e14a80462ea95bb55bb2d019c8fded4e7f17978d96d43349577f72da5a6115
+    md5: 6abd0a41ce58352a008896a51237b7b2
+    sha256: 4e618052a2166c7513814f73ef111b5b3f6458386b28c42a0752242b3bfba668
   category: main
   optional: false
 - name: botocore
-  version: 1.36.14
+  version: 1.36.15
   manager: conda
   platform: osx-64
   dependencies:
@@ -1699,14 +1699,14 @@ package:
     python-dateutil: '>=2.1,<3.0.0'
     jmespath: '>=0.7.1,<2.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.14-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.15-pyge310_1234567_0.conda
   hash:
-    md5: e6688d833f6cb38c3d4e18fe62d19f08
-    sha256: 64e14a80462ea95bb55bb2d019c8fded4e7f17978d96d43349577f72da5a6115
+    md5: 6abd0a41ce58352a008896a51237b7b2
+    sha256: 4e618052a2166c7513814f73ef111b5b3f6458386b28c42a0752242b3bfba668
   category: main
   optional: false
 - name: botocore
-  version: 1.36.14
+  version: 1.36.15
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1714,52 +1714,52 @@ package:
     python-dateutil: '>=2.1,<3.0.0'
     jmespath: '>=0.7.1,<2.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.14-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.15-pyge310_1234567_0.conda
   hash:
-    md5: e6688d833f6cb38c3d4e18fe62d19f08
-    sha256: 64e14a80462ea95bb55bb2d019c8fded4e7f17978d96d43349577f72da5a6115
+    md5: 6abd0a41ce58352a008896a51237b7b2
+    sha256: 4e618052a2166c7513814f73ef111b5b3f6458386b28c42a0752242b3bfba668
   category: main
   optional: false
 - name: botocore-stubs
-  version: 1.36.14
+  version: 1.36.15
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.9'
     types-awscrt: ''
     typing_extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.36.14-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.36.15-pyhd8ed1ab_0.conda
   hash:
-    md5: 5e2037ef4067bd2c4d1dde73977badc7
-    sha256: 7cc2524d20fcef033d1ccb5a8ace97ed92b684372a97c13d605704f3f6f888c8
+    md5: fed0fe4c2ea294313b161479af127127
+    sha256: 44ea661c2af45d75ea31930cbe05f694892061517453c43c5375a01bb364a921
   category: dev
   optional: true
 - name: botocore-stubs
-  version: 1.36.14
+  version: 1.36.15
   manager: conda
   platform: osx-64
   dependencies:
     types-awscrt: ''
     python: '>=3.9'
     typing_extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.36.14-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.36.15-pyhd8ed1ab_0.conda
   hash:
-    md5: 5e2037ef4067bd2c4d1dde73977badc7
-    sha256: 7cc2524d20fcef033d1ccb5a8ace97ed92b684372a97c13d605704f3f6f888c8
+    md5: fed0fe4c2ea294313b161479af127127
+    sha256: 44ea661c2af45d75ea31930cbe05f694892061517453c43c5375a01bb364a921
   category: dev
   optional: true
 - name: botocore-stubs
-  version: 1.36.14
+  version: 1.36.15
   manager: conda
   platform: osx-arm64
   dependencies:
     types-awscrt: ''
     python: '>=3.9'
     typing_extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.36.14-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.36.15-pyhd8ed1ab_0.conda
   hash:
-    md5: 5e2037ef4067bd2c4d1dde73977badc7
-    sha256: 7cc2524d20fcef033d1ccb5a8ace97ed92b684372a97c13d605704f3f6f888c8
+    md5: fed0fe4c2ea294313b161479af127127
+    sha256: 44ea661c2af45d75ea31930cbe05f694892061517453c43c5375a01bb364a921
   category: dev
   optional: true
 - name: bottleneck
@@ -10150,45 +10150,45 @@ package:
   category: dev
   optional: true
 - name: mypy_boto3_cloudformation
-  version: 1.36.0
+  version: 1.36.15
   manager: conda
   platform: linux-64
   dependencies:
     boto3: ''
     python: '>=3.9'
     typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_cloudformation-1.36.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_cloudformation-1.36.15-pyhd8ed1ab_0.conda
   hash:
-    md5: 488d39d13164142267903d8a3db3bdbf
-    sha256: 4f8a6b1ec3652749691e0394fb1ca118a1d98a44e5c0701ae41301c378fe742a
+    md5: 333bc2da7157fdd060f2192ad8374f3a
+    sha256: 520d16757bef8c27302e13b7276b74c327a92bbcde407e3867bed29ab240cafd
   category: dev
   optional: true
 - name: mypy_boto3_cloudformation
-  version: 1.36.0
+  version: 1.36.15
   manager: conda
   platform: osx-64
   dependencies:
     boto3: ''
     typing-extensions: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_cloudformation-1.36.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_cloudformation-1.36.15-pyhd8ed1ab_0.conda
   hash:
-    md5: 488d39d13164142267903d8a3db3bdbf
-    sha256: 4f8a6b1ec3652749691e0394fb1ca118a1d98a44e5c0701ae41301c378fe742a
+    md5: 333bc2da7157fdd060f2192ad8374f3a
+    sha256: 520d16757bef8c27302e13b7276b74c327a92bbcde407e3867bed29ab240cafd
   category: dev
   optional: true
 - name: mypy_boto3_cloudformation
-  version: 1.36.0
+  version: 1.36.15
   manager: conda
   platform: osx-arm64
   dependencies:
     boto3: ''
     typing-extensions: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_cloudformation-1.36.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_cloudformation-1.36.15-pyhd8ed1ab_0.conda
   hash:
-    md5: 488d39d13164142267903d8a3db3bdbf
-    sha256: 4f8a6b1ec3652749691e0394fb1ca118a1d98a44e5c0701ae41301c378fe742a
+    md5: 333bc2da7157fdd060f2192ad8374f3a
+    sha256: 520d16757bef8c27302e13b7276b74c327a92bbcde407e3867bed29ab240cafd
   category: dev
   optional: true
 - name: mypy_boto3_dynamodb
@@ -16498,39 +16498,219 @@ package:
     sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
   category: main
   optional: false
-- name: maap-py
-  version: 0.0.0
+- name: chroma-py
+  version: 0.1.0.dev1
   manager: pip
   platform: linux-64
   dependencies: {}
-  url: git+https://github.com/MAAP-Project/maap-py.git@1887545b4faa03f4e3a6ffcf25e3b170894d3a75
-  hash: {}
+  url: https://files.pythonhosted.org/packages/23/3c/39d07abb9d4bcda64d9c50a4fda2ecfee4d76a436bd590d232a4e1a5ad43/chroma-py-0.1.0.dev1.tar.gz
+  hash:
+    sha256: 0dc1135332e2ed6e74d7b355c8afa7b85c193a7d5af1cb8b6f79c9e2645912b2
   category: main
-  source:
-    type: url
-    url: git+https://github.com/MAAP-Project/maap-py.git@1887545b4faa03f4e3a6ffcf25e3b170894d3a75
   optional: false
-- name: maap-py
-  version: 0.0.0
+- name: chroma-py
+  version: 0.1.0.dev1
   manager: pip
   platform: osx-64
   dependencies: {}
-  url: git+https://github.com/MAAP-Project/maap-py.git@1887545b4faa03f4e3a6ffcf25e3b170894d3a75
-  hash: {}
+  url: https://files.pythonhosted.org/packages/23/3c/39d07abb9d4bcda64d9c50a4fda2ecfee4d76a436bd590d232a4e1a5ad43/chroma-py-0.1.0.dev1.tar.gz
+  hash:
+    sha256: 0dc1135332e2ed6e74d7b355c8afa7b85c193a7d5af1cb8b6f79c9e2645912b2
   category: main
-  source:
-    type: url
-    url: git+https://github.com/MAAP-Project/maap-py.git@1887545b4faa03f4e3a6ffcf25e3b170894d3a75
   optional: false
-- name: maap-py
-  version: 0.0.0
+- name: chroma-py
+  version: 0.1.0.dev1
   manager: pip
   platform: osx-arm64
   dependencies: {}
-  url: git+https://github.com/MAAP-Project/maap-py.git@1887545b4faa03f4e3a6ffcf25e3b170894d3a75
-  hash: {}
+  url: https://files.pythonhosted.org/packages/23/3c/39d07abb9d4bcda64d9c50a4fda2ecfee4d76a436bd590d232a4e1a5ad43/chroma-py-0.1.0.dev1.tar.gz
+  hash:
+    sha256: 0dc1135332e2ed6e74d7b355c8afa7b85c193a7d5af1cb8b6f79c9e2645912b2
   category: main
-  source:
-    type: url
-    url: git+https://github.com/MAAP-Project/maap-py.git@1887545b4faa03f4e3a6ffcf25e3b170894d3a75
+  optional: false
+- name: colour
+  version: 0.1.5
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/74/46/e81907704ab203206769dee1385dc77e1407576ff8f50a0681d0a6b541be/colour-0.1.5-py2.py3-none-any.whl
+  hash:
+    sha256: 33f6db9d564fadc16e59921a56999b79571160ce09916303d35346dddc17978c
+  category: main
+  optional: false
+- name: colour
+  version: 0.1.5
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/74/46/e81907704ab203206769dee1385dc77e1407576ff8f50a0681d0a6b541be/colour-0.1.5-py2.py3-none-any.whl
+  hash:
+    sha256: 33f6db9d564fadc16e59921a56999b79571160ce09916303d35346dddc17978c
+  category: main
+  optional: false
+- name: colour
+  version: 0.1.5
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/74/46/e81907704ab203206769dee1385dc77e1407576ff8f50a0681d0a6b541be/colour-0.1.5-py2.py3-none-any.whl
+  hash:
+    sha256: 33f6db9d564fadc16e59921a56999b79571160ce09916303d35346dddc17978c
+  category: main
+  optional: false
+- name: configparser
+  version: 7.1.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/ee/df/1514580907b0bac0970415e5e24ef96a9c1fa71dcf2aa0139045b58fae9a/configparser-7.1.0-py3-none-any.whl
+  hash:
+    sha256: 98e374573c4e10e92399651e3ba1c47a438526d633c44ee96143dec26dad4299
+  category: main
+  optional: false
+- name: configparser
+  version: 7.1.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/ee/df/1514580907b0bac0970415e5e24ef96a9c1fa71dcf2aa0139045b58fae9a/configparser-7.1.0-py3-none-any.whl
+  hash:
+    sha256: 98e374573c4e10e92399651e3ba1c47a438526d633c44ee96143dec26dad4299
+  category: main
+  optional: false
+- name: configparser
+  version: 7.1.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/ee/df/1514580907b0bac0970415e5e24ef96a9c1fa71dcf2aa0139045b58fae9a/configparser-7.1.0-py3-none-any.whl
+  hash:
+    sha256: 98e374573c4e10e92399651e3ba1c47a438526d633c44ee96143dec26dad4299
+  category: main
+  optional: false
+- name: geojson
+  version: 3.2.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/18/67/a7fa2d650602731c90e0a86279841b4586e14228199e8c09165ba4863e29/geojson-3.2.0-py3-none-any.whl
+  hash:
+    sha256: 69d14156469e13c79479672eafae7b37e2dcd19bdfd77b53f74fa8fe29910b52
+  category: main
+  optional: false
+- name: geojson
+  version: 3.2.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/18/67/a7fa2d650602731c90e0a86279841b4586e14228199e8c09165ba4863e29/geojson-3.2.0-py3-none-any.whl
+  hash:
+    sha256: 69d14156469e13c79479672eafae7b37e2dcd19bdfd77b53f74fa8fe29910b52
+  category: main
+  optional: false
+- name: geojson
+  version: 3.2.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/18/67/a7fa2d650602731c90e0a86279841b4586e14228199e8c09165ba4863e29/geojson-3.2.0-py3-none-any.whl
+  hash:
+    sha256: 69d14156469e13c79479672eafae7b37e2dcd19bdfd77b53f74fa8fe29910b52
+  category: main
+  optional: false
+- name: maap-py
+  version: 4.1.0
+  manager: pip
+  platform: linux-64
+  dependencies:
+    backoff: '>=2.2.1,<3.0.0'
+    boto3: '>=1.34.139,<2.0.0'
+    configparser: '>=7.0.0,<8.0.0'
+    importlib-resources: '>=6.4.0,<7.0.0'
+    mapboxgl: '>=0.10.2,<0.11.0'
+    pyyaml: '>=6.0.1,<7.0.0'
+    requests: '>=2.32.3,<3.0.0'
+  url: https://files.pythonhosted.org/packages/26/b6/31b317ca4277825445fdc7ff3a947783563954744e4a9a1ef0d4b5445fd8/maap_py-4.1.0-py3-none-any.whl
+  hash:
+    sha256: 6433f44a22dc1291d4c3e3f4508203d95f1346ffd5e3e952140e0a1d22145143
+  category: main
+  optional: false
+- name: maap-py
+  version: 4.1.0
+  manager: pip
+  platform: osx-64
+  dependencies:
+    backoff: '>=2.2.1,<3.0.0'
+    boto3: '>=1.34.139,<2.0.0'
+    configparser: '>=7.0.0,<8.0.0'
+    importlib-resources: '>=6.4.0,<7.0.0'
+    mapboxgl: '>=0.10.2,<0.11.0'
+    pyyaml: '>=6.0.1,<7.0.0'
+    requests: '>=2.32.3,<3.0.0'
+  url: https://files.pythonhosted.org/packages/26/b6/31b317ca4277825445fdc7ff3a947783563954744e4a9a1ef0d4b5445fd8/maap_py-4.1.0-py3-none-any.whl
+  hash:
+    sha256: 6433f44a22dc1291d4c3e3f4508203d95f1346ffd5e3e952140e0a1d22145143
+  category: main
+  optional: false
+- name: maap-py
+  version: 4.1.0
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    backoff: '>=2.2.1,<3.0.0'
+    boto3: '>=1.34.139,<2.0.0'
+    configparser: '>=7.0.0,<8.0.0'
+    importlib-resources: '>=6.4.0,<7.0.0'
+    mapboxgl: '>=0.10.2,<0.11.0'
+    pyyaml: '>=6.0.1,<7.0.0'
+    requests: '>=2.32.3,<3.0.0'
+  url: https://files.pythonhosted.org/packages/26/b6/31b317ca4277825445fdc7ff3a947783563954744e4a9a1ef0d4b5445fd8/maap_py-4.1.0-py3-none-any.whl
+  hash:
+    sha256: 6433f44a22dc1291d4c3e3f4508203d95f1346ffd5e3e952140e0a1d22145143
+  category: main
+  optional: false
+- name: mapboxgl
+  version: 0.10.2
+  manager: pip
+  platform: linux-64
+  dependencies:
+    jinja2: '*'
+    geojson: '*'
+    chroma-py: '*'
+    colour: '*'
+    matplotlib: '*'
+  url: https://files.pythonhosted.org/packages/4f/e1/cdaa6c2f6d3a7a29b0b9a675dcfc25f4c481d577d137da8c769f13014ce5/mapboxgl-0.10.2-py2.py3-none-any.whl
+  hash:
+    sha256: 19a81d16d66da49ba4a55a7a28eb2f1fd8d07f2885f6b3a6d386769eefab17ae
+  category: main
+  optional: false
+- name: mapboxgl
+  version: 0.10.2
+  manager: pip
+  platform: osx-64
+  dependencies:
+    jinja2: '*'
+    geojson: '*'
+    chroma-py: '*'
+    colour: '*'
+    matplotlib: '*'
+  url: https://files.pythonhosted.org/packages/4f/e1/cdaa6c2f6d3a7a29b0b9a675dcfc25f4c481d577d137da8c769f13014ce5/mapboxgl-0.10.2-py2.py3-none-any.whl
+  hash:
+    sha256: 19a81d16d66da49ba4a55a7a28eb2f1fd8d07f2885f6b3a6d386769eefab17ae
+  category: main
+  optional: false
+- name: mapboxgl
+  version: 0.10.2
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    jinja2: '*'
+    geojson: '*'
+    chroma-py: '*'
+    colour: '*'
+    matplotlib: '*'
+  url: https://files.pythonhosted.org/packages/4f/e1/cdaa6c2f6d3a7a29b0b9a675dcfc25f4c481d577d137da8c769f13014ce5/mapboxgl-0.10.2-py2.py3-none-any.whl
+  hash:
+    sha256: 19a81d16d66da49ba4a55a7a28eb2f1fd8d07f2885f6b3a6d386769eefab17ae
+  category: main
   optional: false

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -15,9 +15,9 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: 521a2b01730373fd86ff74f738fb0150310084e06334a154ebd624640d801e0a
-    osx-64: 9d739528879c5973101c18123bc73962309048896ff621fefe55ebd65aa0c40e
-    osx-arm64: 36fa91456e95442d57b0ddf9e88c137c94e72f3cabc8c7926c860e92c3a4da03
+    linux-64: 0cbcc30e162a09d6182a12fa0a55a92610d0f2851ad77f85dbee1cfe6b06078b
+    osx-64: db8bf1cee99a460a7394695ec46a57927bd68c323e703b6d1ab27d99fe5beaa7
+    osx-arm64: f9f1144a63d9a271c2ba4ca17028f74c471f869694f60ed8354754bbf6380cc2
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -91,6 +91,244 @@ package:
     sha256: 0deeaf0c001d5543719db9b2686bc1920c86c7e142f9bec74f35e1ce611b1fc2
   category: dev
   optional: true
+- name: aiobotocore
+  version: 2.19.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aiohttp: '>=3.9.2,<4.0.0'
+    aioitertools: '>=0.5.1,<1.0.0'
+    botocore: '>=1.36.0,<1.36.4'
+    jmespath: '>=0.7.1,<2.0.0'
+    multidict: '>=6.0.0,<7.0.0'
+    python: '>=3.9'
+    python-dateutil: '>=2.1,<3.0.0'
+    urllib3: '>=1.25.4,!=2.2.0,<3'
+    wrapt: '>=1.10.10,<2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.19.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 6dc626c926419c14546daedf1cffb4d4
+    sha256: 0072feb6220733066b0b8a4293fa7d4e170490d52bab64f4491818325b2f6ffd
+  category: main
+  optional: false
+- name: aiobotocore
+  version: 2.19.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    python-dateutil: '>=2.1,<3.0.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    urllib3: '>=1.25.4,!=2.2.0,<3'
+    wrapt: '>=1.10.10,<2.0.0'
+    aioitertools: '>=0.5.1,<1.0.0'
+    aiohttp: '>=3.9.2,<4.0.0'
+    multidict: '>=6.0.0,<7.0.0'
+    botocore: '>=1.36.0,<1.36.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.19.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 6dc626c926419c14546daedf1cffb4d4
+    sha256: 0072feb6220733066b0b8a4293fa7d4e170490d52bab64f4491818325b2f6ffd
+  category: main
+  optional: false
+- name: aiobotocore
+  version: 2.19.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    python-dateutil: '>=2.1,<3.0.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    urllib3: '>=1.25.4,!=2.2.0,<3'
+    wrapt: '>=1.10.10,<2.0.0'
+    aioitertools: '>=0.5.1,<1.0.0'
+    aiohttp: '>=3.9.2,<4.0.0'
+    multidict: '>=6.0.0,<7.0.0'
+    botocore: '>=1.36.0,<1.36.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.19.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 6dc626c926419c14546daedf1cffb4d4
+    sha256: 0072feb6220733066b0b8a4293fa7d4e170490d52bab64f4491818325b2f6ffd
+  category: main
+  optional: false
+- name: aiohappyeyeballs
+  version: 2.4.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: 296b403617bafa89df4971567af79013
+    sha256: 95d4713e49ea92ae50cf42393683ede706b7875af5f7cb14c253438180afa732
+  category: main
+  optional: false
+- name: aiohappyeyeballs
+  version: 2.4.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: 296b403617bafa89df4971567af79013
+    sha256: 95d4713e49ea92ae50cf42393683ede706b7875af5f7cb14c253438180afa732
+  category: main
+  optional: false
+- name: aiohappyeyeballs
+  version: 2.4.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: 296b403617bafa89df4971567af79013
+    sha256: 95d4713e49ea92ae50cf42393683ede706b7875af5f7cb14c253438180afa732
+  category: main
+  optional: false
+- name: aiohttp
+  version: 3.11.12
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aiohappyeyeballs: '>=2.3.0'
+    aiosignal: '>=1.1.2'
+    attrs: '>=17.3.0'
+    frozenlist: '>=1.1.1'
+    libgcc: '>=13'
+    multidict: '>=4.5,<7.0'
+    propcache: '>=0.2.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    yarl: '>=1.17.0,<2.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.11.12-py312h178313f_0.conda
+  hash:
+    md5: 9f96d8b6fb9bab11e46c12132283b5b1
+    sha256: 223f271deceaf71d0cbee21162084104a6eca06e79c04ecb322706be3e406ea1
+  category: main
+  optional: false
+- name: aiohttp
+  version: 3.11.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aiohappyeyeballs: '>=2.3.0'
+    aiosignal: '>=1.1.2'
+    attrs: '>=17.3.0'
+    frozenlist: '>=1.1.1'
+    multidict: '>=4.5,<7.0'
+    propcache: '>=0.2.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    yarl: '>=1.17.0,<2.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.11.12-py312h3520af0_0.conda
+  hash:
+    md5: c31e7180a4a86b5a8339689133deea9b
+    sha256: 3274f863fffdd612a18ae4f03ff047ad122799c48195f7cce5b494fc752908d6
+  category: main
+  optional: false
+- name: aiohttp
+  version: 3.11.12
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aiohappyeyeballs: '>=2.3.0'
+    aiosignal: '>=1.1.2'
+    attrs: '>=17.3.0'
+    frozenlist: '>=1.1.1'
+    multidict: '>=4.5,<7.0'
+    propcache: '>=0.2.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    yarl: '>=1.17.0,<2.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.11.12-py312h998013c_0.conda
+  hash:
+    md5: 7675cee14b7e7d9ccf17ad37a4bdf53a
+    sha256: a4d04942bdeedbb7260b41eafb0302b6f8c3799f578c4389984c084a8fc34c16
+  category: main
+  optional: false
+- name: aioitertools
+  version: 0.12.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3eb47adbffac44483f59e580f8600a1e
+    sha256: 7d56e547a819a03c058dd8793ca9df6ff9825812da52c214192edb61a7de1c95
+  category: main
+  optional: false
+- name: aioitertools
+  version: 0.12.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3eb47adbffac44483f59e580f8600a1e
+    sha256: 7d56e547a819a03c058dd8793ca9df6ff9825812da52c214192edb61a7de1c95
+  category: main
+  optional: false
+- name: aioitertools
+  version: 0.12.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3eb47adbffac44483f59e580f8600a1e
+    sha256: 7d56e547a819a03c058dd8793ca9df6ff9825812da52c214192edb61a7de1c95
+  category: main
+  optional: false
+- name: aiosignal
+  version: 1.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    frozenlist: '>=1.1.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1a3981115a398535dbe3f6d5faae3d36
+    sha256: 7de8ced1918bbdadecf8e1c1c68237fe5709c097bd9e0d254f4cad118f4345d0
+  category: main
+  optional: false
+- name: aiosignal
+  version: 1.3.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    frozenlist: '>=1.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1a3981115a398535dbe3f6d5faae3d36
+    sha256: 7de8ced1918bbdadecf8e1c1c68237fe5709c097bd9e0d254f4cad118f4345d0
+  category: main
+  optional: false
+- name: aiosignal
+  version: 1.3.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    frozenlist: '>=1.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1a3981115a398535dbe3f6d5faae3d36
+    sha256: 7de8ced1918bbdadecf8e1c1c68237fe5709c097bd9e0d254f4cad118f4345d0
+  category: main
+  optional: false
 - name: annotated-types
   version: 0.7.0
   manager: conda
@@ -311,8 +549,8 @@ package:
   hash:
     md5: 2cc3f588512f04f3a0c64b4e9bedc02d
     sha256: 1f267886522dfb9ae4e5ebbc3135b5eb13cff27bdbfe8d881a4d893459166ab4
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: attrs
   version: 25.1.0
   manager: conda
@@ -323,8 +561,8 @@ package:
   hash:
     md5: 2cc3f588512f04f3a0c64b4e9bedc02d
     sha256: 1f267886522dfb9ae4e5ebbc3135b5eb13cff27bdbfe8d881a4d893459166ab4
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: attrs
   version: 25.1.0
   manager: conda
@@ -335,8 +573,8 @@ package:
   hash:
     md5: 2cc3f588512f04f3a0c64b4e9bedc02d
     sha256: 1f267886522dfb9ae4e5ebbc3135b5eb13cff27bdbfe8d881a4d893459166ab4
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: aws-c-auth
   version: 0.8.1
   manager: conda
@@ -1529,48 +1767,48 @@ package:
   category: main
   optional: false
 - name: boto3
-  version: 1.36.14
+  version: 1.36.3
   manager: conda
   platform: linux-64
   dependencies:
-    botocore: '>=1.36.14,<1.37.0'
+    botocore: '>=1.36.3,<1.37.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.9'
     s3transfer: '>=0.11.0,<0.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.14-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 8594f2e4a0840816b02b4589fa3a0fd0
-    sha256: 60be8c80c92b87154fc434b0f65aa6ab49cb64b7e67af388cf49a9fc447ee301
+    md5: 2ce714023bbdc1a381ec55505da2e113
+    sha256: 7d649962da531389e078b93459b668fc132238ac977e84c6bfa399a224edc3bf
   category: main
   optional: false
 - name: boto3
-  version: 1.36.14
+  version: 1.36.3
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.9'
     jmespath: '>=0.7.1,<2.0.0'
     s3transfer: '>=0.11.0,<0.12.0'
-    botocore: '>=1.36.14,<1.37.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.14-pyhd8ed1ab_0.conda
+    botocore: '>=1.36.3,<1.37.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 8594f2e4a0840816b02b4589fa3a0fd0
-    sha256: 60be8c80c92b87154fc434b0f65aa6ab49cb64b7e67af388cf49a9fc447ee301
+    md5: 2ce714023bbdc1a381ec55505da2e113
+    sha256: 7d649962da531389e078b93459b668fc132238ac977e84c6bfa399a224edc3bf
   category: main
   optional: false
 - name: boto3
-  version: 1.36.14
+  version: 1.36.3
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9'
     jmespath: '>=0.7.1,<2.0.0'
     s3transfer: '>=0.11.0,<0.12.0'
-    botocore: '>=1.36.14,<1.37.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.14-pyhd8ed1ab_0.conda
+    botocore: '>=1.36.3,<1.37.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 8594f2e4a0840816b02b4589fa3a0fd0
-    sha256: 60be8c80c92b87154fc434b0f65aa6ab49cb64b7e67af388cf49a9fc447ee301
+    md5: 2ce714023bbdc1a381ec55505da2e113
+    sha256: 7d649962da531389e078b93459b668fc132238ac977e84c6bfa399a224edc3bf
   category: main
   optional: false
 - name: boto3-stubs
@@ -1676,7 +1914,7 @@ package:
   category: dev
   optional: true
 - name: botocore
-  version: 1.36.15
+  version: 1.36.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -1684,14 +1922,14 @@ package:
     python: '>=3.10'
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.15-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.3-pyge310_1234567_0.conda
   hash:
-    md5: 6abd0a41ce58352a008896a51237b7b2
-    sha256: 4e618052a2166c7513814f73ef111b5b3f6458386b28c42a0752242b3bfba668
+    md5: d21b74ea6fe0795af13a62f00f5258f3
+    sha256: 3d41462f9f40d0e15b665ad0123693877b9445eca3ed1f16fa698fc5c2e66948
   category: main
   optional: false
 - name: botocore
-  version: 1.36.15
+  version: 1.36.3
   manager: conda
   platform: osx-64
   dependencies:
@@ -1699,14 +1937,14 @@ package:
     python-dateutil: '>=2.1,<3.0.0'
     jmespath: '>=0.7.1,<2.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.15-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.3-pyge310_1234567_0.conda
   hash:
-    md5: 6abd0a41ce58352a008896a51237b7b2
-    sha256: 4e618052a2166c7513814f73ef111b5b3f6458386b28c42a0752242b3bfba668
+    md5: d21b74ea6fe0795af13a62f00f5258f3
+    sha256: 3d41462f9f40d0e15b665ad0123693877b9445eca3ed1f16fa698fc5c2e66948
   category: main
   optional: false
 - name: botocore
-  version: 1.36.15
+  version: 1.36.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1714,10 +1952,10 @@ package:
     python-dateutil: '>=2.1,<3.0.0'
     jmespath: '>=0.7.1,<2.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.15-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.3-pyge310_1234567_0.conda
   hash:
-    md5: 6abd0a41ce58352a008896a51237b7b2
-    sha256: 4e618052a2166c7513814f73ef111b5b3f6458386b28c42a0752242b3bfba668
+    md5: d21b74ea6fe0795af13a62f00f5258f3
+    sha256: 3d41462f9f40d0e15b665ad0123693877b9445eca3ed1f16fa698fc5c2e66948
   category: main
   optional: false
 - name: botocore-stubs
@@ -3998,7 +4236,7 @@ package:
   category: main
   optional: false
 - name: fonttools
-  version: 4.55.8
+  version: 4.56.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4009,14 +4247,14 @@ package:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     unicodedata2: '>=15.1.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.8-py312h178313f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.56.0-py312h178313f_0.conda
   hash:
-    md5: 0fd0743b6d43989c07e41da61f67c41c
-    sha256: f1faed016e9452161e8e07177f7c97109f9db2e23c60fcbcde7c1de0b76e1d33
+    md5: 2f8a66f2f9eb931cdde040d02c6ab54c
+    sha256: 76ca95b4111fe27e64d74111b416b3462ad3db99f7109cbdf50e6e4b67dcf5b7
   category: main
   optional: false
 - name: fonttools
-  version: 4.55.8
+  version: 4.56.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -4026,14 +4264,14 @@ package:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     unicodedata2: '>=15.1.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.55.8-py312h3520af0_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.56.0-py312h3520af0_0.conda
   hash:
-    md5: b6bdcc7cad1bc4c4e762ec15dd238308
-    sha256: 3ff84d883e5abd275f28e1a6aa59bbedaf83fe4f62812ad07d5614254773a4aa
+    md5: 9b603b2fa3072c966ef2ff119e8203f3
+    sha256: 9b206989c9d5e68120d264b6798b9afdfbca6b9a8705cdd71b68a75ce58f81b7
   category: main
   optional: false
 - name: fonttools
-  version: 4.55.8
+  version: 4.56.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4043,10 +4281,10 @@ package:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     unicodedata2: '>=15.1.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.8-py312h998013c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.56.0-py312h998013c_0.conda
   hash:
-    md5: e1088958da94d366609f11bea9fd2e22
-    sha256: 2b916b50259a32963ac8538cb6168a32dfc3f3ad8aca60128c3761f949354307
+    md5: a5cf7d0629863be81d90054882de908c
+    sha256: 6b003a5100ec58e1bd456bf55d0727606f7b067628aed1a7c5d8cf4f0174bfc5
   category: main
   optional: false
 - name: freetype
@@ -4176,6 +4414,49 @@ package:
   hash:
     md5: 22df6d6ec0345fc46182ce47e7ee8e24
     sha256: 357cef10885bd2fb5d5d3197a8565d0c0b86fffd0dbaff58acee29f7d897a935
+  category: main
+  optional: false
+- name: frozenlist
+  version: 1.5.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.5.0-py312h178313f_1.conda
+  hash:
+    md5: fb986e1c089021979dc79606af78ef8f
+    sha256: 501e20626798b6d7f130f4db0fb02c0385d8f4c11ca525925602a4208afb343f
+  category: main
+  optional: false
+- name: frozenlist
+  version: 1.5.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.5.0-py312h3520af0_1.conda
+  hash:
+    md5: 887a4fa613758220fff7641b9d3ead95
+    sha256: 332d78beaec0ab79f176656e71b819d75bb72a9a9c99bb1dc0387c7f0c34f016
+  category: main
+  optional: false
+- name: frozenlist
+  version: 1.5.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.5.0-py312h998013c_1.conda
+  hash:
+    md5: 5eb3715c7e3fa9b533361375bfefe6ee
+    sha256: d503ac8c050abdbd129253973f23be34944978d510de78ef5a3e6aa1e3d9552d
   category: main
   optional: false
 - name: fsspec
@@ -9989,8 +10270,8 @@ package:
   hash:
     md5: 5b5e3267d915a107eca793d52e1b780a
     sha256: b05bc8252a6e957bf4a776ed5e0e61d1ba88cdc46ccb55890c72cc58b10371f4
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: multidict
   version: 6.1.0
   manager: conda
@@ -10003,8 +10284,8 @@ package:
   hash:
     md5: 47e51ecdee53dfc456f02ad633aa43bf
     sha256: 326c92cd8e4bc85294f2f0b5cdf97d90e96158c2881915256e99f8bc07559960
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: multidict
   version: 6.1.0
   manager: conda
@@ -10017,8 +10298,8 @@ package:
   hash:
     md5: 0048335516fed938e4dd2c457b4c5b9b
     sha256: 482fd09fb798090dc8cce2285fa69f43b1459099122eac2fb112d9b922b9f916
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: munkres
   version: 1.1.4
   manager: conda
@@ -11897,8 +12178,8 @@ package:
   hash:
     md5: 349635694b4df27336bc15a49e9220e9
     sha256: 6d5ff6490c53e14591b70924711fe7bd70eb7fbeeeb1cbd9ed2f6d794ec8c4eb
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: propcache
   version: 0.2.1
   manager: conda
@@ -11911,8 +12192,8 @@ package:
   hash:
     md5: e712bcabf1db361f1350b638be66caca
     sha256: 04cd2c807af8ae2921e54c372620bb6d3391a7ad59c0aa566e4d21be0e558ae1
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: propcache
   version: 0.2.1
   manager: conda
@@ -11925,8 +12206,8 @@ package:
   hash:
     md5: 83678928c58c9ae76778a435b6c7a94a
     sha256: 96145760baad111d7ae4213ea8f8cc035cf33b001f5ff37d92268e4d28b0941d
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: psutil
   version: 6.1.1
   manager: conda
@@ -13885,45 +14166,48 @@ package:
   category: main
   optional: false
 - name: s3fs
-  version: 0.4.2
+  version: 2025.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    boto3: ''
-    fsspec: '>=0.6.0'
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
+    aiobotocore: '>=2.5.4,<3.0.0'
+    aiohttp: ''
+    fsspec: 2025.2.0
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2025.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ead328eb12f01d88706126ba061e7a69
-    sha256: 7a4cb574ff7edf773e5e4c396733dcb08ffcfd6e4f8b27e5b84b35fd4666ef5b
+    md5: abe2ecb98694733ad8a82513465531e4
+    sha256: 5fe3413275ff7d02ff73f054d8d341a072316a387c96839e3580393ec11368fb
   category: main
   optional: false
 - name: s3fs
-  version: 0.4.2
+  version: 2025.2.0
   manager: conda
   platform: osx-64
   dependencies:
-    boto3: ''
-    python: '>=3.5'
-    fsspec: '>=0.6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
+    aiohttp: ''
+    python: '>=3.9'
+    aiobotocore: '>=2.5.4,<3.0.0'
+    fsspec: 2025.2.0
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2025.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ead328eb12f01d88706126ba061e7a69
-    sha256: 7a4cb574ff7edf773e5e4c396733dcb08ffcfd6e4f8b27e5b84b35fd4666ef5b
+    md5: abe2ecb98694733ad8a82513465531e4
+    sha256: 5fe3413275ff7d02ff73f054d8d341a072316a387c96839e3580393ec11368fb
   category: main
   optional: false
 - name: s3fs
-  version: 0.4.2
+  version: 2025.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    boto3: ''
-    python: '>=3.5'
-    fsspec: '>=0.6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
+    aiohttp: ''
+    python: '>=3.9'
+    aiobotocore: '>=2.5.4,<3.0.0'
+    fsspec: 2025.2.0
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2025.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ead328eb12f01d88706126ba061e7a69
-    sha256: 7a4cb574ff7edf773e5e4c396733dcb08ffcfd6e4f8b27e5b84b35fd4666ef5b
+    md5: abe2ecb98694733ad8a82513465531e4
+    sha256: 5fe3413275ff7d02ff73f054d8d341a072316a387c96839e3580393ec11368fb
   category: main
   optional: false
 - name: s3transfer
@@ -15907,8 +16191,8 @@ package:
   hash:
     md5: 669e63af87710f8d52fdec9d4d63b404
     sha256: ed3a1700ecc5d38c7e7dc7d2802df1bc1da6ba3d6f6017448b8ded0affb4ae00
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: wrapt
   version: 1.17.2
   manager: conda
@@ -15921,8 +16205,8 @@ package:
   hash:
     md5: 6a860c98c6aea375eea574693a98d409
     sha256: 476ea998d7279d9f71ff7b2e30408e69e5a0b921090c07a124f3f52ff7d3424b
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: wrapt
   version: 1.17.2
   manager: conda
@@ -15935,8 +16219,8 @@ package:
   hash:
     md5: e49608c832fcf438f70cbcae09c3adc5
     sha256: 6a3e68b57de29802e8703d1791dcacb7613bfdc17bbb087c6b2ea2796e6893ef
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: x265
   version: '3.5'
   manager: conda
@@ -16251,8 +16535,8 @@ package:
   hash:
     md5: 6822c49f294d4355f19d314b8b6063d8
     sha256: 6b054c93dd19fd7544af51b41a8eacca2ab62271f6c0c5a2a0cffe80dc37a0ce
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: yarl
   version: 1.18.3
   manager: conda
@@ -16268,8 +16552,8 @@ package:
   hash:
     md5: c9c69a722e1cb1250608ed6c58bd2215
     sha256: 0aa40f238e282d8b0a549732722ec655b752ff1bf6c0e0b5248aba16cc57a527
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: yarl
   version: 1.18.3
   manager: conda
@@ -16285,8 +16569,8 @@ package:
   hash:
     md5: 092d3b40acc67c470f379049be343a7a
     sha256: 48821d23567ca0f853eee6f7812c74392867e123798b5b3c44f58758d8eb580e
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: zeromq
   version: 4.3.5
   manager: conda

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -55,16 +55,58 @@ package:
     sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
   category: main
   optional: false
+- name: adwaita-icon-theme
+  version: '47.0'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+    hicolor-icon-theme: ''
+    librsvg: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-47.0-unix_0.conda
+  hash:
+    md5: 49436a5c604f99058473d84580f0e341
+    sha256: 188dca9a847f474b3df71eda9fe828fbe10b53aa6f4313c7e117f3114b1dd84e
+  category: dev
+  optional: true
+- name: adwaita-icon-theme
+  version: '47.0'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+    librsvg: ''
+    hicolor-icon-theme: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-47.0-unix_0.conda
+  hash:
+    md5: 49436a5c604f99058473d84580f0e341
+    sha256: 188dca9a847f474b3df71eda9fe828fbe10b53aa6f4313c7e117f3114b1dd84e
+  category: dev
+  optional: true
+- name: adwaita-icon-theme
+  version: '47.0'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __unix: ''
+    librsvg: ''
+    hicolor-icon-theme: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-47.0-unix_0.conda
+  hash:
+    md5: 49436a5c604f99058473d84580f0e341
+    sha256: 188dca9a847f474b3df71eda9fe828fbe10b53aa6f4313c7e117f3114b1dd84e
+  category: dev
+  optional: true
 - name: affine
   version: 2.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ae5f4ad87126c55ba3f690ef07f81d64
-    sha256: fbf0288cae7c6e5005280436ff73c95a36c5a4c978ba50175cc8e3eb22abc5f9
+    md5: 8c4061f499edec6b8ac7000f6d586829
+    sha256: 0deeaf0c001d5543719db9b2686bc1920c86c7e142f9bec74f35e1ce611b1fc2
   category: dev
   optional: true
 - name: affine
@@ -72,11 +114,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ae5f4ad87126c55ba3f690ef07f81d64
-    sha256: fbf0288cae7c6e5005280436ff73c95a36c5a4c978ba50175cc8e3eb22abc5f9
+    md5: 8c4061f499edec6b8ac7000f6d586829
+    sha256: 0deeaf0c001d5543719db9b2686bc1920c86c7e142f9bec74f35e1ce611b1fc2
   category: dev
   optional: true
 - name: affine
@@ -84,231 +126,327 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ae5f4ad87126c55ba3f690ef07f81d64
-    sha256: fbf0288cae7c6e5005280436ff73c95a36c5a4c978ba50175cc8e3eb22abc5f9
+    md5: 8c4061f499edec6b8ac7000f6d586829
+    sha256: 0deeaf0c001d5543719db9b2686bc1920c86c7e142f9bec74f35e1ce611b1fc2
   category: dev
   optional: true
 - name: aiobotocore
-  version: 2.13.1
+  version: 2.19.0
   manager: conda
   platform: linux-64
   dependencies:
     aiohttp: '>=3.9.2,<4.0.0'
     aioitertools: '>=0.5.1,<1.0.0'
-    botocore: '>=1.34.70,<1.34.132'
-    python: '>=3.8'
+    botocore: '>=1.36.0,<1.36.4'
+    jmespath: '>=0.7.1,<2.0.0'
+    multidict: '>=6.0.0,<7.0.0'
+    python: '>=3.9'
+    python-dateutil: '>=2.1,<3.0.0'
+    urllib3: '>=1.25.4,!=2.2.0,<3'
     wrapt: '>=1.10.10,<2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.19.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 64ebb883a6c94f2a18aafedecc215351
-    sha256: 8eacb10e5877fb743d75ae2c50eaaa89ece85479e557e693db8275bd96740ef3
+    md5: 6dc626c926419c14546daedf1cffb4d4
+    sha256: 0072feb6220733066b0b8a4293fa7d4e170490d52bab64f4491818325b2f6ffd
   category: main
   optional: false
 - name: aiobotocore
-  version: 2.13.1
+  version: 2.19.0
   manager: conda
   platform: osx-64
   dependencies:
-    aiohttp: '>=3.9.2,<4.0.0'
-    aioitertools: '>=0.5.1,<1.0.0'
-    botocore: '>=1.34.70,<1.34.132'
-    python: '>=3.8'
+    python: '>=3.9'
+    python-dateutil: '>=2.1,<3.0.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    urllib3: '>=1.25.4,!=2.2.0,<3'
     wrapt: '>=1.10.10,<2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
+    aioitertools: '>=0.5.1,<1.0.0'
+    aiohttp: '>=3.9.2,<4.0.0'
+    multidict: '>=6.0.0,<7.0.0'
+    botocore: '>=1.36.0,<1.36.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.19.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 64ebb883a6c94f2a18aafedecc215351
-    sha256: 8eacb10e5877fb743d75ae2c50eaaa89ece85479e557e693db8275bd96740ef3
+    md5: 6dc626c926419c14546daedf1cffb4d4
+    sha256: 0072feb6220733066b0b8a4293fa7d4e170490d52bab64f4491818325b2f6ffd
   category: main
   optional: false
 - name: aiobotocore
-  version: 2.13.1
+  version: 2.19.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    aiohttp: '>=3.9.2,<4.0.0'
-    aioitertools: '>=0.5.1,<1.0.0'
-    botocore: '>=1.34.70,<1.34.132'
-    python: '>=3.8'
+    python: '>=3.9'
+    python-dateutil: '>=2.1,<3.0.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    urllib3: '>=1.25.4,!=2.2.0,<3'
     wrapt: '>=1.10.10,<2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
+    aioitertools: '>=0.5.1,<1.0.0'
+    aiohttp: '>=3.9.2,<4.0.0'
+    multidict: '>=6.0.0,<7.0.0'
+    botocore: '>=1.36.0,<1.36.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.19.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 64ebb883a6c94f2a18aafedecc215351
-    sha256: 8eacb10e5877fb743d75ae2c50eaaa89ece85479e557e693db8275bd96740ef3
+    md5: 6dc626c926419c14546daedf1cffb4d4
+    sha256: 0072feb6220733066b0b8a4293fa7d4e170490d52bab64f4491818325b2f6ffd
+  category: main
+  optional: false
+- name: aiohappyeyeballs
+  version: 2.4.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: 296b403617bafa89df4971567af79013
+    sha256: 95d4713e49ea92ae50cf42393683ede706b7875af5f7cb14c253438180afa732
+  category: main
+  optional: false
+- name: aiohappyeyeballs
+  version: 2.4.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: 296b403617bafa89df4971567af79013
+    sha256: 95d4713e49ea92ae50cf42393683ede706b7875af5f7cb14c253438180afa732
+  category: main
+  optional: false
+- name: aiohappyeyeballs
+  version: 2.4.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: 296b403617bafa89df4971567af79013
+    sha256: 95d4713e49ea92ae50cf42393683ede706b7875af5f7cb14c253438180afa732
   category: main
   optional: false
 - name: aiohttp
-  version: 3.9.5
+  version: 3.11.12
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aiohappyeyeballs: '>=2.3.0'
     aiosignal: '>=1.1.2'
     attrs: '>=17.3.0'
     frozenlist: '>=1.1.1'
+    libgcc: '>=13'
+    multidict: '>=4.5,<7.0'
+    propcache: '>=0.2.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    yarl: '>=1.17.0,<2.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.11.12-py312h178313f_0.conda
+  hash:
+    md5: 9f96d8b6fb9bab11e46c12132283b5b1
+    sha256: 223f271deceaf71d0cbee21162084104a6eca06e79c04ecb322706be3e406ea1
+  category: main
+  optional: false
+- name: aiohttp
+  version: 3.11.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aiohappyeyeballs: '>=2.3.0'
+    aiosignal: '>=1.1.2'
+    attrs: '>=17.3.0'
+    frozenlist: '>=1.1.1'
+    multidict: '>=4.5,<7.0'
+    propcache: '>=0.2.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    yarl: '>=1.17.0,<2.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.11.12-py312h3520af0_0.conda
+  hash:
+    md5: c31e7180a4a86b5a8339689133deea9b
+    sha256: 3274f863fffdd612a18ae4f03ff047ad122799c48195f7cce5b494fc752908d6
+  category: main
+  optional: false
+- name: aiohttp
+  version: 3.11.12
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aiohappyeyeballs: '>=2.3.0'
+    aiosignal: '>=1.1.2'
+    attrs: '>=17.3.0'
+    frozenlist: '>=1.1.1'
+    multidict: '>=4.5,<7.0'
+    propcache: '>=0.2.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    yarl: '>=1.17.0,<2.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.11.12-py312h998013c_0.conda
+  hash:
+    md5: 7675cee14b7e7d9ccf17ad37a4bdf53a
+    sha256: a4d04942bdeedbb7260b41eafb0302b6f8c3799f578c4389984c084a8fc34c16
+  category: main
+  optional: false
+- name: aioitertools
+  version: 0.12.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3eb47adbffac44483f59e580f8600a1e
+    sha256: 7d56e547a819a03c058dd8793ca9df6ff9825812da52c214192edb61a7de1c95
+  category: main
+  optional: false
+- name: aioitertools
+  version: 0.12.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3eb47adbffac44483f59e580f8600a1e
+    sha256: 7d56e547a819a03c058dd8793ca9df6ff9825812da52c214192edb61a7de1c95
+  category: main
+  optional: false
+- name: aioitertools
+  version: 0.12.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3eb47adbffac44483f59e580f8600a1e
+    sha256: 7d56e547a819a03c058dd8793ca9df6ff9825812da52c214192edb61a7de1c95
+  category: main
+  optional: false
+- name: aiosignal
+  version: 1.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    frozenlist: '>=1.1.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1a3981115a398535dbe3f6d5faae3d36
+    sha256: 7de8ced1918bbdadecf8e1c1c68237fe5709c097bd9e0d254f4cad118f4345d0
+  category: main
+  optional: false
+- name: aiosignal
+  version: 1.3.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    frozenlist: '>=1.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1a3981115a398535dbe3f6d5faae3d36
+    sha256: 7de8ced1918bbdadecf8e1c1c68237fe5709c097bd9e0d254f4cad118f4345d0
+  category: main
+  optional: false
+- name: aiosignal
+  version: 1.3.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    frozenlist: '>=1.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1a3981115a398535dbe3f6d5faae3d36
+    sha256: 7de8ced1918bbdadecf8e1c1c68237fe5709c097bd9e0d254f4cad118f4345d0
+  category: main
+  optional: false
+- name: annotated-types
+  version: 0.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    typing-extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 2934f256a8acfe48f6ebb4fce6cde29c
+    sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
+  category: main
+  optional: false
+- name: annotated-types
+  version: 0.7.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    typing-extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 2934f256a8acfe48f6ebb4fce6cde29c
+    sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
+  category: main
+  optional: false
+- name: annotated-types
+  version: 0.7.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    typing-extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 2934f256a8acfe48f6ebb4fce6cde29c
+    sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
+  category: main
+  optional: false
+- name: aom
+  version: 3.9.1
+  manager: conda
+  platform: linux-64
+  dependencies:
     libgcc-ng: '>=12'
-    multidict: '>=4.5,<7.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    yarl: '>=1.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.5-py312h98912ed_0.conda
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
   hash:
-    md5: edc01db954d139fe398a5f378f96ab4d
-    sha256: 4727041c2bf3ee90f1a3bba68f846f6ea34f59b292bf5bc390db3bc4ae56d315
+    md5: 346722a0be40f6edc53f12640d301338
+    sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
   category: main
   optional: false
-- name: aiohttp
-  version: 3.9.5
+- name: aom
+  version: 3.9.1
   manager: conda
   platform: osx-64
   dependencies:
-    aiosignal: '>=1.1.2'
-    attrs: '>=17.3.0'
-    frozenlist: '>=1.1.1'
-    multidict: '>=4.5,<7.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    yarl: '>=1.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.9.5-py312h41838bb_0.conda
+    __osx: '>=10.13'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
   hash:
-    md5: 559e0083034b5313393798e733f784bf
-    sha256: fce6b95a067af67fc5bd04a7d3e95e49da32ee09585f36bfc9ecc0460d2044a6
+    md5: 3f17bc32cb7fcb2b4bf3d8d37f656eb8
+    sha256: 3032f2f55d6eceb10d53217c2a7f43e1eac83603d91e21ce502e8179e63a75f5
   category: main
   optional: false
-- name: aiohttp
-  version: 3.9.5
+- name: aom
+  version: 3.9.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    aiosignal: '>=1.1.2'
-    attrs: '>=17.3.0'
-    frozenlist: '>=1.1.1'
-    multidict: '>=4.5,<7.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    yarl: '>=1.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.9.5-py312he37b823_0.conda
+    __osx: '>=11.0'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
   hash:
-    md5: 5b7aa6817d365896c16910bf7e78c099
-    sha256: 98bebf4177a9b296eaac0e2b2541dc4e1d2c584a278cc15e7c03f910b75810f3
-  category: main
-  optional: false
-- name: aioitertools
-  version: 0.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-    typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 59c40397276a286241c65faec5e1be3c
-    sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
-  category: main
-  optional: false
-- name: aioitertools
-  version: 0.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-    typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 59c40397276a286241c65faec5e1be3c
-    sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
-  category: main
-  optional: false
-- name: aioitertools
-  version: 0.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-    typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 59c40397276a286241c65faec5e1be3c
-    sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
-  category: main
-  optional: false
-- name: aiosignal
-  version: 1.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    frozenlist: '>=1.1.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: d1e1eb7e21a9e2c74279d87dafb68156
-    sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
-  category: main
-  optional: false
-- name: aiosignal
-  version: 1.3.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    frozenlist: '>=1.1.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: d1e1eb7e21a9e2c74279d87dafb68156
-    sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
-  category: main
-  optional: false
-- name: aiosignal
-  version: 1.3.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    frozenlist: '>=1.1.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: d1e1eb7e21a9e2c74279d87dafb68156
-    sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
-  category: main
-  optional: false
-- name: annotated-types
-  version: 0.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7e9f4612544c8edbfd6afad17f1bd045
-    sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
-  category: main
-  optional: false
-- name: annotated-types
-  version: 0.7.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7e9f4612544c8edbfd6afad17f1bd045
-    sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
-  category: main
-  optional: false
-- name: annotated-types
-  version: 0.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7e9f4612544c8edbfd6afad17f1bd045
-    sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
+    md5: 7adba36492a1bb22d98ffffe4f6fc6de
+    sha256: ec238f18ce8140485645252351a0eca9ef4f7a1c568a420f240a585229bc12ef
   category: main
   optional: false
 - name: appdirs
@@ -316,11 +454,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 5f095bc6454094e96f146491fd03633b
-    sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+    md5: f4e90937bbfc3a4a92539545a37bb448
+    sha256: 5b9ef6d338525b332e17c3ed089ca2f53a5d74b7a7b432747d29c6466e39346d
   category: main
   optional: false
 - name: appdirs
@@ -328,11 +466,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 5f095bc6454094e96f146491fd03633b
-    sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+    md5: f4e90937bbfc3a4a92539545a37bb448
+    sha256: 5b9ef6d338525b332e17c3ed089ca2f53a5d74b7a7b432747d29c6466e39346d
   category: main
   optional: false
 - name: appdirs
@@ -340,11 +478,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 5f095bc6454094e96f146491fd03633b
-    sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+    md5: f4e90937bbfc3a4a92539545a37bb448
+    sha256: 5b9ef6d338525b332e17c3ed089ca2f53a5d74b7a7b432747d29c6466e39346d
   category: main
   optional: false
 - name: appnope
@@ -352,11 +490,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
   hash:
-    md5: cc4834a9ee7cc49ce8d25177c47b10d8
-    sha256: 45ae2d41f4a4dcf8707633d3d7ae376fc62f0c09b1d063c3049c3f6f8c911670
+    md5: 54898d0f524c9dee622d44bbb081a8ab
+    sha256: 8f032b140ea4159806e4969a68b4a3c0a7cab1ad936eb958a2b5ffe5335e19bf
   category: dev
   optional: true
 - name: appnope
@@ -364,86 +502,116 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
   hash:
-    md5: cc4834a9ee7cc49ce8d25177c47b10d8
-    sha256: 45ae2d41f4a4dcf8707633d3d7ae376fc62f0c09b1d063c3049c3f6f8c911670
+    md5: 54898d0f524c9dee622d44bbb081a8ab
+    sha256: 8f032b140ea4159806e4969a68b4a3c0a7cab1ad936eb958a2b5ffe5335e19bf
   category: dev
   optional: true
 - name: archspec
-  version: 0.2.3
+  version: 0.2.5
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 192278292e20704f663b9c766909d67b
-    sha256: cef4062ea91f07a961a808801d6b34a163632150037f4bd28232310ff0301cd7
+    md5: 845b38297fca2f2d18a29748e2ece7fa
+    sha256: eb68e1ce9e9a148168a4b1e257a8feebffdb0664b557bb526a1e4853f2d2fc00
   category: main
   optional: false
 - name: archspec
-  version: 0.2.3
+  version: 0.2.5
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 192278292e20704f663b9c766909d67b
-    sha256: cef4062ea91f07a961a808801d6b34a163632150037f4bd28232310ff0301cd7
+    md5: 845b38297fca2f2d18a29748e2ece7fa
+    sha256: eb68e1ce9e9a148168a4b1e257a8feebffdb0664b557bb526a1e4853f2d2fc00
   category: main
   optional: false
 - name: archspec
-  version: 0.2.3
+  version: 0.2.5
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 192278292e20704f663b9c766909d67b
-    sha256: cef4062ea91f07a961a808801d6b34a163632150037f4bd28232310ff0301cd7
+    md5: 845b38297fca2f2d18a29748e2ece7fa
+    sha256: eb68e1ce9e9a148168a4b1e257a8feebffdb0664b557bb526a1e4853f2d2fc00
   category: main
   optional: false
 - name: asttokens
-  version: 2.4.1
+  version: 3.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-    six: '>=1.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 5f25798dcefd8252ce5f9dc494d5f571
-    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+    md5: 8f587de4bcf981e26228f268df374a9b
+    sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
   category: dev
   optional: true
 - name: asttokens
-  version: 2.4.1
+  version: 3.0.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.5'
-    six: '>=1.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 5f25798dcefd8252ce5f9dc494d5f571
-    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+    md5: 8f587de4bcf981e26228f268df374a9b
+    sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
   category: dev
   optional: true
 - name: asttokens
-  version: 2.4.1
+  version: 3.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.5'
-    six: '>=1.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 5f25798dcefd8252ce5f9dc494d5f571
-    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+    md5: 8f587de4bcf981e26228f268df374a9b
+    sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
+  category: dev
+  optional: true
+- name: at-spi2-atk
+  version: 2.38.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    at-spi2-core: '>=2.40.0,<2.41.0a0'
+    atk-1.0: '>=2.36.0'
+    dbus: '>=1.13.6,<2.0a0'
+    libgcc-ng: '>=9.3.0'
+    libglib: '>=2.68.1,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
+  hash:
+    md5: 6b889f174df1e0f816276ae69281af4d
+    sha256: 26ab9386e80bf196e51ebe005da77d57decf6d989b4f34d96130560bc133479c
+  category: dev
+  optional: true
+- name: at-spi2-core
+  version: 2.40.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    dbus: '>=1.13.6,<2.0a0'
+    libgcc-ng: '>=9.3.0'
+    libglib: '>=2.68.3,<3.0a0'
+    xorg-libx11: ''
+    xorg-libxi: ''
+    xorg-libxtst: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
+  hash:
+    md5: 8cb2fc4cd6cc63f1369cfa318f581cc3
+    sha256: c4f9b66bd94c40d8f1ce1fad2d8b46534bdefda0c86e3337b28f6c25779f258d
   category: dev
   optional: true
 - name: atk-1.0
@@ -490,699 +658,724 @@ package:
     sha256: b0747f9b1bc03d1932b4d8c586f39a35ac97e7e72fe6e63f2b2a2472d466f3c1
   category: dev
   optional: true
-- name: attrs
-  version: 23.2.0
+- name: attr
+  version: 2.5.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
   hash:
-    md5: 5e4c0743c70186509d1412e03c2d8dfa
-    sha256: 77c7d03bdb243a048fff398cedc74327b7dc79169ebe3b4c8448b0331ea55fea
-  category: main
-  optional: false
-- name: attrs
-  version: 23.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
-  hash:
-    md5: 5e4c0743c70186509d1412e03c2d8dfa
-    sha256: 77c7d03bdb243a048fff398cedc74327b7dc79169ebe3b4c8448b0331ea55fea
+    md5: d9c69a24ad678ffce24c6543a0176b00
+    sha256: 82c13b1772c21fc4a17441734de471d3aabf82b61db9b11f4a1bd04a9c4ac324
   category: main
   optional: false
 - name: attrs
-  version: 23.2.0
+  version: 25.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-25.1.0-pyh71513ae_0.conda
+  hash:
+    md5: 2cc3f588512f04f3a0c64b4e9bedc02d
+    sha256: 1f267886522dfb9ae4e5ebbc3135b5eb13cff27bdbfe8d881a4d893459166ab4
+  category: main
+  optional: false
+- name: attrs
+  version: 25.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-25.1.0-pyh71513ae_0.conda
+  hash:
+    md5: 2cc3f588512f04f3a0c64b4e9bedc02d
+    sha256: 1f267886522dfb9ae4e5ebbc3135b5eb13cff27bdbfe8d881a4d893459166ab4
+  category: main
+  optional: false
+- name: attrs
+  version: 25.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-25.1.0-pyh71513ae_0.conda
   hash:
-    md5: 5e4c0743c70186509d1412e03c2d8dfa
-    sha256: 77c7d03bdb243a048fff398cedc74327b7dc79169ebe3b4c8448b0331ea55fea
+    md5: 2cc3f588512f04f3a0c64b4e9bedc02d
+    sha256: 1f267886522dfb9ae4e5ebbc3135b5eb13cff27bdbfe8d881a4d893459166ab4
   category: main
   optional: false
 - name: aws-c-auth
-  version: 0.7.22
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-http: '>=0.8.2,<0.8.3.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    aws-c-sdkutils: '>=0.1.16,<0.1.17.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.22-heee8711_7.conda
-  hash:
-    md5: 4f4ea05eaaaf001cad56fc4723caf208
-    sha256: 5391c9e3ddcf82de0ce59c6c516ab9e4b2ec70152ceb1ce3e5c6992568013077
-  category: main
-  optional: false
-- name: aws-c-auth
-  version: 0.7.22
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-http: '>=0.8.2,<0.8.3.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    aws-c-sdkutils: '>=0.1.16,<0.1.17.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.22-he52cbe7_7.conda
-  hash:
-    md5: bfa9a4d55804bab91ed4006089496264
-    sha256: fc89e3b398983cc978f2c6cd35757b9b3a149ead2ed0524e84eede109374ad5f
-  category: main
-  optional: false
-- name: aws-c-auth
-  version: 0.7.22
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-http: '>=0.8.2,<0.8.3.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    aws-c-sdkutils: '>=0.1.16,<0.1.17.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.22-haa5a189_7.conda
-  hash:
-    md5: 194eb593fd2a7c4cf762ffebbad9bc7c
-    sha256: 48214c89b8552bf3dff7bb57452e4d4ab0f642edb9f2b72615bd7a10000eef58
-  category: main
-  optional: false
-- name: aws-c-cal
-  version: 0.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    libgcc-ng: '>=12'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.0-h816f305_0.conda
-  hash:
-    md5: 9024f0647bfac11e986bba79a2e5daaa
-    sha256: ad48652b619b3af551b64ac14866a5e398f373a1d78ed9d2c55ec06f1662ae25
-  category: main
-  optional: false
-- name: aws-c-cal
-  version: 0.7.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.7.0-hd73d8db_0.conda
-  hash:
-    md5: 735d5c936d9c2bbe1a1449b408cff4c7
-    sha256: aa13679021c3c6613fb35a3cf9ca1b9d354583f5c54312dd7cfe88f2e62754c4
-  category: main
-  optional: false
-- name: aws-c-cal
-  version: 0.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.7.0-h94d0942_0.conda
-  hash:
-    md5: 255ac3454ccb5d4930c8a012da0ba1d3
-    sha256: e0f1a1b9e93e42a91f7960544fc32908a04327446b05ac1e2b8b50b7b030222b
-  category: main
-  optional: false
-- name: aws-c-common
-  version: 0.9.23
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.23-h4ab18f5_0.conda
-  hash:
-    md5: 94d61ae2b2b701008a9d52ce6bbead27
-    sha256: f3eab0ec3f01ddc3ebdc235d4ae1b3b803d83e40f2cd2389bf8c65ab96e90f02
-  category: main
-  optional: false
-- name: aws-c-common
-  version: 0.9.23
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.23-hfdf4475_0.conda
-  hash:
-    md5: 35083fa12de9dc9918de60c112ceab27
-    sha256: 63680a7e163a947eb97f68cf1d5dd26fe0fef9443196de4fc31615b28d6095a7
-  category: main
-  optional: false
-- name: aws-c-common
-  version: 0.9.23
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.23-h99b78c6_0.conda
-  hash:
-    md5: d9f2adf47d2078d44a23480140e76550
-    sha256: 15e965a0d1c37927e23d46691e632cf8b39afee5c9ba735f2d535fdb7b58b19e
-  category: main
-  optional: false
-- name: aws-c-compression
-  version: 0.2.18
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-he027950_7.conda
-  hash:
-    md5: 11e5cb0b426772974f6416545baee0ce
-    sha256: d4c70b8716e19fe56a563ab858ab7440f41c2dd927687357a44e69f23001126d
-  category: main
-  optional: false
-- name: aws-c-compression
-  version: 0.2.18
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-hd73d8db_7.conda
-  hash:
-    md5: b082d6b9a40e41fd27f48786d318e910
-    sha256: c8fabda8233f979f9c5173a5ba5f6482c26e8ac8af55e78550fff27e997e0dbd
-  category: main
-  optional: false
-- name: aws-c-compression
-  version: 0.2.18
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.18-h94d0942_7.conda
-  hash:
-    md5: c9a37f68bef48f48782746404f4050a2
-    sha256: d0244c7638853f8f8feb4a3107844fc6be23c6e29312fc5eda9221df5817b8a7
-  category: main
-  optional: false
-- name: aws-c-event-stream
-  version: 0.4.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-hb72ac1a_14.conda
-  hash:
-    md5: 64676cc50610171ec66083b82be93e52
-    sha256: 3d35d94361acaba6f272df690f3d25f62eaccd82e7f33aba7972f60283905fa4
-  category: main
-  optional: false
-- name: aws-c-event-stream
-  version: 0.4.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-ha5205da_14.conda
-  hash:
-    md5: 86842567307ff168a4237fe214d99cbc
-    sha256: 38fd28ea4f1839a80070d9b29df17182455905a0ed7703f830a0575d6f6bbe79
-  category: main
-  optional: false
-- name: aws-c-event-stream
-  version: 0.4.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.2-he43e89f_14.conda
-  hash:
-    md5: 80418a84df5d4ad87f3a35df31c6398d
-    sha256: 74da88265e7ad47edc62160c30cd1e25dff8b5468c0a1e38b1fa04052e348653
-  category: main
-  optional: false
-- name: aws-c-http
-  version: 0.8.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-compression: '>=0.2.18,<0.2.19.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.2-had8cc17_4.conda
-  hash:
-    md5: ccf5df89d5ac0e7812c1bd0023356248
-    sha256: 69381a48e10f469d4d36a6de64e585ddf891ddd01ec3644d8396e1a7528a308f
-  category: main
-  optional: false
-- name: aws-c-http
-  version: 0.8.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-compression: '>=0.2.18,<0.2.19.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.2-hf609411_4.conda
-  hash:
-    md5: db8bcad486843bab0ce73a4c51e8988e
-    sha256: 64916072087a874b122293370d0683865554f4fbd3c46a30fded1be5ab47f82b
-  category: main
-  optional: false
-- name: aws-c-http
-  version: 0.8.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-compression: '>=0.2.18,<0.2.19.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.2-h638bd1a_4.conda
-  hash:
-    md5: adfd440d1b11273adfb17bf9a1af3350
-    sha256: 667cbdfb389b4e4a3bb0f706b01cbdae13a17dbfda79a89cee8e112fbef5d158
-  category: main
-  optional: false
-- name: aws-c-io
-  version: 0.14.9
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    libgcc-ng: '>=12'
-    s2n: '>=1.4.17,<1.4.18.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.9-h37d6bf3_5.conda
-  hash:
-    md5: 2a651c0ba059f3da2449b4e03fddf9fb
-    sha256: 956af71689342edddd7524ea26b5f5ca8bf07df936ec0266c7d180eafd4de018
-  category: main
-  optional: false
-- name: aws-c-io
-  version: 0.14.9
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.9-h9f49e27_5.conda
-  hash:
-    md5: 8b1dafe98eefa86a9f874b30d88b0f06
-    sha256: 073354624ed160d65a5cb9ccc4693fb30a50556dda0943359cd3d8edd42d1bd1
-  category: main
-  optional: false
-- name: aws-c-io
-  version: 0.14.9
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.9-hf0e3e08_5.conda
-  hash:
-    md5: e279aef614bea9aa7ddb8f43ae282c18
-    sha256: 10158d10734fd0efa0c7ddeac137c2e56cca88c4b92a74b7527ba39888ecb2f7
-  category: main
-  optional: false
-- name: aws-c-mqtt
-  version: 0.10.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-http: '>=0.8.2,<0.8.3.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-hb0abfc5_7.conda
-  hash:
-    md5: b49afe12555befb53150e401d03264b3
-    sha256: 0878b77aa589c09fb4c00d8f383ac564e8908a5ccf39ac48e94fb0c14d7d4379
-  category: main
-  optional: false
-- name: aws-c-mqtt
-  version: 0.10.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-http: '>=0.8.2,<0.8.3.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.4-hcc4e2a5_7.conda
-  hash:
-    md5: 385617b6f01c4b53e0f223988db1c78e
-    sha256: fa609345a28eeebaaa2595f0a572e06e220cc62751a7c8711522ddbb2d6dbce1
-  category: main
-  optional: false
-- name: aws-c-mqtt
-  version: 0.10.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-http: '>=0.8.2,<0.8.3.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.4-h80c1ce3_7.conda
-  hash:
-    md5: 1c3749103857d0f31826d7f37f9776e9
-    sha256: b2d6d92a9daed8db9de940b87aae7c699c3e96e723335f2fea4310e2d1486bed
-  category: main
-  optional: false
-- name: aws-c-s3
-  version: 0.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-auth: '>=0.7.22,<0.7.23.0a0'
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-http: '>=0.8.2,<0.8.3.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    libgcc-ng: '>=12'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.0-h1f67ec3_0.conda
-  hash:
-    md5: 3db1e3d14496117a12851350eafe7c82
-    sha256: 21e874d3400e9235e5cb5bd6feafa3eb492050a947fd261fce4d9542a5eee54e
-  category: main
-  optional: false
-- name: aws-c-s3
-  version: 0.6.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    aws-c-auth: '>=0.7.22,<0.7.23.0a0'
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-http: '>=0.8.2,<0.8.3.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    aws-checksums: '>=0.1.18,<0.1.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.6.0-h8fdb93b_0.conda
-  hash:
-    md5: cc22bdb00822a498d9d53b5c31048c01
-    sha256: 0c3be55a5c433836f9c91cbe4e268af0af9f8af7a449690f35d4ea5f4021439f
-  category: main
-  optional: false
-- name: aws-c-s3
-  version: 0.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-auth: '>=0.7.22,<0.7.23.0a0'
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-http: '>=0.8.2,<0.8.3.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    aws-checksums: '>=0.1.18,<0.1.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.6.0-h11f64d3_0.conda
-  hash:
-    md5: c565526ae0997e4eb1fec3dae61cec99
-    sha256: 3c50502ff37e238fc1a773aa80dbd1f3c9f57a10ca025ee85ec9c3987b53f044
-  category: main
-  optional: false
-- name: aws-c-sdkutils
-  version: 0.1.16
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.16-he027950_3.conda
-  hash:
-    md5: adbf0c44ca88a3cded175cd809a106b6
-    sha256: 0f957d8cebe9c9b4041c858ca9a20619eb3fa866c71b21478a02d51f219d59cb
-  category: main
-  optional: false
-- name: aws-c-sdkutils
-  version: 0.1.16
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.16-hd73d8db_3.conda
-  hash:
-    md5: 7932c9b2420f0a809ab1b08e2ea53896
-    sha256: b944db69a4bf7481362378d81ff634b5eeed88f0b85c6609f195cd68ab3a8948
-  category: main
-  optional: false
-- name: aws-c-sdkutils
-  version: 0.1.16
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.16-h94d0942_3.conda
-  hash:
-    md5: 1f9dd57e79cf2191ed139491aa460e24
-    sha256: 4303f310b156abeca86ea8a4b4c8be5cfb96dd4214c2ebcfeef1bec3fa1dc793
-  category: main
-  optional: false
-- name: aws-checksums
-  version: 0.1.18
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-he027950_7.conda
-  hash:
-    md5: 95611b325a9728ed68b8f7eef2dd3feb
-    sha256: 094cff556dbf8fdd60505c8285b0a873de101374f568200275d8fd7fb77ad5e9
-  category: main
-  optional: false
-- name: aws-checksums
-  version: 0.1.18
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-hd73d8db_7.conda
-  hash:
-    md5: c3f25d79d4a36a89b3c638a6e3614f28
-    sha256: a4e2dc37e4bbb2d64d1fac29c1d9fbc7c50ad3b5e15ff52e05ae63e8052e54d3
-  category: main
-  optional: false
-- name: aws-checksums
-  version: 0.1.18
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.18-h94d0942_7.conda
-  hash:
-    md5: fbd0be30bdd84b6735dfa3d6c5916b2e
-    sha256: cdd08a5b6b4ebadf05087238987681dc370bd0336ed410d0047171020f160187
-  category: main
-  optional: false
-- name: aws-crt-cpp
-  version: 0.27.2
+  version: 0.8.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-auth: '>=0.7.22,<0.7.23.0a0'
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
-    aws-c-http: '>=0.8.2,<0.8.3.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    aws-c-mqtt: '>=0.10.4,<0.10.5.0a0'
-    aws-c-s3: '>=0.6.0,<0.6.1.0a0'
-    aws-c-sdkutils: '>=0.1.16,<0.1.17.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.2-heffe44f_0.conda
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-http: '>=0.9.0,<0.9.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-c-sdkutils: '>=0.2.1,<0.2.2.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.0-hcd8ed7f_7.conda
   hash:
-    md5: 6ee0af31304bca1d7406e41d30721db8
-    sha256: 3332ea4915514b1649fa0f85920b87fd68882ab642d3e346324a2dc30d4cd5a5
+    md5: b8725d87357c876b0458dee554c39b28
+    sha256: 35a8c73e750af3096170bba6a3a834b43b2241df6f57dd2d479e8eece1f2c526
   category: main
   optional: false
-- name: aws-crt-cpp
-  version: 0.27.2
+- name: aws-c-auth
+  version: 0.8.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-auth: '>=0.7.22,<0.7.23.0a0'
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
-    aws-c-http: '>=0.8.2,<0.8.3.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    aws-c-mqtt: '>=0.10.4,<0.10.5.0a0'
-    aws-c-s3: '>=0.6.0,<0.6.1.0a0'
-    aws-c-sdkutils: '>=0.1.16,<0.1.17.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.27.2-h7746516_0.conda
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-http: '>=0.9.0,<0.9.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-c-sdkutils: '>=0.2.1,<0.2.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.8.0-h69e5304_7.conda
   hash:
-    md5: 3edacdac85446f8e8b19ddb7f366919c
-    sha256: 5584d4febc8179d64b76e6a3831bdf55beb3f4fb602f6d1e1dde873f9ebae109
+    md5: 2242fb13381c1025354a51848ac324e5
+    sha256: 397684aee5ccb2ace5d57ee1a9137fd7cde89657a8543825267abc9beccf7ad9
   category: main
   optional: false
-- name: aws-crt-cpp
-  version: 0.27.2
+- name: aws-c-auth
+  version: 0.8.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-auth: '>=0.7.22,<0.7.23.0a0'
-    aws-c-cal: '>=0.7.0,<0.7.1.0a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
-    aws-c-http: '>=0.8.2,<0.8.3.0a0'
-    aws-c-io: '>=0.14.9,<0.14.10.0a0'
-    aws-c-mqtt: '>=0.10.4,<0.10.5.0a0'
-    aws-c-s3: '>=0.6.0,<0.6.1.0a0'
-    aws-c-sdkutils: '>=0.1.16,<0.1.17.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.27.2-hd9c8ee4_0.conda
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-http: '>=0.9.0,<0.9.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-c-sdkutils: '>=0.2.1,<0.2.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.0-h6935006_7.conda
   hash:
-    md5: f9c5468b84202b89ac5a19748f88660c
-    sha256: babeb9df9290198629ce4236315312721777955026ab71ce0c3459103249554c
+    md5: c1181b45af5bb8867ee9edf2e85ecc91
+    sha256: 1b2d103607232935425565d929eb704924f72c41abbf7ad55ccbaa7a4c4ef832
   category: main
   optional: false
-- name: aws-sam-translator
-  version: 1.89.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    boto3: '>=1.19.5,<2'
-    jsonschema: <5,>=3.2
-    pydantic: '>=1.8,<3'
-    python: '>=3.8,<4.0'
-    typing-extensions: '>=4.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/aws-sam-translator-1.89.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 9ffaf73ba21b08f4fe2cd59417702c21
-    sha256: 5e830fdb1c8368957f1eb0a2172c39e49ed50717f8eebb2fd3e1d8942767deb2
-  category: dev
-  optional: true
-- name: aws-sam-translator
-  version: 1.89.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    boto3: '>=1.19.5,<2'
-    jsonschema: <5,>=3.2
-    pydantic: '>=1.8,<3'
-    python: '>=3.8,<4.0'
-    typing-extensions: '>=4.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/aws-sam-translator-1.89.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 9ffaf73ba21b08f4fe2cd59417702c21
-    sha256: 5e830fdb1c8368957f1eb0a2172c39e49ed50717f8eebb2fd3e1d8942767deb2
-  category: dev
-  optional: true
-- name: aws-sam-translator
-  version: 1.89.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    boto3: '>=1.19.5,<2'
-    jsonschema: <5,>=3.2
-    pydantic: '>=1.8,<3'
-    python: '>=3.8,<4.0'
-    typing-extensions: '>=4.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/aws-sam-translator-1.89.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 9ffaf73ba21b08f4fe2cd59417702c21
-    sha256: 5e830fdb1c8368957f1eb0a2172c39e49ed50717f8eebb2fd3e1d8942767deb2
-  category: dev
-  optional: true
-- name: aws-sdk-cpp
-  version: 1.11.329
+- name: aws-c-cal
+  version: 0.8.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
-    aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    aws-crt-cpp: '>=0.27.2,<0.27.3.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.3.1,<2.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    libgcc: '>=13'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.329-habc23cd_8.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.0-he70792b_1.conda
   hash:
-    md5: 9d709ffcc4cfaa5ae35a740084188c5e
-    sha256: 160e0583ee46bc9eeb0ddcc6053b0c966e510d508085704394063c802278c67d
+    md5: 9b81a9d9395fb2abd60984fcfe7eb01a
+    sha256: 83724251e3d8a98c8236d478a9ea9d164b55c4031dbdf45f728fa1bdbc43d6ef
+  category: main
+  optional: false
+- name: aws-c-cal
+  version: 0.8.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    openssl: '>=3.3.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.8.0-h814e318_1.conda
+  hash:
+    md5: 532f048c811213cf7f9c0c280ed5b760
+    sha256: 004de52b7d7abca21d28f81408983f1cebd0f9b379842e89c69b4e3a617a8aea
+  category: main
+  optional: false
+- name: aws-c-cal
+  version: 0.8.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    openssl: '>=3.3.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.0-h8a8b6a7_1.conda
+  hash:
+    md5: 107fcd20e67df3945a34129098f3da4a
+    sha256: 0f8ad4bd6067ca35ef89834b8f11ed391bec122afa4f4df2c087b7c2934c4743
+  category: main
+  optional: false
+- name: aws-c-common
+  version: 0.10.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.0-hb9d3cd8_0.conda
+  hash:
+    md5: f6495bc3a19a4400d3407052d22bef13
+    sha256: cf825c991332f4803fbc552bee92e46d2d5e2919a5521fa55043207f39882e3c
+  category: main
+  optional: false
+- name: aws-c-common
+  version: 0.10.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.10.0-ha44c9a9_0.conda
+  hash:
+    md5: 49cfcde38ade26d72fc6a103bede21f5
+    sha256: 797fa5eac65ad3f95795a88aef23f938cc31cd1e365b6537147dea50ba28d7e8
+  category: main
+  optional: false
+- name: aws-c-common
+  version: 0.10.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.0-h7ab814d_0.conda
+  hash:
+    md5: d4a98098dac19b54459855c1eb4a689a
+    sha256: 4ac33b0ec0d8a3b8af462d51e0e5e9095d9726860eb9b711ab6c6f84ba6b6b5e
+  category: main
+  optional: false
+- name: aws-c-compression
+  version: 0.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-hba2fe39_1.conda
+  hash:
+    md5: c6133966058e553727f0afe21ab38cd2
+    sha256: c7930aa52911ddc01de6ff92e5c93f1c71ecf3fc36d85ffe920b5dc422f6de4a
+  category: main
+  optional: false
+- name: aws-c-compression
+  version: 0.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.0-h814e318_1.conda
+  hash:
+    md5: ec975f9c7d27591f84dd4da0957ec1a0
+    sha256: 16d388ad30be1b338507a19088a2022b9c9a6bb5e1f5171ac686093b61007364
+  category: main
+  optional: false
+- name: aws-c-compression
+  version: 0.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-h8a8b6a7_1.conda
+  hash:
+    md5: e3306612c4561cbea6d0216b3dd85338
+    sha256: 701d2b269ce3d58f298d79a76e4a6537b2b9df32745584a3d012253dc49dd9d9
+  category: main
+  optional: false
+- name: aws-c-event-stream
+  version: 0.5.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-checksums: '>=0.2.0,<0.2.1.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h127f702_4.conda
+  hash:
+    md5: 81d250bca40c7907ece5f5dd00de51d0
+    sha256: 5da248465f9e271c9fbbdb3090d5aa19c7f1d7017aa18a47ce69466339fe8c20
+  category: main
+  optional: false
+- name: aws-c-event-stream
+  version: 0.5.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-checksums: '>=0.2.0,<0.2.1.0a0'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.5.0-hbfe8335_4.conda
+  hash:
+    md5: 2a772340b744718fa73710e84cc74ff6
+    sha256: 96b25601b9a882d066238903234a4e4e27356338f754011d7d189482e07406e4
+  category: main
+  optional: false
+- name: aws-c-event-stream
+  version: 0.5.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-checksums: '>=0.2.0,<0.2.1.0a0'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h53a7d5e_4.conda
+  hash:
+    md5: ee6ab18e57b915a8680bbbc583c04f0b
+    sha256: c0302836312b1755d47cd9a6dac6de21a98846a9a23d0208d772f450942e0c0e
+  category: main
+  optional: false
+- name: aws-c-http
+  version: 0.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-compression: '>=0.3.0,<0.3.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.0-h8a7d7e2_5.conda
+  hash:
+    md5: c40bb8a9f3936ebeea804e97c5adf179
+    sha256: 9f2751a0f23561789b7d0df996755b135e90dd00d319d2ae07dd1128bd203748
+  category: main
+  optional: false
+- name: aws-c-http
+  version: 0.9.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-compression: '>=0.3.0,<0.3.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.9.0-h8316fcd_5.conda
+  hash:
+    md5: 0bdc212b67bc378fbbf25b848ffb6c35
+    sha256: 7b988431d13bc7ee055f4d19be8b2784d21fb8d3e100b98d02d6a857644ac6ea
+  category: main
+  optional: false
+- name: aws-c-http
+  version: 0.9.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-compression: '>=0.3.0,<0.3.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.0-h007639a_5.conda
+  hash:
+    md5: e8be780c203c54a620f70dd2b15263ce
+    sha256: 50e506e55e491c1560324e73de001af21dcdbd1c5c4d2a46984588fb87813ecc
+  category: main
+  optional: false
+- name: aws-c-io
+  version: 0.15.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    libgcc: '>=13'
+    s2n: '>=1.5.7,<1.5.8.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.1-h2a50c78_1.conda
+  hash:
+    md5: 67dfecff4c4253cfe33c3c8e428f1767
+    sha256: 598f75e63aff93eec7f284f1bafdb808b79a7f57acd4442169f1b5f35caab914
+  category: main
+  optional: false
+- name: aws-c-io
+  version: 0.15.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.15.1-h33d4847_1.conda
+  hash:
+    md5: 4fed3d69593030e575d098a3dffa5b00
+    sha256: 98001055b5f2f5be0a93484ed95ea6fcba42a887eabdc8d9d78b4bc4d1c715ba
+  category: main
+  optional: false
+- name: aws-c-io
+  version: 0.15.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.1-hb495e35_1.conda
+  hash:
+    md5: d6d283e3ba890b8386b54ca8f571f616
+    sha256: 3dabe80b2fe7965e05debcb6e28a622e95c411a37d2695b9a09bec612307337d
+  category: main
+  optional: false
+- name: aws-c-mqtt
+  version: 0.11.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-http: '>=0.9.0,<0.9.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-hd25e75f_5.conda
+  hash:
+    md5: 277dae7174fd2bc81c01411039ac2173
+    sha256: 88d3f42dc37d6718e93b21b26eadd97207191b7bce6bd8e29f9f7ab36fd99b7d
+  category: main
+  optional: false
+- name: aws-c-mqtt
+  version: 0.11.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-http: '>=0.9.0,<0.9.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.11.0-hec7e333_5.conda
+  hash:
+    md5: 9d91c9c8c61d1ea2fb5b6d3bab4b795d
+    sha256: 51b036110e1a216cb4652434d9697512f341e8196ea0b5af635d25a7bc2d9360
+  category: main
+  optional: false
+- name: aws-c-mqtt
+  version: 0.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-http: '>=0.9.0,<0.9.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h6850007_5.conda
+  hash:
+    md5: bec16e1070d9ebfc27bde490c68fe9d9
+    sha256: 9cfcea2aa6020e6af635ab3390eeee6949461ca65565fa7d08d599fdeebcf2af
+  category: main
+  optional: false
+- name: aws-c-s3
+  version: 0.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-auth: '>=0.8.0,<0.8.1.0a0'
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-http: '>=0.9.0,<0.9.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-checksums: '>=0.2.0,<0.2.1.0a0'
+    libgcc: '>=13'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.0-h858c4ad_7.conda
+  hash:
+    md5: 1698a4867ecd97931d1bb743428686ec
+    sha256: d24980ca81e08bf7196f3ee21df73b4aef7d860818594a88920cdba41d75e522
+  category: main
+  optional: false
+- name: aws-c-s3
+  version: 0.7.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-auth: '>=0.8.0,<0.8.1.0a0'
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-http: '>=0.9.0,<0.9.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-checksums: '>=0.2.0,<0.2.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.7.0-hdbd2099_7.conda
+  hash:
+    md5: 8d93a49485ce40fa6765e2cbc6df560e
+    sha256: 7e21aa519a588364c0fa49573a83dacce994a7b07e8ada5a5e1abab35613bb0d
+  category: main
+  optional: false
+- name: aws-c-s3
+  version: 0.7.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-auth: '>=0.8.0,<0.8.1.0a0'
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-http: '>=0.9.0,<0.9.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-checksums: '>=0.2.0,<0.2.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.0-h2bee52d_7.conda
+  hash:
+    md5: 651d54a474bf4663cd4acbb9c63ba261
+    sha256: b5203bfe36cc18ffb7c6270d1334c5525ba4dea6a86a2130dba80a8d4df64621
+  category: main
+  optional: false
+- name: aws-c-sdkutils
+  version: 0.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.1-hba2fe39_0.conda
+  hash:
+    md5: f0b3524e47ed870bb8304a8d6fa67c7f
+    sha256: 8f11ec96e5a81e35b166b98b5c481568e5df18618d4de9dec00cace3a674c9bb
+  category: main
+  optional: false
+- name: aws-c-sdkutils
+  version: 0.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.1-hc280b33_0.conda
+  hash:
+    md5: ea1bec6200d75ab9cd3a879f407a4310
+    sha256: b12b4b455f8e66e260b2bbd69259cdb6b5b5f8d80f83521f1fcd4a23c190a91a
+  category: main
+  optional: false
+- name: aws-c-sdkutils
+  version: 0.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.1-h0b63f77_0.conda
+  hash:
+    md5: c399890eb4c3c3fb1b4b4838cd7d7208
+    sha256: 1f17f70ada62bbfd900fb051f8a3988c7436e45fe69d5e9aa69bf0154983d1f9
+  category: main
+  optional: false
+- name: aws-checksums
+  version: 0.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.0-hba2fe39_1.conda
+  hash:
+    md5: ac8d58d81bdcefa5bce4e883c6b88c42
+    sha256: 6c87c69df9dc2293d7159cb56b265da0a5bd12521ff4c664c6e57c24b1cfcc90
+  category: main
+  optional: false
+- name: aws-checksums
+  version: 0.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.0-h814e318_1.conda
+  hash:
+    md5: 40d2ba11f708ec9beccf99a4387a0a25
+    sha256: 13bdf44125c9be9c3e92d96bfe696562412187454a565d8c438e0bef01e7ae29
+  category: main
+  optional: false
+- name: aws-checksums
+  version: 0.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.0-h8a8b6a7_1.conda
+  hash:
+    md5: d9db2bb8ced62ee3d6bfc32b46c5af1f
+    sha256: 1297ef83c67e9b0cb2bf80abf7ff1c05d62d485dd9eda963318d338e18cb89bd
+  category: main
+  optional: false
+- name: aws-crt-cpp
+  version: 0.29.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-auth: '>=0.8.0,<0.8.1.0a0'
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
+    aws-c-http: '>=0.9.0,<0.9.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-c-mqtt: '>=0.11.0,<0.11.1.0a0'
+    aws-c-s3: '>=0.7.0,<0.7.1.0a0'
+    aws-c-sdkutils: '>=0.2.1,<0.2.2.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.3-hbc793f2_2.conda
+  hash:
+    md5: 3ac9933695a731e6507eef6c3704c10f
+    sha256: 19c213c62bfe60aba9c48140d1a921c351df96548d50ffa16d8c03d24f8a1e5b
+  category: main
+  optional: false
+- name: aws-crt-cpp
+  version: 0.29.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aws-c-auth: '>=0.8.0,<0.8.1.0a0'
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
+    aws-c-http: '>=0.9.0,<0.9.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-c-mqtt: '>=0.11.0,<0.11.1.0a0'
+    aws-c-s3: '>=0.7.0,<0.7.1.0a0'
+    aws-c-sdkutils: '>=0.2.1,<0.2.2.0a0'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.29.3-h9d5f034_2.conda
+  hash:
+    md5: 5d627f1d988c07ca8a3f49739f9413e3
+    sha256: 78110457920217e59bb74700b5a4caf082966bff1c7c3171255fe75fce5c7a9f
+  category: main
+  optional: false
+- name: aws-crt-cpp
+  version: 0.29.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-c-auth: '>=0.8.0,<0.8.1.0a0'
+    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
+    aws-c-http: '>=0.9.0,<0.9.1.0a0'
+    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-c-mqtt: '>=0.11.0,<0.11.1.0a0'
+    aws-c-s3: '>=0.7.0,<0.7.1.0a0'
+    aws-c-sdkutils: '>=0.2.1,<0.2.2.0a0'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.3-h7abc90e_2.conda
+  hash:
+    md5: 38a65640b8885238fb6155718d7c52b0
+    sha256: c187663950bad364957cf490c0a380312ac018852eeaaa996750149d80fe90f0
+  category: main
+  optional: false
+- name: aws-sam-translator
+  version: 1.94.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    boto3: '>=1.19.5,<2'
+    jsonschema: <5,>=3.2
+    pydantic: '>=1.8,<3,!=1.10.15,!=1.10.17'
+    python: '>=3.9,<4.0'
+    typing-extensions: '>=4.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/aws-sam-translator-1.94.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: f517c0c8063484928324bc7049f58c3c
+    sha256: 16a1715ccdc73a12cb855152c79350bc4c012af8cab88426506955cde037aa2b
+  category: dev
+  optional: true
+- name: aws-sam-translator
+  version: 1.94.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9,<4.0'
+    typing-extensions: '>=4.4'
+    boto3: '>=1.19.5,<2'
+    jsonschema: <5,>=3.2
+    pydantic: '>=1.8,<3,!=1.10.15,!=1.10.17'
+  url: https://conda.anaconda.org/conda-forge/noarch/aws-sam-translator-1.94.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: f517c0c8063484928324bc7049f58c3c
+    sha256: 16a1715ccdc73a12cb855152c79350bc4c012af8cab88426506955cde037aa2b
+  category: dev
+  optional: true
+- name: aws-sam-translator
+  version: 1.94.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9,<4.0'
+    typing-extensions: '>=4.4'
+    boto3: '>=1.19.5,<2'
+    jsonschema: <5,>=3.2
+    pydantic: '>=1.8,<3,!=1.10.15,!=1.10.17'
+  url: https://conda.anaconda.org/conda-forge/noarch/aws-sam-translator-1.94.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: f517c0c8063484928324bc7049f58c3c
+    sha256: 16a1715ccdc73a12cb855152c79350bc4c012af8cab88426506955cde037aa2b
+  category: dev
+  optional: true
+- name: aws-sdk-cpp
+  version: 1.11.407
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
+    aws-checksums: '>=0.2.0,<0.2.1.0a0'
+    aws-crt-cpp: '>=0.29.3,<0.29.4.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.407-h5cd358a_9.conda
+  hash:
+    md5: 1bba87c0e95867ad8ef2932d603ce7ee
+    sha256: 844fc29c66cad653c54d2a8a5edd62a01d3b02195dc11eed54060a24ad8911f5
   category: main
   optional: false
 - name: aws-sdk-cpp
-  version: 1.11.329
+  version: 1.11.407
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
-    aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    aws-crt-cpp: '>=0.27.2,<0.27.3.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
+    aws-checksums: '>=0.2.0,<0.2.1.0a0'
+    aws-crt-cpp: '>=0.29.3,<0.29.4.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=18'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.329-hce9e41e_8.conda
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.407-hd94a03e_9.conda
   hash:
-    md5: 1e9d46fc8971c589be2e5c3ddd7ad736
-    sha256: f0bfff6e7e705d54c4363ac3a91239da43fff781b6496f028946b5b20a8df17d
+    md5: c7f63181f02906d4f2f1634e251b4a1b
+    sha256: d5554dcbcb89d8951b5c39359be544daa0c9e8ab6a2ea690cd6c73a331964319
   category: main
   optional: false
 - name: aws-sdk-cpp
-  version: 1.11.329
+  version: 1.11.407
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.9.23,<0.9.24.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
-    aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    aws-crt-cpp: '>=0.27.2,<0.27.3.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
+    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
+    aws-checksums: '>=0.2.0,<0.2.1.0a0'
+    aws-crt-cpp: '>=0.29.3,<0.29.4.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=18'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.329-haf867cf_8.conda
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.407-h124cfea_9.conda
   hash:
-    md5: b802184760523a9e0c1c0e8dbb56e2d0
-    sha256: e5a1fdc4875905a37128a0f01939996f023ea0d52fce5e70620e9e91558869aa
+    md5: 08c1305729417bd80910219c37eef1e8
+    sha256: 52260e96642a44db84e38cb01dfc99d8c134e2676fafc90dc38c82453f7751d5
   category: main
   optional: false
 - name: aws-xray-sdk
@@ -1191,12 +1384,12 @@ package:
   platform: linux-64
   dependencies:
     botocore: '>=1.11.3'
-    python: '>=3.7'
+    python: '>=3.9'
     wrapt: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/aws-xray-sdk-2.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aws-xray-sdk-2.14.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 4edf2974ccb972d12e1f00bffddebb4b
-    sha256: 7da177e1c364c08cd7e7aadfcc1a20451c7c565dce4939006c50303f53beac63
+    md5: fcb64fea2dd8454379e3a6872415fa99
+    sha256: cee9764c5a75f28af403891161517066be30cb1819034958e490479c62317dc0
   category: dev
   optional: true
 - name: aws-xray-sdk
@@ -1204,13 +1397,13 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    botocore: '>=1.11.3'
-    python: '>=3.7'
     wrapt: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/aws-xray-sdk-2.14.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    botocore: '>=1.11.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/aws-xray-sdk-2.14.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 4edf2974ccb972d12e1f00bffddebb4b
-    sha256: 7da177e1c364c08cd7e7aadfcc1a20451c7c565dce4939006c50303f53beac63
+    md5: fcb64fea2dd8454379e3a6872415fa99
+    sha256: cee9764c5a75f28af403891161517066be30cb1819034958e490479c62317dc0
   category: dev
   optional: true
 - name: aws-xray-sdk
@@ -1218,208 +1411,25 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    botocore: '>=1.11.3'
-    python: '>=3.7'
     wrapt: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/aws-xray-sdk-2.14.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    botocore: '>=1.11.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/aws-xray-sdk-2.14.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 4edf2974ccb972d12e1f00bffddebb4b
-    sha256: 7da177e1c364c08cd7e7aadfcc1a20451c7c565dce4939006c50303f53beac63
+    md5: fcb64fea2dd8454379e3a6872415fa99
+    sha256: cee9764c5a75f28af403891161517066be30cb1819034958e490479c62317dc0
   category: dev
   optional: true
-- name: azure-core-cpp
-  version: 1.12.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libcurl: '>=8.7.1,<9.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.3.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.12.0-h830ed8b_0.conda
-  hash:
-    md5: 320d066f9cad598854f4af32c7c82931
-    sha256: f76438c1f2a2c6142b344652c9fb93304cf1bb1534521f94c9c30fb9b238f0f5
-  category: main
-  optional: false
-- name: azure-core-cpp
-  version: 1.12.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcurl: '>=8.7.1,<9.0a0'
-    libcxx: '>=16'
-    openssl: '>=3.3.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.12.0-hf8dbe3c_0.conda
-  hash:
-    md5: bbe2fcdfbdd6bb570691ea3c814bf0ea
-    sha256: c6ea0cec8d2a6d1cb6c30105f7e99fb8bf3de6cbd8c36dafb972517998725448
-  category: main
-  optional: false
-- name: azure-core-cpp
-  version: 1.12.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcurl: '>=8.7.1,<9.0a0'
-    libcxx: '>=16'
-    openssl: '>=3.3.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.12.0-hd01fc5c_0.conda
-  hash:
-    md5: 2accb43f3af2ebf2dbd127978242c10a
-    sha256: 046435d3502da0f13c13ee6d92d57684624bf18aefc0d84b99d3ed39d034b078
-  category: main
-  optional: false
-- name: azure-identity-cpp
-  version: 1.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.8.0-hdb0d106_1.conda
-  hash:
-    md5: a297ffb4b505f51d0f58352c5c13971b
-    sha256: 87420c137ae4d3e139cace9d9da8d63e6888d206f4eea0082975352d4ee65b14
-  category: main
-  optional: false
-- name: azure-identity-cpp
-  version: 1.8.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
-    libcxx: '>=16'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.8.0-h906f3f0_1.conda
-  hash:
-    md5: 710118f53411ec0f8b8832cb52374d72
-    sha256: d6656ddfd349b546105f9b47944f2fe3200601d5fa31e13236b3a248e85faa47
-  category: main
-  optional: false
-- name: azure-identity-cpp
-  version: 1.8.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
-    libcxx: '>=16'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.8.0-h0a11218_1.conda
-  hash:
-    md5: ed8853eaa0ea62cee06025902a46ff17
-    sha256: 2e54b5d0bd189f43d93e5d3f93534d360c071a4fa4c9f1c9e17301cb29943d43
-  category: main
-  optional: false
-- name: azure-storage-blobs-cpp
-  version: 12.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
-    azure-storage-common-cpp: '>=12.6.0,<12.6.1.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.11.0-ha67cba7_1.conda
-  hash:
-    md5: f03bba57b85a5b3ac443a871787fc429
-    sha256: 1dc694bcecdead2dbd871bb3abe5470c4473a7e46cfa39885aec70c230d3c16e
-  category: main
-  optional: false
-- name: azure-storage-blobs-cpp
-  version: 12.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
-    azure-storage-common-cpp: '>=12.6.0,<12.6.1.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.11.0-h5f32033_1.conda
-  hash:
-    md5: ac9d444eda34370acdf088291aeeaf5b
-    sha256: b77b800ff43ed3ef54c78a66e280905244086d8cb5188ba2c04c3b0fb4708528
-  category: main
-  optional: false
-- name: azure-storage-blobs-cpp
-  version: 12.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
-    azure-storage-common-cpp: '>=12.6.0,<12.6.1.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.11.0-h77cc766_1.conda
-  hash:
-    md5: 817fa040e0458866a658a471abc74c64
-    sha256: 390ada2bad5c76b33ef3d2e9e03ee54f7245060a34d6b199117e956301101449
-  category: main
-  optional: false
-- name: azure-storage-common-cpp
-  version: 12.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.7,<3.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.6.0-he3f277c_1.conda
-  hash:
-    md5: 8a10bb068b138dd473300b5fe34a1865
-    sha256: 464c687ed110befb4099be88ea69d2d2fd039a428ab6d9575ac9bf88e932dd55
-  category: main
-  optional: false
-- name: azure-storage-common-cpp
-  version: 12.6.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
-    libcxx: '>=16'
-    libxml2: '>=2.12.7,<3.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.6.0-h0dc8e96_1.conda
-  hash:
-    md5: 91bbe2122324a2044d5d174b493d4670
-    sha256: 8ca1fa9c687825bb8fc6578e6d29569d1a0158361e1f9217e018ab1c0743e9c4
-  category: main
-  optional: false
-- name: azure-storage-common-cpp
-  version: 12.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
-    libcxx: '>=16'
-    libxml2: '>=2.12.7,<3.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.6.0-h7024f69_1.conda
-  hash:
-    md5: e796ec0c1c7486270353910f0683de86
-    sha256: fbf126aad4d98627a32334cdff8e8f0626120a641f424e08d741595d8b6dc8de
-  category: main
-  optional: false
 - name: backoff
   version: 2.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 4600709bd85664d8606ae0c76642f8db
-    sha256: b1cf7df15741e5fbc57e22a3a89db427383335aaab22ddc1b30710deeb0130de
+    md5: a38b801f2bcc12af80c2e02a9e4ce7d9
+    sha256: f334115c6b0c6c2cd0d28595365f205ec7eaa60bcc5ff91a75d7245f728be820
   category: main
   optional: false
 - name: backoff
@@ -1427,11 +1437,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 4600709bd85664d8606ae0c76642f8db
-    sha256: b1cf7df15741e5fbc57e22a3a89db427383335aaab22ddc1b30710deeb0130de
+    md5: a38b801f2bcc12af80c2e02a9e4ce7d9
+    sha256: f334115c6b0c6c2cd0d28595365f205ec7eaa60bcc5ff91a75d7245f728be820
   category: main
   optional: false
 - name: backoff
@@ -1439,11 +1449,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 4600709bd85664d8606ae0c76642f8db
-    sha256: b1cf7df15741e5fbc57e22a3a89db427383335aaab22ddc1b30710deeb0130de
+    md5: a38b801f2bcc12af80c2e02a9e4ce7d9
+    sha256: f334115c6b0c6c2cd0d28595365f205ec7eaa60bcc5ff91a75d7245f728be820
   category: main
   optional: false
 - name: backports
@@ -1451,11 +1461,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
   hash:
-    md5: 54ca2e08b3220c148a1d8329c2678e02
-    sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+    md5: 767d508c1a67e02ae8f50e44cacfadb2
+    sha256: e1c3dc8b5aa6e12145423fed262b4754d70fec601339896b9ccf483178f690a6
   category: main
   optional: false
 - name: backports
@@ -1463,11 +1473,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
   hash:
-    md5: 54ca2e08b3220c148a1d8329c2678e02
-    sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+    md5: 767d508c1a67e02ae8f50e44cacfadb2
+    sha256: e1c3dc8b5aa6e12145423fed262b4754d70fec601339896b9ccf483178f690a6
   category: main
   optional: false
 - name: backports
@@ -1475,96 +1485,97 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
   hash:
-    md5: 54ca2e08b3220c148a1d8329c2678e02
-    sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+    md5: 767d508c1a67e02ae8f50e44cacfadb2
+    sha256: e1c3dc8b5aa6e12145423fed262b4754d70fec601339896b9ccf483178f690a6
   category: main
   optional: false
 - name: backports.tarfile
-  version: 1.0.0
+  version: 1.2.0
   manager: conda
   platform: linux-64
   dependencies:
     backports: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.0.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: c747b1d79f136013c3b7ebcba876afa6
-    sha256: 7ba30f32daad2e7ca251508525185ba170eedc14123572611c2acf261c7956b3
+    md5: df837d654933488220b454c6a3b0fad6
+    sha256: a0f41db6d7580cec3c850e5d1b82cb03197dd49a3179b1cee59c62cd2c761b36
   category: main
   optional: false
 - name: backports.tarfile
-  version: 1.0.0
+  version: 1.2.0
   manager: conda
   platform: osx-64
   dependencies:
     backports: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.0.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: c747b1d79f136013c3b7ebcba876afa6
-    sha256: 7ba30f32daad2e7ca251508525185ba170eedc14123572611c2acf261c7956b3
+    md5: df837d654933488220b454c6a3b0fad6
+    sha256: a0f41db6d7580cec3c850e5d1b82cb03197dd49a3179b1cee59c62cd2c761b36
   category: main
   optional: false
 - name: backports.tarfile
-  version: 1.0.0
+  version: 1.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
     backports: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.0.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: c747b1d79f136013c3b7ebcba876afa6
-    sha256: 7ba30f32daad2e7ca251508525185ba170eedc14123572611c2acf261c7956b3
+    md5: df837d654933488220b454c6a3b0fad6
+    sha256: a0f41db6d7580cec3c850e5d1b82cb03197dd49a3179b1cee59c62cd2c761b36
   category: main
   optional: false
 - name: bcrypt
-  version: 4.1.3
+  version: 4.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/bcrypt-4.1.3-py312h4413252_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/bcrypt-4.2.1-py312h12e396e_0.conda
   hash:
-    md5: 6c31ba904235897ff6869ad448139838
-    sha256: 85974c97ed04aaa19aa2ad7c645d436f1a8333dfae2d48c1ede902fe3a6c83bb
+    md5: fbfaa371b5f14cb89756483bb4e030be
+    sha256: 6f2b82c69893ef33d24975572a03c031a889c0a0e8406ae1d3a09c7f1608bf4b
   category: dev
   optional: true
 - name: bcrypt
-  version: 4.1.3
+  version: 4.2.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/bcrypt-4.1.3-py312ha47ea1c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/bcrypt-4.2.1-py312h0d0de52_0.conda
   hash:
-    md5: 5aca18c1646e4ac262ad0e91bb57c103
-    sha256: d6f10befa05415172b25b5aa731a0510fee71ba8fe7f8b3acc10a3cfb85730f9
+    md5: 6ed8319cec2be2818ce6270645a57d22
+    sha256: ed6adbba5e892a5165401c2513b77b570692cc311b8a0d6bb4a2edac353ebdd7
   category: dev
   optional: true
 - name: bcrypt
-  version: 4.1.3
+  version: 4.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bcrypt-4.1.3-py312h552d48e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bcrypt-4.2.1-py312hcd83bfe_0.conda
   hash:
-    md5: b950266b0ab4c5364db25b410726a38d
-    sha256: a536268c5cd93235b14c89eafd5f8bc86d1259be1d454b928162c6013447ece6
+    md5: 527903e14dd5572f8e076c6ad6954d67
+    sha256: eec3209348e156e7879c20e7f49afe603460889dccac1263d07a6239c086b134
   category: dev
   optional: true
 - name: black
-  version: 24.4.2
+  version: 24.10.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -1575,14 +1586,14 @@ package:
     platformdirs: '>=2'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/black-24.4.2-py312h7900ff3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/black-24.10.0-py312h7900ff3_0.conda
   hash:
-    md5: 777e84c9bef7349c8cee65cffb11f7c4
-    sha256: 02e36917e82adf0b2929b6fc35e60d7df224621c2d0b0c5ef819a4fb016e0742
+    md5: 2daba153b913b1b901cf61440ad5e019
+    sha256: 2b4344d18328b3e8fd9b5356f4ee15556779766db8cb21ecf2ff818809773df6
   category: dev
   optional: true
 - name: black
-  version: 24.4.2
+  version: 24.10.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -1593,14 +1604,14 @@ package:
     platformdirs: '>=2'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/black-24.4.2-py312hb401068_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/black-24.10.0-py312hb401068_0.conda
   hash:
-    md5: 22de584e109e98d9ee0ca3820fcff185
-    sha256: ed5cd347f987e1f581e5ccee4cba0a03451bbe6e72d800c636c617a427c48e7a
+    md5: e832f4c2afb84e85718008b600944bc0
+    sha256: a1397d32f6d40ff19107bab8c1570f3934ad91a601d1d973b129eabe08b943e6
   category: dev
   optional: true
 - name: black
-  version: 24.4.2
+  version: 24.10.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1611,46 +1622,46 @@ package:
     platformdirs: '>=2'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-24.4.2-py312h81bd7bf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-24.10.0-py312h81bd7bf_0.conda
   hash:
-    md5: 696163f7d375e2bef948694129470337
-    sha256: c78b125ad8e3492836524add8dd757489bf109363bb89ad9b6f86b64e5f6513b
+    md5: 702d7bf6d22135d3e30811ed9c62bb07
+    sha256: 7e0cd77935e68717506469463546365637abf3f73aa597a890cb5f5ef3c75caf
   category: dev
   optional: true
 - name: blinker
-  version: 1.8.2
+  version: 1.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.8.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
   hash:
-    md5: cf85c002319c15e9721934104aaa1137
-    sha256: 8ca3cd8f78d0607df28c9f76adb9800348f8f2dc8aa49d188a995a0acdc4477d
+    md5: 42834439227a4551b939beeeb8a4b085
+    sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
   category: dev
   optional: true
 - name: blinker
-  version: 1.8.2
+  version: 1.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.8.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
   hash:
-    md5: cf85c002319c15e9721934104aaa1137
-    sha256: 8ca3cd8f78d0607df28c9f76adb9800348f8f2dc8aa49d188a995a0acdc4477d
+    md5: 42834439227a4551b939beeeb8a4b085
+    sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
   category: dev
   optional: true
 - name: blinker
-  version: 1.8.2
+  version: 1.9.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.8.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
   hash:
-    md5: cf85c002319c15e9721934104aaa1137
-    sha256: 8ca3cd8f78d0607df28c9f76adb9800348f8f2dc8aa49d188a995a0acdc4477d
+    md5: 42834439227a4551b939beeeb8a4b085
+    sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
   category: dev
   optional: true
 - name: blosc
@@ -1709,11 +1720,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: 2.7.*|>=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 61de176bd62041f9cd5bd4fcd09eb0ff
-    sha256: e44d07932306392372411ab1261670a552f96077f925af00c1559a18a73a1bdc
+    md5: d88c38e66d85ecc9c7e2c4110676bbf4
+    sha256: 4d6101f6a900c22495fbaa3c0ca713f1876d11f14aba3f7832bf6e6986ee5e64
   category: main
   optional: false
 - name: boltons
@@ -1721,11 +1732,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: 2.7.*|>=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 61de176bd62041f9cd5bd4fcd09eb0ff
-    sha256: e44d07932306392372411ab1261670a552f96077f925af00c1559a18a73a1bdc
+    md5: d88c38e66d85ecc9c7e2c4110676bbf4
+    sha256: 4d6101f6a900c22495fbaa3c0ca713f1876d11f14aba3f7832bf6e6986ee5e64
   category: main
   optional: false
 - name: boltons
@@ -1733,106 +1744,109 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: 2.7.*|>=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 61de176bd62041f9cd5bd4fcd09eb0ff
-    sha256: e44d07932306392372411ab1261670a552f96077f925af00c1559a18a73a1bdc
+    md5: d88c38e66d85ecc9c7e2c4110676bbf4
+    sha256: 4d6101f6a900c22495fbaa3c0ca713f1876d11f14aba3f7832bf6e6986ee5e64
   category: main
   optional: false
 - name: boto3
-  version: 1.34.131
+  version: 1.36.3
   manager: conda
   platform: linux-64
   dependencies:
-    botocore: '>=1.34.131,<1.35.0'
+    botocore: '>=1.36.3,<1.37.0'
     jmespath: '>=0.7.1,<2.0.0'
-    python: '>=3.8'
-    s3transfer: '>=0.10.0,<0.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    s3transfer: '>=0.11.0,<0.12.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 16cbd51eb7f0fc40a88c636006437c85
-    sha256: cf90e13146b5d143a749c68a0550b6ddd0e1e0d5f87976cf41b1708f88b84589
+    md5: 2ce714023bbdc1a381ec55505da2e113
+    sha256: 7d649962da531389e078b93459b668fc132238ac977e84c6bfa399a224edc3bf
   category: main
   optional: false
 - name: boto3
-  version: 1.34.131
+  version: 1.36.3
   manager: conda
   platform: osx-64
   dependencies:
-    botocore: '>=1.34.131,<1.35.0'
+    python: '>=3.9'
     jmespath: '>=0.7.1,<2.0.0'
-    python: '>=3.8'
-    s3transfer: '>=0.10.0,<0.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
+    s3transfer: '>=0.11.0,<0.12.0'
+    botocore: '>=1.36.3,<1.37.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 16cbd51eb7f0fc40a88c636006437c85
-    sha256: cf90e13146b5d143a749c68a0550b6ddd0e1e0d5f87976cf41b1708f88b84589
+    md5: 2ce714023bbdc1a381ec55505da2e113
+    sha256: 7d649962da531389e078b93459b668fc132238ac977e84c6bfa399a224edc3bf
   category: main
   optional: false
 - name: boto3
-  version: 1.34.131
+  version: 1.36.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    botocore: '>=1.34.131,<1.35.0'
+    python: '>=3.9'
     jmespath: '>=0.7.1,<2.0.0'
-    python: '>=3.8'
-    s3transfer: '>=0.10.0,<0.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
+    s3transfer: '>=0.11.0,<0.12.0'
+    botocore: '>=1.36.3,<1.37.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 16cbd51eb7f0fc40a88c636006437c85
-    sha256: cf90e13146b5d143a749c68a0550b6ddd0e1e0d5f87976cf41b1708f88b84589
+    md5: 2ce714023bbdc1a381ec55505da2e113
+    sha256: 7d649962da531389e078b93459b668fc132238ac977e84c6bfa399a224edc3bf
   category: main
   optional: false
 - name: boto3-stubs
-  version: 1.34.142
+  version: 1.36.13
   manager: conda
   platform: linux-64
   dependencies:
-    boto3: ''
+    botocore-stubs: ''
     python: ''
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.142-pyhd8ed1ab_0.conda
+    types-s3transfer: ''
+    typing-extensions: '>=4.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.36.13-pyhd8ed1ab_0.conda
   hash:
-    md5: 04dd6e7ea44388d943788374320180ee
-    sha256: 6283039d5821be546d01d1d7b2778f87564cbf4430e5aefb0cb022084539aa58
+    md5: 78361c879809a699abfe318de2df610e
+    sha256: 850727752368a6c3d598b4df1dd8e551ccc7b2b40b1045c1cf95f997e4f3a34a
   category: dev
   optional: true
 - name: boto3-stubs
-  version: 1.34.142
+  version: 1.36.13
   manager: conda
   platform: osx-64
   dependencies:
-    boto3: ''
     python: ''
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.142-pyhd8ed1ab_0.conda
+    botocore-stubs: ''
+    types-s3transfer: ''
+    typing-extensions: '>=4.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.36.13-pyhd8ed1ab_0.conda
   hash:
-    md5: 04dd6e7ea44388d943788374320180ee
-    sha256: 6283039d5821be546d01d1d7b2778f87564cbf4430e5aefb0cb022084539aa58
+    md5: 78361c879809a699abfe318de2df610e
+    sha256: 850727752368a6c3d598b4df1dd8e551ccc7b2b40b1045c1cf95f997e4f3a34a
   category: dev
   optional: true
 - name: boto3-stubs
-  version: 1.34.142
+  version: 1.36.13
   manager: conda
   platform: osx-arm64
   dependencies:
-    boto3: ''
     python: ''
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.34.142-pyhd8ed1ab_0.conda
+    botocore-stubs: ''
+    types-s3transfer: ''
+    typing-extensions: '>=4.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.36.13-pyhd8ed1ab_0.conda
   hash:
-    md5: 04dd6e7ea44388d943788374320180ee
-    sha256: 6283039d5821be546d01d1d7b2778f87564cbf4430e5aefb0cb022084539aa58
+    md5: 78361c879809a699abfe318de2df610e
+    sha256: 850727752368a6c3d598b4df1dd8e551ccc7b2b40b1045c1cf95f997e4f3a34a
   category: dev
   optional: true
 - name: boto3-stubs-essential
-  version: 1.34.142
+  version: 1.36.13
   manager: conda
   platform: linux-64
   dependencies:
-    boto3-stubs: 1.34.142
+    boto3-stubs: 1.36.13
     mypy-boto3-s3: ''
     mypy_boto3_cloudformation: ''
     mypy_boto3_dynamodb: ''
@@ -1840,52 +1854,52 @@ package:
     mypy_boto3_lambda: ''
     mypy_boto3_rds: ''
     mypy_boto3_sqs: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-essential-1.34.142-hd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-essential-1.36.13-hd8ed1ab_0.conda
   hash:
-    md5: 2418891b9cb05791d646ff2fecbb1704
-    sha256: 3d75ca0c51b715cf4598a206988d7eb712e95a1973dec57e943c5413ea869853
+    md5: 37e2a960e55c344a79df520122d06017
+    sha256: cfd10a7e2d3cd3d3d43aadede190c6c0479d8fca6f070b17408f6704682e0862
   category: dev
   optional: true
 - name: boto3-stubs-essential
-  version: 1.34.142
+  version: 1.36.13
   manager: conda
   platform: osx-64
   dependencies:
-    boto3-stubs: 1.34.142
-    mypy-boto3-s3: ''
-    mypy_boto3_cloudformation: ''
-    mypy_boto3_dynamodb: ''
     mypy_boto3_ec2: ''
-    mypy_boto3_lambda: ''
     mypy_boto3_rds: ''
+    mypy-boto3-s3: ''
+    mypy_boto3_dynamodb: ''
+    mypy_boto3_lambda: ''
+    mypy_boto3_cloudformation: ''
     mypy_boto3_sqs: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-essential-1.34.142-hd8ed1ab_0.conda
+    boto3-stubs: 1.36.13
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-essential-1.36.13-hd8ed1ab_0.conda
   hash:
-    md5: 2418891b9cb05791d646ff2fecbb1704
-    sha256: 3d75ca0c51b715cf4598a206988d7eb712e95a1973dec57e943c5413ea869853
+    md5: 37e2a960e55c344a79df520122d06017
+    sha256: cfd10a7e2d3cd3d3d43aadede190c6c0479d8fca6f070b17408f6704682e0862
   category: dev
   optional: true
 - name: boto3-stubs-essential
-  version: 1.34.142
+  version: 1.36.13
   manager: conda
   platform: osx-arm64
   dependencies:
-    boto3-stubs: 1.34.142
-    mypy-boto3-s3: ''
-    mypy_boto3_cloudformation: ''
-    mypy_boto3_dynamodb: ''
     mypy_boto3_ec2: ''
-    mypy_boto3_lambda: ''
     mypy_boto3_rds: ''
+    mypy-boto3-s3: ''
+    mypy_boto3_dynamodb: ''
+    mypy_boto3_lambda: ''
+    mypy_boto3_cloudformation: ''
     mypy_boto3_sqs: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-essential-1.34.142-hd8ed1ab_0.conda
+    boto3-stubs: 1.36.13
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-essential-1.36.13-hd8ed1ab_0.conda
   hash:
-    md5: 2418891b9cb05791d646ff2fecbb1704
-    sha256: 3d75ca0c51b715cf4598a206988d7eb712e95a1973dec57e943c5413ea869853
+    md5: 37e2a960e55c344a79df520122d06017
+    sha256: cfd10a7e2d3cd3d3d43aadede190c6c0479d8fca6f070b17408f6704682e0862
   category: dev
   optional: true
 - name: botocore
-  version: 1.34.131
+  version: 1.36.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -1893,166 +1907,167 @@ package:
     python: '>=3.10'
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.3-pyge310_1234567_0.conda
   hash:
-    md5: 955a32ec433efee3e3ab19658ce1996d
-    sha256: 35e3141a25580397dc7977c88409b3d19871fb7e5be4951b7f9879abb307a04d
+    md5: d21b74ea6fe0795af13a62f00f5258f3
+    sha256: 3d41462f9f40d0e15b665ad0123693877b9445eca3ed1f16fa698fc5c2e66948
   category: main
   optional: false
 - name: botocore
-  version: 1.34.131
+  version: 1.36.3
   manager: conda
   platform: osx-64
   dependencies:
-    jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.10'
     python-dateutil: '>=2.1,<3.0.0'
+    jmespath: '>=0.7.1,<2.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.3-pyge310_1234567_0.conda
   hash:
-    md5: 955a32ec433efee3e3ab19658ce1996d
-    sha256: 35e3141a25580397dc7977c88409b3d19871fb7e5be4951b7f9879abb307a04d
+    md5: d21b74ea6fe0795af13a62f00f5258f3
+    sha256: 3d41462f9f40d0e15b665ad0123693877b9445eca3ed1f16fa698fc5c2e66948
   category: main
   optional: false
 - name: botocore
-  version: 1.34.131
+  version: 1.36.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.10'
     python-dateutil: '>=2.1,<3.0.0'
+    jmespath: '>=0.7.1,<2.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.3-pyge310_1234567_0.conda
   hash:
-    md5: 955a32ec433efee3e3ab19658ce1996d
-    sha256: 35e3141a25580397dc7977c88409b3d19871fb7e5be4951b7f9879abb307a04d
+    md5: d21b74ea6fe0795af13a62f00f5258f3
+    sha256: 3d41462f9f40d0e15b665ad0123693877b9445eca3ed1f16fa698fc5c2e66948
   category: main
   optional: false
 - name: botocore-stubs
-  version: 1.34.142
+  version: 1.36.14
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8,<4.0'
+    python: '>=3.9'
     types-awscrt: ''
     typing_extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.34.142-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.36.14-pyhd8ed1ab_0.conda
   hash:
-    md5: f209cbbb58e4ccd8171a96302dcc432c
-    sha256: 3d2e81d06c4b026423bf8315413695b0434f9e2222ab29e8e264af1a911d51d9
+    md5: 5e2037ef4067bd2c4d1dde73977badc7
+    sha256: 7cc2524d20fcef033d1ccb5a8ace97ed92b684372a97c13d605704f3f6f888c8
   category: dev
   optional: true
 - name: botocore-stubs
-  version: 1.34.142
+  version: 1.36.14
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8,<4.0'
     types-awscrt: ''
+    python: '>=3.9'
     typing_extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.34.142-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.36.14-pyhd8ed1ab_0.conda
   hash:
-    md5: f209cbbb58e4ccd8171a96302dcc432c
-    sha256: 3d2e81d06c4b026423bf8315413695b0434f9e2222ab29e8e264af1a911d51d9
+    md5: 5e2037ef4067bd2c4d1dde73977badc7
+    sha256: 7cc2524d20fcef033d1ccb5a8ace97ed92b684372a97c13d605704f3f6f888c8
   category: dev
   optional: true
 - name: botocore-stubs
-  version: 1.34.142
+  version: 1.36.14
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8,<4.0'
     types-awscrt: ''
+    python: '>=3.9'
     typing_extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.34.142-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.36.14-pyhd8ed1ab_0.conda
   hash:
-    md5: f209cbbb58e4ccd8171a96302dcc432c
-    sha256: 3d2e81d06c4b026423bf8315413695b0434f9e2222ab29e8e264af1a911d51d9
+    md5: 5e2037ef4067bd2c4d1dde73977badc7
+    sha256: 7cc2524d20fcef033d1ccb5a8ace97ed92b684372a97c13d605704f3f6f888c8
   category: dev
   optional: true
 - name: bottleneck
-  version: 1.4.0
+  version: 1.4.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    numpy: '>=1.19,<3'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    numpy: '>=1.21,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/bottleneck-1.4.0-py312h085067d_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/bottleneck-1.4.2-py312hc0a28a1_0.conda
   hash:
-    md5: 465afba0490075f44a3f6ae1bb087352
-    sha256: 47da3473b782494c254d4a7cd761bea4ce464b47435c170036f99ab8c389d8a3
+    md5: 762b7307cf27e4926f48889788c12d2d
+    sha256: b3c2ccc7241cc6993856499a6c0a855f798a4db1fd4cefc695dfed53005a31e7
   category: main
   optional: false
 - name: bottleneck
-  version: 1.4.0
+  version: 1.4.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    numpy: '>=1.19,<3'
+    numpy: '>=1.21,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/bottleneck-1.4.0-py312h5dc8b90_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/bottleneck-1.4.2-py312h59f7578_0.conda
   hash:
-    md5: 655cb3c4949594bc758a261ff9b5e922
-    sha256: e14a615c550be4dc94200ca2e34721e8769f72744842b85cab5cf6a4be7c424b
+    md5: 17873f659e104fec31f3874ff52da640
+    sha256: dd4dc95190da595c4e2f7e0e5e7147d2cc3197ba42d582ec81f884a16486e015
   category: main
   optional: false
 - name: bottleneck
-  version: 1.4.0
+  version: 1.4.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    numpy: '>=1.19,<3'
+    numpy: '>=1.21,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bottleneck-1.4.0-py312hbebd99a_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bottleneck-1.4.2-py312h147345f_0.conda
   hash:
-    md5: 1182ad97d64513e333df2ac4242fc23b
-    sha256: be0e74afdc086af5868611691964cccd9fce5f8bd5adb7f0b582df03c4f8ea55
+    md5: 205625f6954f79522a5e23e0e4b420a4
+    sha256: b93db481a5368ba8876235a126ddb60f0c0ac939a13bf950d947d0da79dfacf6
   category: main
   optional: false
 - name: branca
-  version: 0.7.2
+  version: 0.8.1
   manager: conda
   platform: linux-64
   dependencies:
     jinja2: '>=3'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 5f1c719f1cac0aee5e6bd6ca7d54a7fa
-    sha256: 9f7df349cb5a8852804d5bb1f5f49e3076a55ac7229b9c114bb5f7461f497ba7
+    md5: 9f3937b768675ab4346f07e9ef723e4b
+    sha256: 38de10b8608ed962ad3e01d6ddc5cfa373221cfdc0faa96a46765d6defffc75f
   category: main
   optional: false
 - name: branca
-  version: 0.7.2
+  version: 0.8.1
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.9'
     jinja2: '>=3'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 5f1c719f1cac0aee5e6bd6ca7d54a7fa
-    sha256: 9f7df349cb5a8852804d5bb1f5f49e3076a55ac7229b9c114bb5f7461f497ba7
+    md5: 9f3937b768675ab4346f07e9ef723e4b
+    sha256: 38de10b8608ed962ad3e01d6ddc5cfa373221cfdc0faa96a46765d6defffc75f
   category: main
   optional: false
 - name: branca
-  version: 0.7.2
+  version: 0.8.1
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.9'
     jinja2: '>=3'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 5f1c719f1cac0aee5e6bd6ca7d54a7fa
-    sha256: 9f7df349cb5a8852804d5bb1f5f49e3076a55ac7229b9c114bb5f7461f497ba7
+    md5: 9f3937b768675ab4346f07e9ef723e4b
+    sha256: 38de10b8608ed962ad3e01d6ddc5cfa373221cfdc0faa96a46765d6defffc75f
   category: main
   optional: false
 - name: brotli
@@ -2060,14 +2075,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     brotli-bin: 1.1.0
     libbrotlidec: 1.1.0
     libbrotlienc: 1.1.0
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
   hash:
-    md5: f27a24d46e3ea7b70a1f98e50c62508f
-    sha256: f2d918d351edd06c55a6c2d84b488fe392f85ea018ff227daac07db22b408f6b
+    md5: 98514fe74548d768907ce7a13f680e8f
+    sha256: fcb0b5b28ba7492093e54f3184435144e074dfceab27ac8e6a9457e736565b0b
   category: main
   optional: false
 - name: brotli
@@ -2075,13 +2091,14 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     brotli-bin: 1.1.0
     libbrotlidec: 1.1.0
     libbrotlienc: 1.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h0dc2134_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h00291cd_2.conda
   hash:
-    md5: 9272dd3b19c4e8212f8542cefd5c3d67
-    sha256: 4bf66d450be5d3f9ebe029b50f818d088b1ef9666b1f19e90c85479c77bbdcde
+    md5: 2db0c38a7f2321c5bdaf32b181e832c7
+    sha256: 624954bc08b3d7885a58c7d547282cfb9a201ce79b748b358f801de53e20f523
   category: main
   optional: false
 - name: brotli
@@ -2089,13 +2106,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     brotli-bin: 1.1.0
     libbrotlidec: 1.1.0
     libbrotlienc: 1.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hb547adb_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
   hash:
-    md5: a33aa58d448cbc054f887e39dd1dfaea
-    sha256: 62d1587deab752fcee07adc371eb20fcadc09f72c0c85399c22b637ca858020f
+    md5: 215e3dc8f2f837906d066e7f01aa77c0
+    sha256: a086f36ff68d6e30da625e910547f6211385246fb2474b144ac8c47c32254576
   category: main
   optional: false
 - name: brotli-bin
@@ -2103,13 +2121,14 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libbrotlidec: 1.1.0
     libbrotlienc: 1.1.0
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
   hash:
-    md5: 39f910d205726805a958da408ca194ba
-    sha256: a641abfbaec54f454c8434061fffa7fdaa9c695e8a5a400ed96b4f07c0c00677
+    md5: c63b5e52939e795ba8d26e35d767a843
+    sha256: 261364d7445513b9a4debc345650fad13c627029bfc800655a266bf1e375bc65
   category: main
   optional: false
 - name: brotli-bin
@@ -2117,12 +2136,13 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     libbrotlidec: 1.1.0
     libbrotlienc: 1.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h0dc2134_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h00291cd_2.conda
   hash:
-    md5: ece565c215adcc47fc1db4e651ee094b
-    sha256: 7ca3cfb4c5df314ed481301335387ab2b2ee651e2c74fbb15bacc795c664a5f1
+    md5: 049933ecbf552479a12c7917f0a4ce59
+    sha256: 642a8492491109fd8270c1e2c33b18126712df0cedb94aaa2b1c6b02505a4bfa
   category: main
   optional: false
 - name: brotli-bin
@@ -2130,12 +2150,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     libbrotlidec: 1.1.0
     libbrotlienc: 1.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hb547adb_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
   hash:
-    md5: 990d04f8c017b1b77103f9a7730a5f12
-    sha256: 8fbfc2834606292016f2faffac67deea4c5cdbc21a61169f0b355e1600105a24
+    md5: b8512db2145dc3ae8d86cdc21a8d421e
+    sha256: 28f1af63b49fddf58084fb94e5512ad46e9c453eb4be1d97449c67059e5b0680
   category: main
   optional: false
 - name: brotli-python
@@ -2143,14 +2164,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.12.0rc3,<3.13.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h30efb56_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_2.conda
   hash:
-    md5: 45801a89533d3336a365284d93298e36
-    sha256: b68706698b6ac0d31196a8bcb061f0d1f35264bcd967ea45e03e108149a74c6f
+    md5: b0b867af6fc74b2a0aa206da29c0f3cf
+    sha256: f2a59ccd20b4816dea9a2a5cb917eb69728271dbf1aeab4e1b7e609330a50b6f
   category: main
   optional: false
 - name: brotli-python
@@ -2158,13 +2180,14 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
-    python: '>=3.12.0rc3,<3.13.0a0'
+    __osx: '>=10.13'
+    libcxx: '>=17'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py312heafc425_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py312h5861a67_2.conda
   hash:
-    md5: a288b88f06b8bfe0dedaf5c4b6ac6b7a
-    sha256: fc55988f9bc05a938ea4b8c20d6545bed6e9c6c10aa5147695f981136ca894c1
+    md5: b95025822e43128835826ec0cc45a551
+    sha256: 265764ff4ad9e5cfefe7ea85c53d95157bf16ac2c0e5f190c528e4c9c0c1e2d0
   category: main
   optional: false
 - name: brotli-python
@@ -2172,13 +2195,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-    python: '>=3.12.0rc3,<3.13.0a0'
+    __osx: '>=11.0'
+    libcxx: '>=17'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312h9f69965_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312hde4cb15_2.conda
   hash:
-    md5: 1bc01b9ffdf42beb1a9fe4e9222e0567
-    sha256: 3418b1738243abba99e931c017b952771eeaa1f353c07f7d45b55e83bb74fcb3
+    md5: a83c2ef76ccb11bc2349f4f17696b15d
+    sha256: 254b411fa78ccc226f42daf606772972466f93e9bc6895eabb4cfda22f5178af
   category: main
   optional: false
 - name: bzip2
@@ -2186,184 +2210,190 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
   hash:
-    md5: 69b8b6202a07720f448be700e300ccf4
-    sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
+    md5: 62ee74e96c5ebb0af99386de58cf9553
+    sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
   category: main
   optional: false
 - name: bzip2
   version: 1.0.8
   manager: conda
   platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
   hash:
-    md5: 6097a6ca9ada32699b5fc4312dd6ef18
-    sha256: 61fb2b488928a54d9472113e1280b468a309561caa54f33825a3593da390b242
+    md5: 7ed4301d437b59045be7e051a0308211
+    sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
   category: main
   optional: false
 - name: bzip2
   version: 1.0.8
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
   hash:
-    md5: 1bbc659ca658bfd49a481b5ef7a0f40f
-    sha256: bfa84296a638bea78a8bb29abc493ee95f2a0218775642474a840411b950fe5f
+    md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+    sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
   category: main
   optional: false
 - name: c-ares
-  version: 1.28.1
+  version: 1.34.4
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.28.1-hd590300_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.4-hb9d3cd8_0.conda
   hash:
-    md5: dcde58ff9a1f30b0037a2315d1846d1f
-    sha256: cb25063f3342149c7924b21544109696197a9d774f1407567477d4f3026bf38a
+    md5: e2775acf57efd5af15b8e3d1d74d72d3
+    sha256: d4f28d87b6339b94f74762c0076e29c8ef8ddfff51a564a92da2843573c18320
   category: main
   optional: false
 - name: c-ares
-  version: 1.28.1
+  version: 1.34.4
   manager: conda
   platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.28.1-h10d778d_0.conda
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.4-hf13058a_0.conda
   hash:
-    md5: d5eb7992227254c0e9a0ce71151f0079
-    sha256: fccd7ad7e3dfa6b19352705b33eb738c4c55f79f398e106e6cf03bab9415595a
+    md5: 133255af67aaf1e0c0468cc753fd800b
+    sha256: 8dcc1628d34fe7d759f3a7dee52e09c5162a3f9669dddd6100bff965450f4a0a
   category: main
   optional: false
 - name: c-ares
-  version: 1.28.1
+  version: 1.34.4
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.28.1-h93a5062_0.conda
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.4-h5505292_0.conda
   hash:
-    md5: 04f776a6139f7eafc2f38668570eb7db
-    sha256: 2fc553d7a75e912efbdd6b82cd7916cc9cb2773e6cd873b77e02d631dd7be698
+    md5: c1c999a38a4303b29d75c636eaa13cf9
+    sha256: 09c0c8476e50b2955f474a4a1c17c4c047dd52993b5366b6ea8e968e583b921f
   category: main
   optional: false
 - name: ca-certificates
-  version: 2024.7.4
+  version: 2025.1.31
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.7.4-hbcca054_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2025.1.31-hbcca054_0.conda
   hash:
-    md5: 23ab7665c5f63cfb9f1f6195256daac6
-    sha256: c1548a3235376f464f9931850b64b02492f379b2f2bb98bc786055329b080446
+    md5: 19f3a56f68d2fd06c516076bff482c52
+    sha256: bf832198976d559ab44d6cdb315642655547e26d826e34da67cbee6624cda189
   category: main
   optional: false
 - name: ca-certificates
-  version: 2024.7.4
+  version: 2025.1.31
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.7.4-h8857fd0_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2025.1.31-h8857fd0_0.conda
   hash:
-    md5: 7df874a4b05b2d2b82826190170eaa0f
-    sha256: d16f46c489cb3192305c7d25b795333c5fc17bb0986de20598ed519f8c9cc9e4
+    md5: 3418b6c8cac3e71c0bc089fc5ea53042
+    sha256: 42e911ee2d8808eacedbec46d99b03200a6138b8e8a120bd8acabe1cac41c63b
   category: main
   optional: false
 - name: ca-certificates
-  version: 2024.7.4
+  version: 2025.1.31
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.7.4-hf0a4a13_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2025.1.31-hf0a4a13_0.conda
   hash:
-    md5: 21f9a33e5fe996189e470c19c5354dbe
-    sha256: 33a61116dae7f369b6ce92a7f2a1ff361ae737c675a493b11feb5570b89e0e3b
+    md5: 3569d6a9141adc64d2fe4797f3289e06
+    sha256: 7e12816618173fe70f5c638b72adf4bfd4ddabf27794369bb17871c5bb75b9f9
   category: main
   optional: false
 - name: cachecontrol
-  version: 0.14.0
+  version: 0.14.2
   manager: conda
   platform: linux-64
   dependencies:
     msgpack-python: '>=0.5.2,<2.0.0'
-    python: '>=3.7'
+    python: '>=3.9'
     requests: '>=2.16.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.2-pyha770c72_0.conda
   hash:
-    md5: a54e449940b3e4bb2129b8daae0c1f65
-    sha256: 8d8dadbea881c690037e432075357ad6629f7b050e129a5944a0402d674fd754
+    md5: df6a1180171318e6a58c206c38ff66fd
+    sha256: 5684d23509525b65dd019a70bbb73c987a5d64177c0ce3def3dfdb175687ea27
   category: main
   optional: false
 - name: cachecontrol
-  version: 0.14.0
+  version: 0.14.2
   manager: conda
   platform: osx-64
   dependencies:
-    msgpack-python: '>=0.5.2,<2.0.0'
-    python: '>=3.7'
+    python: '>=3.9'
     requests: '>=2.16.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_1.conda
+    msgpack-python: '>=0.5.2,<2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.2-pyha770c72_0.conda
   hash:
-    md5: a54e449940b3e4bb2129b8daae0c1f65
-    sha256: 8d8dadbea881c690037e432075357ad6629f7b050e129a5944a0402d674fd754
+    md5: df6a1180171318e6a58c206c38ff66fd
+    sha256: 5684d23509525b65dd019a70bbb73c987a5d64177c0ce3def3dfdb175687ea27
   category: main
   optional: false
 - name: cachecontrol
-  version: 0.14.0
+  version: 0.14.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    msgpack-python: '>=0.5.2,<2.0.0'
-    python: '>=3.7'
+    python: '>=3.9'
     requests: '>=2.16.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_1.conda
+    msgpack-python: '>=0.5.2,<2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.2-pyha770c72_0.conda
   hash:
-    md5: a54e449940b3e4bb2129b8daae0c1f65
-    sha256: 8d8dadbea881c690037e432075357ad6629f7b050e129a5944a0402d674fd754
+    md5: df6a1180171318e6a58c206c38ff66fd
+    sha256: 5684d23509525b65dd019a70bbb73c987a5d64177c0ce3def3dfdb175687ea27
   category: main
   optional: false
 - name: cachecontrol-with-filecache
-  version: 0.14.0
+  version: 0.14.2
   manager: conda
   platform: linux-64
   dependencies:
-    cachecontrol: 0.14.0
+    cachecontrol: 0.14.2
     filelock: '>=3.8.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 42a12b0b21d64b36a9ab9a24a04eb910
-    sha256: 482d0f3ce8dad6b881f76620ee18152755c61bb968039dcbc0ad45689c70b0d5
+    md5: 193d7362ba6d1b551ffe7b1da103f47f
+    sha256: cee46674041043c046232c6334b25487caa5c3d57c8b78adec0265afade4bda3
   category: main
   optional: false
 - name: cachecontrol-with-filecache
-  version: 0.14.0
+  version: 0.14.2
   manager: conda
   platform: osx-64
   dependencies:
-    cachecontrol: 0.14.0
+    python: '>=3.9'
     filelock: '>=3.8.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_1.conda
+    cachecontrol: 0.14.2
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 42a12b0b21d64b36a9ab9a24a04eb910
-    sha256: 482d0f3ce8dad6b881f76620ee18152755c61bb968039dcbc0ad45689c70b0d5
+    md5: 193d7362ba6d1b551ffe7b1da103f47f
+    sha256: cee46674041043c046232c6334b25487caa5c3d57c8b78adec0265afade4bda3
   category: main
   optional: false
 - name: cachecontrol-with-filecache
-  version: 0.14.0
+  version: 0.14.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    cachecontrol: 0.14.0
+    python: '>=3.9'
     filelock: '>=3.8.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_1.conda
+    cachecontrol: 0.14.2
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 42a12b0b21d64b36a9ab9a24a04eb910
-    sha256: 482d0f3ce8dad6b881f76620ee18152755c61bb968039dcbc0ad45689c70b0d5
+    md5: 193d7362ba6d1b551ffe7b1da103f47f
+    sha256: cee46674041043c046232c6334b25487caa5c3d57c8b78adec0265afade4bda3
   category: main
   optional: false
 - name: cached-property
@@ -2443,11 +2473,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachy-0.3.0-pyhd8ed1ab_1.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachy-0.3.0-pyhd8ed1ab_2.conda
   hash:
-    md5: 5dfee17f24e2dfd18d7392b48c9351e2
-    sha256: 9b193a4e483c4d0004bc5b88fac7a02516b6311137ab61b8db85aa9741422e35
+    md5: 1efe226b868cf59b8330356c37c8186e
+    sha256: 2560a98e3dc0ff4ff408a199d05922ae10fab2629417c4c4309e4226267cef8c
   category: main
   optional: false
 - name: cachy
@@ -2455,11 +2485,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachy-0.3.0-pyhd8ed1ab_1.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachy-0.3.0-pyhd8ed1ab_2.conda
   hash:
-    md5: 5dfee17f24e2dfd18d7392b48c9351e2
-    sha256: 9b193a4e483c4d0004bc5b88fac7a02516b6311137ab61b8db85aa9741422e35
+    md5: 1efe226b868cf59b8330356c37c8186e
+    sha256: 2560a98e3dc0ff4ff408a199d05922ae10fab2629417c4c4309e4226267cef8c
   category: main
   optional: false
 - name: cachy
@@ -2467,396 +2497,352 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachy-0.3.0-pyhd8ed1ab_1.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachy-0.3.0-pyhd8ed1ab_2.conda
   hash:
-    md5: 5dfee17f24e2dfd18d7392b48c9351e2
-    sha256: 9b193a4e483c4d0004bc5b88fac7a02516b6311137ab61b8db85aa9741422e35
+    md5: 1efe226b868cf59b8330356c37c8186e
+    sha256: 2560a98e3dc0ff4ff408a199d05922ae10fab2629417c4c4309e4226267cef8c
   category: main
   optional: false
 - name: cairo
-  version: 1.18.0
+  version: 1.18.2
   manager: conda
   platform: linux-64
   dependencies:
-    fontconfig: '>=2.14.2,<3.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.2,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libstdcxx-ng: '>=12'
-    libxcb: '>=1.16,<1.17.0a0'
+    icu: '>=75.1,<76.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
+    libglib: '>=2.82.2,<3.0a0'
+    libpng: '>=1.6.44,<1.7.0a0'
+    libstdcxx: '>=13'
+    libxcb: '>=1.17.0,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    pixman: '>=0.43.2,<1.0a0'
+    pixman: '>=0.44.2,<1.0a0'
     xorg-libice: '>=1.1.1,<2.0a0'
     xorg-libsm: '>=1.2.4,<2.0a0'
-    xorg-libx11: '>=1.8.9,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
     xorg-libxrender: '>=0.9.11,<0.10.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hbb29018_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.2-h3394656_1.conda
   hash:
-    md5: b6d90276c5aee9b4407dd94eb0cd40a8
-    sha256: 51cfaf4669ad83499b3da215b915c503d36faf6edf6db4681a70b5710842a86c
-  category: main
-  optional: false
+    md5: b34c2833a1f56db610aeb27f206d800d
+    sha256: de7d0d094e53decc005cb13e527be2635b8f604978da497d4c0d282c7dc08385
+  category: dev
+  optional: true
 - name: cairo
-  version: 1.18.0
+  version: 1.18.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    fontconfig: '>=2.14.2,<3.0a0'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libcxx: '>=16'
-    libglib: '>=2.80.2,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
+    icu: '>=75.1,<76.0a0'
+    libcxx: '>=18'
+    libexpat: '>=2.6.4,<3.0a0'
+    libglib: '>=2.82.2,<3.0a0'
+    libpng: '>=1.6.44,<1.7.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    pixman: '>=0.43.4,<1.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h9f650ed_2.conda
+    pixman: '>=0.44.2,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.2-h950ec3b_1.conda
   hash:
-    md5: d264e5b9759cab8d203cdfe43eabd8b5
-    sha256: 1d2480538838cf5009df0285a73aa405798bc49de0c689ab270f543f5ae961aa
-  category: main
-  optional: false
+    md5: ae293443dff77ba14eab9e9ee68ec833
+    sha256: ad8c41650e5a10d9177e9d92652d2bd5fe9eefa095ebd4805835c3f067c0202b
+  category: dev
+  optional: true
 - name: cairo
-  version: 1.18.0
+  version: 1.18.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    fontconfig: '>=2.14.2,<3.0a0'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libcxx: '>=16'
-    libglib: '>=2.80.2,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
+    icu: '>=75.1,<76.0a0'
+    libcxx: '>=18'
+    libexpat: '>=2.6.4,<3.0a0'
+    libglib: '>=2.82.2,<3.0a0'
+    libpng: '>=1.6.44,<1.7.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    pixman: '>=0.43.4,<1.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hc6c324b_2.conda
+    pixman: '>=0.44.2,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.2-h6a3b0d2_1.conda
   hash:
-    md5: 6efeefcad878c15377f49f64e2cbf232
-    sha256: 7cb330f41fd5abd3d2444a62c0439af8b11c96497aa2f87d76a5b580edf6d35c
+    md5: 8e3666c3f6e2c3e57aa261ab103a3600
+    sha256: 9a28344e806b89c87fda0cdabd2fb961e5d2ff97107dba25bac9f5dc57220cc3
+  category: dev
+  optional: true
+- name: certifi
+  version: 2024.12.14
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6feb87357ecd66733be3279f16a8c400
+    sha256: 048c16a9cbcb1fbad02083414d3bc7c1d0eea4b39aee6aa6bf8d1d5089ca8bad
   category: main
   optional: false
 - name: certifi
-  version: 2024.7.4
+  version: 2024.12.14
   manager: conda
-  platform: linux-64
+  platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 24e7fd6ca65997938fff9e5ab6f653e4
-    sha256: dd3577bb5275062c388c46b075dcb795f47f8dac561da7dd35fe504b936934e5
+    md5: 6feb87357ecd66733be3279f16a8c400
+    sha256: 048c16a9cbcb1fbad02083414d3bc7c1d0eea4b39aee6aa6bf8d1d5089ca8bad
   category: main
   optional: false
 - name: certifi
-  version: 2024.7.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 24e7fd6ca65997938fff9e5ab6f653e4
-    sha256: dd3577bb5275062c388c46b075dcb795f47f8dac561da7dd35fe504b936934e5
-  category: main
-  optional: false
-- name: certifi
-  version: 2024.7.4
+  version: 2024.12.14
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 24e7fd6ca65997938fff9e5ab6f653e4
-    sha256: dd3577bb5275062c388c46b075dcb795f47f8dac561da7dd35fe504b936934e5
+    md5: 6feb87357ecd66733be3279f16a8c400
+    sha256: 048c16a9cbcb1fbad02083414d3bc7c1d0eea4b39aee6aa6bf8d1d5089ca8bad
   category: main
   optional: false
 - name: cffi
-  version: 1.16.0
+  version: 1.17.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libffi: '>=3.4,<4.0a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     pycparser: ''
-    python: '>=3.12.0rc3,<3.13.0a0'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py312hf06ca03_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py312h06ac9bb_0.conda
   hash:
-    md5: 56b0ca764ce23cc54f3f7e2a7b970f6d
-    sha256: 5a36e2c254603c367d26378fa3a205bd92263e30acf195f488749562b4c44251
+    md5: a861504bbea4161a9170b85d4d2be840
+    sha256: cba6ea83c4b0b4f5b5dc59cb19830519b28f95d7ebef7c9c5cf1c14843621457
   category: main
   optional: false
 - name: cffi
-  version: 1.16.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libffi: '>=3.4,<4.0a0'
-    pycparser: ''
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py312h38bf5a0_0.conda
-  hash:
-    md5: a45759c013ab20b9017ef9539d234dd7
-    sha256: 8b856583b56fc30f064a7cb286f85e4b5725f2bd4fda8ba0c4e94bffe258741e
-  category: main
-  optional: false
-- name: cffi
-  version: 1.16.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libffi: '>=3.4,<4.0a0'
-    pycparser: ''
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py312h8e38eb3_0.conda
-  hash:
-    md5: 960ecbd65860d3b1de5e30373e1bffb1
-    sha256: 1544403cb1a5ca2aeabf0dac86d9ce6066d6fb4363493643b33ffd1b78038d18
-  category: main
-  optional: false
-- name: cfgv
-  version: 3.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: ebb5f5f7dc4f1a3780ef7ea7738db08c
-    sha256: fbc03537a27ef756162c49b1d0608bf7ab12fa5e38ceb8563d6f4859e835ac5c
-  category: dev
-  optional: true
-- name: cfgv
-  version: 3.3.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: ebb5f5f7dc4f1a3780ef7ea7738db08c
-    sha256: fbc03537a27ef756162c49b1d0608bf7ab12fa5e38ceb8563d6f4859e835ac5c
-  category: dev
-  optional: true
-- name: cfgv
-  version: 3.3.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: ebb5f5f7dc4f1a3780ef7ea7738db08c
-    sha256: fbc03537a27ef756162c49b1d0608bf7ab12fa5e38ceb8563d6f4859e835ac5c
-  category: dev
-  optional: true
-- name: cfitsio
-  version: 4.4.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.4.1-hf8ad068_0.conda
-  hash:
-    md5: 1b7a01fd02d11efe0eb5a676842a7b7d
-    sha256: 74ed4d8b327fa775d9c87e476a7221b74fb913aadcef207622596a99683c8faf
-  category: main
-  optional: false
-- name: cfitsio
-  version: 4.4.1
+  version: 1.17.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libgfortran: 5.*
-    libgfortran5: '>=13.2.0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.4.1-ha105788_0.conda
+    libffi: '>=3.4,<4.0a0'
+    pycparser: ''
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py312hf857d28_0.conda
   hash:
-    md5: 99445be39aaea44a05046c479f8c6dc9
-    sha256: 6b54b24abd3122d33d80a59a901cd51b26b6d47fbb9f84c2bf1f87606e9899c6
+    md5: 5bbc69b8194fedc2792e451026cac34f
+    sha256: 94fe49aed25d84997e2630d6e776a75ee2a85bd64f258702c57faa4fe2986902
   category: main
   optional: false
-- name: cfitsio
-  version: 4.4.1
+- name: cffi
+  version: 1.17.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libgfortran: 5.*
-    libgfortran5: '>=13.2.0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cfitsio-4.4.1-h793ed5c_0.conda
+    libffi: '>=3.4,<4.0a0'
+    pycparser: ''
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py312h0fad829_0.conda
   hash:
-    md5: c2a9a79b58d2de021ad9295f53e1f40a
-    sha256: cad6c9f86f98f1ac980e8229ef76a9bb8f62d167a52d29770e0548c7f9a80eb1
+    md5: 19a5456f72f505881ba493979777b24e
+    sha256: 8d91a0d01358b5c3f20297c6c536c5d24ccd3e0c2ddd37f9d0593d0f0070226f
   category: main
   optional: false
-- name: cfn-lint
-  version: 1.5.3
+- name: cfgv
+  version: 3.3.1
   manager: conda
   platform: linux-64
   dependencies:
-    aws-sam-translator: '>=1.89.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 57df494053e17dce2ac3a0b33e1b2a2e
+    sha256: d5696636733b3c301054b948cdd793f118efacce361d9bd4afb57d5980a9064f
+  category: dev
+  optional: true
+- name: cfgv
+  version: 3.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 57df494053e17dce2ac3a0b33e1b2a2e
+    sha256: d5696636733b3c301054b948cdd793f118efacce361d9bd4afb57d5980a9064f
+  category: dev
+  optional: true
+- name: cfgv
+  version: 3.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 57df494053e17dce2ac3a0b33e1b2a2e
+    sha256: d5696636733b3c301054b948cdd793f118efacce361d9bd4afb57d5980a9064f
+  category: dev
+  optional: true
+- name: cfn-lint
+  version: 1.24.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-sam-translator: '>=1.94.0'
     jschema-to-python: '>=1.2.3,<1.3.dev0'
     jsonpatch: ''
     junit-xml: '>=1.9,<2.dev0'
     networkx: '>=2.4,<4'
     pydot: ''
-    python: '>=3.8,<4.0'
+    python: '>=3.9,<4.0'
     pyyaml: '>5.4'
     regex: ''
     sarif-om: '>=1.0.4,<1.1.dev0'
     sympy: '>=1.0.0'
     typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cfn-lint-1.5.3-pyhd8ed1ab_0.conda
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/cfn-lint-1.24.0-pyhd8ed1ab_0.conda
   hash:
-    md5: b25ff21d40004568d1f22f3df2c241bb
-    sha256: 43c142ef3ba8bec334497383f960a9f8550eda984d47ad1dea2f44a7f95fa387
+    md5: ea4081d2415fbcf0715fb46ca52610d8
+    sha256: 1f5a49315ab6bd0f925fdbf0ca9e5858d5f03d34c0c2a0e5258c111ee312f150
   category: dev
   optional: true
 - name: cfn-lint
-  version: 1.5.3
+  version: 1.24.0
   manager: conda
   platform: osx-64
   dependencies:
-    aws-sam-translator: '>=1.89.0'
-    jschema-to-python: '>=1.2.3,<1.3.dev0'
+    typing_extensions: ''
+    typing-extensions: ''
+    regex: ''
+    pydot: ''
     jsonpatch: ''
+    python: '>=3.9,<4.0'
+    pyyaml: '>5.4'
+    sympy: '>=1.0.0'
+    jschema-to-python: '>=1.2.3,<1.3.dev0'
     junit-xml: '>=1.9,<2.dev0'
     networkx: '>=2.4,<4'
-    pydot: ''
-    python: '>=3.8,<4.0'
-    pyyaml: '>5.4'
-    regex: ''
     sarif-om: '>=1.0.4,<1.1.dev0'
-    sympy: '>=1.0.0'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cfn-lint-1.5.3-pyhd8ed1ab_0.conda
+    aws-sam-translator: '>=1.94.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cfn-lint-1.24.0-pyhd8ed1ab_0.conda
   hash:
-    md5: b25ff21d40004568d1f22f3df2c241bb
-    sha256: 43c142ef3ba8bec334497383f960a9f8550eda984d47ad1dea2f44a7f95fa387
+    md5: ea4081d2415fbcf0715fb46ca52610d8
+    sha256: 1f5a49315ab6bd0f925fdbf0ca9e5858d5f03d34c0c2a0e5258c111ee312f150
   category: dev
   optional: true
 - name: cfn-lint
-  version: 1.5.3
+  version: 1.24.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    aws-sam-translator: '>=1.89.0'
-    jschema-to-python: '>=1.2.3,<1.3.dev0'
+    typing_extensions: ''
+    typing-extensions: ''
+    regex: ''
+    pydot: ''
     jsonpatch: ''
+    python: '>=3.9,<4.0'
+    pyyaml: '>5.4'
+    sympy: '>=1.0.0'
+    jschema-to-python: '>=1.2.3,<1.3.dev0'
     junit-xml: '>=1.9,<2.dev0'
     networkx: '>=2.4,<4'
-    pydot: ''
-    python: '>=3.8,<4.0'
-    pyyaml: '>5.4'
-    regex: ''
     sarif-om: '>=1.0.4,<1.1.dev0'
-    sympy: '>=1.0.0'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cfn-lint-1.5.3-pyhd8ed1ab_0.conda
+    aws-sam-translator: '>=1.94.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cfn-lint-1.24.0-pyhd8ed1ab_0.conda
   hash:
-    md5: b25ff21d40004568d1f22f3df2c241bb
-    sha256: 43c142ef3ba8bec334497383f960a9f8550eda984d47ad1dea2f44a7f95fa387
+    md5: ea4081d2415fbcf0715fb46ca52610d8
+    sha256: 1f5a49315ab6bd0f925fdbf0ca9e5858d5f03d34c0c2a0e5258c111ee312f150
   category: dev
   optional: true
 - name: charset-normalizer
-  version: 3.3.2
+  version: 3.4.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 7f4a9e3fcff3f6356ae99244a014da6a
-    sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+    md5: e83a31202d1c0a000fce3e9cf3825875
+    sha256: 4e0ee91b97e5de3e74567bdacea27f0139709fceca4db8adffbe24deffccb09b
   category: main
   optional: false
 - name: charset-normalizer
-  version: 3.3.2
+  version: 3.4.1
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 7f4a9e3fcff3f6356ae99244a014da6a
-    sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+    md5: e83a31202d1c0a000fce3e9cf3825875
+    sha256: 4e0ee91b97e5de3e74567bdacea27f0139709fceca4db8adffbe24deffccb09b
   category: main
   optional: false
 - name: charset-normalizer
-  version: 3.3.2
+  version: 3.4.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 7f4a9e3fcff3f6356ae99244a014da6a
-    sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+    md5: e83a31202d1c0a000fce3e9cf3825875
+    sha256: 4e0ee91b97e5de3e74567bdacea27f0139709fceca4db8adffbe24deffccb09b
   category: main
   optional: false
 - name: click
-  version: 8.1.7
+  version: 8.1.8
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
   hash:
-    md5: f3ad426304898027fc619827ff428eca
-    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+    md5: f22f4d4970e09d68a10b922cbb0408d3
+    sha256: c920d23cd1fcf565031c679adb62d848af60d6fbb0edc2d50ba475cea4f0d8ab
   category: main
   optional: false
 - name: click
-  version: 8.1.7
+  version: 8.1.8
   manager: conda
   platform: osx-64
   dependencies:
     __unix: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
   hash:
-    md5: f3ad426304898027fc619827ff428eca
-    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+    md5: f22f4d4970e09d68a10b922cbb0408d3
+    sha256: c920d23cd1fcf565031c679adb62d848af60d6fbb0edc2d50ba475cea4f0d8ab
   category: main
   optional: false
 - name: click
-  version: 8.1.7
+  version: 8.1.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
   hash:
-    md5: f3ad426304898027fc619827ff428eca
-    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+    md5: f22f4d4970e09d68a10b922cbb0408d3
+    sha256: c920d23cd1fcf565031c679adb62d848af60d6fbb0edc2d50ba475cea4f0d8ab
   category: main
   optional: false
 - name: click-default-group
@@ -2865,11 +2851,11 @@ package:
   platform: linux-64
   dependencies:
     click: ''
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 7c2b6931f9b3548ed78478332095c3e9
-    sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
+    md5: 7cd83dd6831b61ad9624a694e4afd7dc
+    sha256: cb7279eecddbd35ea78fd0e189a9a7db8b84c2c0e3b1271cf26251615f75dc4d
   category: main
   optional: false
 - name: click-default-group
@@ -2878,11 +2864,11 @@ package:
   platform: osx-64
   dependencies:
     click: ''
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 7c2b6931f9b3548ed78478332095c3e9
-    sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
+    md5: 7cd83dd6831b61ad9624a694e4afd7dc
+    sha256: cb7279eecddbd35ea78fd0e189a9a7db8b84c2c0e3b1271cf26251615f75dc4d
   category: main
   optional: false
 - name: click-default-group
@@ -2891,11 +2877,11 @@ package:
   platform: osx-arm64
   dependencies:
     click: ''
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 7c2b6931f9b3548ed78478332095c3e9
-    sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
+    md5: 7cd83dd6831b61ad9624a694e4afd7dc
+    sha256: cb7279eecddbd35ea78fd0e189a9a7db8b84c2c0e3b1271cf26251615f75dc4d
   category: main
   optional: false
 - name: click-plugins
@@ -2904,11 +2890,11 @@ package:
   platform: linux-64
   dependencies:
     click: '>=3.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
-    sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+    md5: 82bea35e4dac4678ba623cf10e95e375
+    sha256: e7e2371a2561fbda9d50deb895d56fb16ccefe54f6d81b35ba8f1d33d3cc6957
   category: dev
   optional: true
 - name: click-plugins
@@ -2916,12 +2902,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.9'
     click: '>=3.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
-    sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+    md5: 82bea35e4dac4678ba623cf10e95e375
+    sha256: e7e2371a2561fbda9d50deb895d56fb16ccefe54f6d81b35ba8f1d33d3cc6957
   category: dev
   optional: true
 - name: click-plugins
@@ -2929,12 +2915,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.9'
     click: '>=3.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
-    sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+    md5: 82bea35e4dac4678ba623cf10e95e375
+    sha256: e7e2371a2561fbda9d50deb895d56fb16ccefe54f6d81b35ba8f1d33d3cc6957
   category: dev
   optional: true
 - name: cligj
@@ -2943,11 +2929,11 @@ package:
   platform: linux-64
   dependencies:
     click: '>=4.0'
-    python: <4.0
-  url: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
   hash:
-    md5: a29b7c141d6b2de4bb67788a5f107734
-    sha256: 97bd58f0cfcff56a0bcda101e26f7d936625599325beba3e3a1fa512dd7fc174
+    md5: 55c7804f428719241a90b152016085a1
+    sha256: 1a52ae1febfcfb8f56211d1483a1ac4419b0028b7c3e9e61960a298978a42396
   category: dev
   optional: true
 - name: cligj
@@ -2955,12 +2941,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.9,<4.0'
     click: '>=4.0'
-    python: <4.0
-  url: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
   hash:
-    md5: a29b7c141d6b2de4bb67788a5f107734
-    sha256: 97bd58f0cfcff56a0bcda101e26f7d936625599325beba3e3a1fa512dd7fc174
+    md5: 55c7804f428719241a90b152016085a1
+    sha256: 1a52ae1febfcfb8f56211d1483a1ac4419b0028b7c3e9e61960a298978a42396
   category: dev
   optional: true
 - name: cligj
@@ -2968,12 +2954,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.9,<4.0'
     click: '>=4.0'
-    python: <4.0
-  url: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
   hash:
-    md5: a29b7c141d6b2de4bb67788a5f107734
-    sha256: 97bd58f0cfcff56a0bcda101e26f7d936625599325beba3e3a1fa512dd7fc174
+    md5: 55c7804f428719241a90b152016085a1
+    sha256: 1a52ae1febfcfb8f56211d1483a1ac4419b0028b7c3e9e61960a298978a42396
   category: dev
   optional: true
 - name: clikit
@@ -2983,11 +2969,11 @@ package:
   dependencies:
     pastel: '>=0.2.0,<0.3.0'
     pylev: '>=1.3,<2.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_3.conda
   hash:
-    md5: 02abb7b66b02e8b9f5a9b05454400087
-    sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
+    md5: 37e178bf9356122c35005a62d850e5d9
+    sha256: da000653be96a15b9aad5c59f655dbd4a60cb66fc0137e1018db9de76671bb08
   category: main
   optional: false
 - name: clikit
@@ -2995,13 +2981,13 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    pastel: '>=0.2.0,<0.3.0'
+    python: '>=3.9'
     pylev: '>=1.3,<2.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
+    pastel: '>=0.2.0,<0.3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_3.conda
   hash:
-    md5: 02abb7b66b02e8b9f5a9b05454400087
-    sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
+    md5: 37e178bf9356122c35005a62d850e5d9
+    sha256: da000653be96a15b9aad5c59f655dbd4a60cb66fc0137e1018db9de76671bb08
   category: main
   optional: false
 - name: clikit
@@ -3009,49 +2995,49 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    pastel: '>=0.2.0,<0.3.0'
+    python: '>=3.9'
     pylev: '>=1.3,<2.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
+    pastel: '>=0.2.0,<0.3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_3.conda
   hash:
-    md5: 02abb7b66b02e8b9f5a9b05454400087
-    sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
+    md5: 37e178bf9356122c35005a62d850e5d9
+    sha256: da000653be96a15b9aad5c59f655dbd4a60cb66fc0137e1018db9de76671bb08
   category: main
   optional: false
 - name: cloudpickle
-  version: 3.0.0
+  version: 3.1.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 753d29fe41bb881e4b9c004f0abf973f
-    sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
+    md5: 364ba6c9fb03886ac979b482f39ebb92
+    sha256: 21ecead7268241007bf65691610cd7314da68c1f88113092af690203b5780db5
   category: main
   optional: false
 - name: cloudpickle
-  version: 3.0.0
+  version: 3.1.1
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 753d29fe41bb881e4b9c004f0abf973f
-    sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
+    md5: 364ba6c9fb03886ac979b482f39ebb92
+    sha256: 21ecead7268241007bf65691610cd7314da68c1f88113092af690203b5780db5
   category: main
   optional: false
 - name: cloudpickle
-  version: 3.0.0
+  version: 3.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 753d29fe41bb881e4b9c004f0abf973f
-    sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
+    md5: 364ba6c9fb03886ac979b482f39ebb92
+    sha256: 21ecead7268241007bf65691610cd7314da68c1f88113092af690203b5780db5
   category: main
   optional: false
 - name: colorama
@@ -3059,11 +3045,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   hash:
-    md5: 3faab06a954c2a04039983f2c4a50d99
-    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+    md5: 962b9857ee8e7018c22f2776ffa0b2d7
+    sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   category: main
   optional: false
 - name: colorama
@@ -3071,11 +3057,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   hash:
-    md5: 3faab06a954c2a04039983f2c4a50d99
-    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+    md5: 962b9857ee8e7018c22f2776ffa0b2d7
+    sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   category: main
   optional: false
 - name: colorama
@@ -3083,11 +3069,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   hash:
-    md5: 3faab06a954c2a04039983f2c4a50d99
-    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+    md5: 962b9857ee8e7018c22f2776ffa0b2d7
+    sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   category: main
   optional: false
 - name: comm
@@ -3095,12 +3081,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 948d84721b578d426294e17a02e24cbb
-    sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
+    md5: 74673132601ec2b7fc592755605f4c1b
+    sha256: 7e87ef7c91574d9fac19faedaaee328a70f718c9b4ddadfdc0ba9ac021bd64af
   category: dev
   optional: true
 - name: comm
@@ -3108,12 +3094,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 948d84721b578d426294e17a02e24cbb
-    sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
+    md5: 74673132601ec2b7fc592755605f4c1b
+    sha256: 7e87ef7c91574d9fac19faedaaee328a70f718c9b4ddadfdc0ba9ac021bd64af
   category: dev
   optional: true
 - name: comm
@@ -3121,16 +3107,16 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 948d84721b578d426294e17a02e24cbb
-    sha256: e923acf02708a8a0b591f3bce4bdc11c8e63b73198b99b35fe6cd96bfb6a0dbe
+    md5: 74673132601ec2b7fc592755605f4c1b
+    sha256: 7e87ef7c91574d9fac19faedaaee328a70f718c9b4ddadfdc0ba9ac021bd64af
   category: dev
   optional: true
 - name: conda
-  version: 24.5.0
+  version: 24.11.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -3155,14 +3141,14 @@ package:
     tqdm: '>=4'
     truststore: '>=0.8.0'
     zstandard: '>=0.19.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/conda-24.5.0-py312h7900ff3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/conda-24.11.3-py312h7900ff3_0.conda
   hash:
-    md5: bda145e97ad4eb12bf5b7aed7d3d5d45
-    sha256: 913254d93807667543aca625da828909529ba7b3c1a8c700b201ae1723df7996
+    md5: bdaca5d82db98d8b5639f058a818ff03
+    sha256: dbf0b37da0cd3eb2ee5535467c13c16fc2c2a1bc959d68fde89c60b3fec78763
   category: main
   optional: false
 - name: conda
-  version: 24.5.0
+  version: 24.11.3
   manager: conda
   platform: osx-64
   dependencies:
@@ -3187,14 +3173,14 @@ package:
     tqdm: '>=4'
     truststore: '>=0.8.0'
     zstandard: '>=0.19.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/conda-24.5.0-py312hb401068_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/conda-24.11.3-py312hb401068_0.conda
   hash:
-    md5: 7b2fe4530602e681a1fb9ae9c4de5cea
-    sha256: 7ce4f091260639e76d6417bf5461bed2ef96de15db19ab7b2f2f4d6e829029aa
+    md5: b19d45d499a4249ef39db67162f4be7b
+    sha256: 393d8a2109d551a3fb03a69d32c4f48b57aeec61f59c582f861fcc59f62e2940
   category: main
   optional: false
 - name: conda
-  version: 24.5.0
+  version: 24.11.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3219,55 +3205,55 @@ package:
     tqdm: '>=4'
     truststore: '>=0.8.0'
     zstandard: '>=0.19.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/conda-24.5.0-py312h81bd7bf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/conda-24.11.3-py312h81bd7bf_0.conda
   hash:
-    md5: f408bfea2eaf2ec3238422fe13bab78d
-    sha256: 5edfa3d5fd81c692be0f31421cc6e9e5cd9d7146635612f61f4f3321a33595b5
+    md5: 18fa2b450241200ac0e9f3ce77efa839
+    sha256: 5204b7e937d08597c0d7ab14591d71a3f42d46eff40b36a7568e7dbd0ecf8d1d
   category: main
   optional: false
 - name: conda-libmamba-solver
-  version: 24.1.0
+  version: 25.1.1
   manager: conda
   platform: linux-64
   dependencies:
     boltons: '>=23.0.0'
     conda: '>=23.7.4'
-    libmambapy: '>=1.5.6,<2.0a0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-libmamba-solver-24.1.0-pyhd8ed1ab_0.conda
+    libmambapy: '>=2.0.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-libmamba-solver-25.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 304dc78ad6e52e0fd663df1d484c1531
-    sha256: 0667d49300062da2b46b04c097a9ace55c7a133d035517ec093e54a54f8f6b55
+    md5: d698a2b82570ced4505030b216e069d8
+    sha256: 9604e89e5aadf389afa9ee3504ee84222c43115754f89c576ce9105f44837d4f
   category: main
   optional: false
 - name: conda-libmamba-solver
-  version: 24.1.0
+  version: 25.1.1
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.9'
     boltons: '>=23.0.0'
     conda: '>=23.7.4'
-    libmambapy: '>=1.5.6,<2.0a0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-libmamba-solver-24.1.0-pyhd8ed1ab_0.conda
+    libmambapy: '>=2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-libmamba-solver-25.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 304dc78ad6e52e0fd663df1d484c1531
-    sha256: 0667d49300062da2b46b04c097a9ace55c7a133d035517ec093e54a54f8f6b55
+    md5: d698a2b82570ced4505030b216e069d8
+    sha256: 9604e89e5aadf389afa9ee3504ee84222c43115754f89c576ce9105f44837d4f
   category: main
   optional: false
 - name: conda-libmamba-solver
-  version: 24.1.0
+  version: 25.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.9'
     boltons: '>=23.0.0'
     conda: '>=23.7.4'
-    libmambapy: '>=1.5.6,<2.0a0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-libmamba-solver-24.1.0-pyhd8ed1ab_0.conda
+    libmambapy: '>=2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-libmamba-solver-25.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 304dc78ad6e52e0fd663df1d484c1531
-    sha256: 0667d49300062da2b46b04c097a9ace55c7a133d035517ec093e54a54f8f6b55
+    md5: d698a2b82570ced4505030b216e069d8
+    sha256: 9604e89e5aadf389afa9ee3504ee84222c43115754f89c576ce9105f44837d4f
   category: main
   optional: false
 - name: conda-lock
@@ -3289,7 +3275,7 @@ package:
     packaging: '>=20.4'
     pkginfo: '>=1.4'
     pydantic: '>=1.10'
-    python: '>=3.8'
+    python: '>=3.9'
     pyyaml: '>=5.1'
     requests: '>=2.18'
     ruamel.yaml: ''
@@ -3300,10 +3286,10 @@ package:
     typing_extensions: ''
     urllib3: '>=1.26.5,<2.0'
     virtualenv: '>=20.0.26'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_1.conda
   hash:
-    md5: 154d0c643be6a9ce6fbe655d007d8e4e
-    sha256: bdce4c0d6491d12db676633dcf1cae031a5105073996a4a0ae8dba9ecafda2b2
+    md5: 518d59879a7ba4f3972109e8666860b2
+    sha256: 905618b595d7a067fe37a282e3b84a4ed46542c1b497c76cef7b0f33f9335cb7
   category: main
   optional: false
 - name: conda-lock
@@ -3311,35 +3297,35 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    cachecontrol-with-filecache: '>=0.12.9'
-    cachy: '>=0.3.0'
-    click: '>=8.0'
+    setuptools: ''
+    typing_extensions: ''
+    jinja2: ''
+    tomli: ''
+    ruamel.yaml: ''
     click-default-group: ''
+    python: '>=3.9'
+    pyyaml: '>=5.1'
+    click: '>=8.0'
+    packaging: '>=20.4'
+    requests: '>=2.18'
+    pydantic: '>=1.10'
+    gitpython: '>=3.1.30'
+    ensureconda: '>=1.3'
+    keyring: '>=21.2.0'
+    html5lib: '>=1.0'
+    cachy: '>=0.3.0'
     clikit: '>=0.6.2'
     crashtest: '>=0.3.0'
-    ensureconda: '>=1.3'
-    gitpython: '>=3.1.30'
-    html5lib: '>=1.0'
-    jinja2: ''
-    keyring: '>=21.2.0'
-    packaging: '>=20.4'
     pkginfo: '>=1.4'
-    pydantic: '>=1.10'
-    python: '>=3.8'
-    pyyaml: '>=5.1'
-    requests: '>=2.18'
-    ruamel.yaml: ''
-    setuptools: ''
-    tomli: ''
     tomlkit: '>=0.7.0'
-    toolz: '>=0.12.0,<1.0.0'
-    typing_extensions: ''
-    urllib3: '>=1.26.5,<2.0'
     virtualenv: '>=20.0.26'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_0.conda
+    toolz: '>=0.12.0,<1.0.0'
+    cachecontrol-with-filecache: '>=0.12.9'
+    urllib3: '>=1.26.5,<2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_1.conda
   hash:
-    md5: 154d0c643be6a9ce6fbe655d007d8e4e
-    sha256: bdce4c0d6491d12db676633dcf1cae031a5105073996a4a0ae8dba9ecafda2b2
+    md5: 518d59879a7ba4f3972109e8666860b2
+    sha256: 905618b595d7a067fe37a282e3b84a4ed46542c1b497c76cef7b0f33f9335cb7
   category: main
   optional: false
 - name: conda-lock
@@ -3347,120 +3333,123 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    cachecontrol-with-filecache: '>=0.12.9'
-    cachy: '>=0.3.0'
-    click: '>=8.0'
+    setuptools: ''
+    typing_extensions: ''
+    jinja2: ''
+    tomli: ''
+    ruamel.yaml: ''
     click-default-group: ''
+    python: '>=3.9'
+    pyyaml: '>=5.1'
+    click: '>=8.0'
+    packaging: '>=20.4'
+    requests: '>=2.18'
+    pydantic: '>=1.10'
+    gitpython: '>=3.1.30'
+    ensureconda: '>=1.3'
+    keyring: '>=21.2.0'
+    html5lib: '>=1.0'
+    cachy: '>=0.3.0'
     clikit: '>=0.6.2'
     crashtest: '>=0.3.0'
-    ensureconda: '>=1.3'
-    gitpython: '>=3.1.30'
-    html5lib: '>=1.0'
-    jinja2: ''
-    keyring: '>=21.2.0'
-    packaging: '>=20.4'
     pkginfo: '>=1.4'
-    pydantic: '>=1.10'
-    python: '>=3.8'
-    pyyaml: '>=5.1'
-    requests: '>=2.18'
-    ruamel.yaml: ''
-    setuptools: ''
-    tomli: ''
     tomlkit: '>=0.7.0'
-    toolz: '>=0.12.0,<1.0.0'
-    typing_extensions: ''
-    urllib3: '>=1.26.5,<2.0'
     virtualenv: '>=20.0.26'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_0.conda
+    toolz: '>=0.12.0,<1.0.0'
+    cachecontrol-with-filecache: '>=0.12.9'
+    urllib3: '>=1.26.5,<2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_1.conda
   hash:
-    md5: 154d0c643be6a9ce6fbe655d007d8e4e
-    sha256: bdce4c0d6491d12db676633dcf1cae031a5105073996a4a0ae8dba9ecafda2b2
+    md5: 518d59879a7ba4f3972109e8666860b2
+    sha256: 905618b595d7a067fe37a282e3b84a4ed46542c1b497c76cef7b0f33f9335cb7
   category: main
   optional: false
 - name: conda-package-handling
-  version: 2.3.0
+  version: 2.4.0
   manager: conda
   platform: linux-64
   dependencies:
     conda-package-streaming: '>=0.9.0'
-    python: '>=3.8'
+    python: '>=3.9'
+    requests: ''
     zstandard: '>=0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-package-handling-2.3.0-pyh7900ff3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-package-handling-2.4.0-pyh7900ff3_2.conda
   hash:
-    md5: 0a7dce281ae2be81acab0aa963e6bb99
-    sha256: c85a76ffd08608c3c61d1ca6c82be9f45ab31a5e108a1aec0872d84b3546e4f1
+    md5: 32c158f481b4fd7630c565030f7bc482
+    sha256: 8b2b1c235b7cbfa8488ad88ff934bdad25bac6a4c035714681fbff85b602f3f0
   category: main
   optional: false
 - name: conda-package-handling
-  version: 2.3.0
+  version: 2.4.0
   manager: conda
   platform: osx-64
   dependencies:
-    conda-package-streaming: '>=0.9.0'
-    python: '>=3.8'
+    requests: ''
+    python: '>=3.9'
     zstandard: '>=0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-package-handling-2.3.0-pyh7900ff3_0.conda
+    conda-package-streaming: '>=0.9.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-package-handling-2.4.0-pyh7900ff3_2.conda
   hash:
-    md5: 0a7dce281ae2be81acab0aa963e6bb99
-    sha256: c85a76ffd08608c3c61d1ca6c82be9f45ab31a5e108a1aec0872d84b3546e4f1
+    md5: 32c158f481b4fd7630c565030f7bc482
+    sha256: 8b2b1c235b7cbfa8488ad88ff934bdad25bac6a4c035714681fbff85b602f3f0
   category: main
   optional: false
 - name: conda-package-handling
-  version: 2.3.0
+  version: 2.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    conda-package-streaming: '>=0.9.0'
-    python: '>=3.8'
+    requests: ''
+    python: '>=3.9'
     zstandard: '>=0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-package-handling-2.3.0-pyh7900ff3_0.conda
+    conda-package-streaming: '>=0.9.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-package-handling-2.4.0-pyh7900ff3_2.conda
   hash:
-    md5: 0a7dce281ae2be81acab0aa963e6bb99
-    sha256: c85a76ffd08608c3c61d1ca6c82be9f45ab31a5e108a1aec0872d84b3546e4f1
+    md5: 32c158f481b4fd7630c565030f7bc482
+    sha256: 8b2b1c235b7cbfa8488ad88ff934bdad25bac6a4c035714681fbff85b602f3f0
   category: main
   optional: false
 - name: conda-package-streaming
-  version: 0.10.0
+  version: 0.11.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
     zstandard: '>=0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-package-streaming-0.10.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-package-streaming-0.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3480386e00995f7a1dfb3b9aa2fe70fd
-    sha256: 69674f1389168be29964e2d89c9597c7903462bf7525727a2df93dbd9f960934
+    md5: bc9533d8616a97551ed144789bf9c1cd
+    sha256: 685b06951e563514a9b158e82d3d44faf102f0770af42e4d08347a6eec3d48ea
   category: main
   optional: false
 - name: conda-package-streaming
-  version: 0.10.0
+  version: 0.11.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.7'
     zstandard: '>=0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-package-streaming-0.10.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-package-streaming-0.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3480386e00995f7a1dfb3b9aa2fe70fd
-    sha256: 69674f1389168be29964e2d89c9597c7903462bf7525727a2df93dbd9f960934
+    md5: bc9533d8616a97551ed144789bf9c1cd
+    sha256: 685b06951e563514a9b158e82d3d44faf102f0770af42e4d08347a6eec3d48ea
   category: main
   optional: false
 - name: conda-package-streaming
-  version: 0.10.0
+  version: 0.11.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
     zstandard: '>=0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-package-streaming-0.10.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-package-streaming-0.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3480386e00995f7a1dfb3b9aa2fe70fd
-    sha256: 69674f1389168be29964e2d89c9597c7903462bf7525727a2df93dbd9f960934
+    md5: bc9533d8616a97551ed144789bf9c1cd
+    sha256: 685b06951e563514a9b158e82d3d44faf102f0770af42e4d08347a6eec3d48ea
   category: main
   optional: false
 - name: contextily
-  version: 1.6.0
+  version: 1.6.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -3469,112 +3458,191 @@ package:
     matplotlib-base: ''
     mercantile: ''
     pillow: ''
-    python: '>=3.8'
+    python: '>=3.9'
     rasterio: ''
     requests: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.2-pyhd8ed1ab_1.conda
   hash:
-    md5: a3e5ccece003758e379be05cb5a08dff
-    sha256: 3e70e8cdffc1b6134076f720e864caa29250160a2c4f726dbf557210554fbf46
+    md5: 04c0d3c54ae90b9aedccebd30e09cab8
+    sha256: 3f0a1518e35e090070e7da76609d11ef8dafb655eda3ab9d4956fa85554e8513
   category: dev
   optional: true
 - name: contextily
-  version: 1.6.0
+  version: 1.6.2
   manager: conda
   platform: osx-64
   dependencies:
-    geopy: ''
-    joblib: ''
-    matplotlib-base: ''
-    mercantile: ''
-    pillow: ''
-    python: '>=3.8'
-    rasterio: ''
     requests: ''
+    matplotlib-base: ''
+    pillow: ''
+    joblib: ''
+    rasterio: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.0-pyhd8ed1ab_0.conda
+    geopy: ''
+    mercantile: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.2-pyhd8ed1ab_1.conda
   hash:
-    md5: a3e5ccece003758e379be05cb5a08dff
-    sha256: 3e70e8cdffc1b6134076f720e864caa29250160a2c4f726dbf557210554fbf46
+    md5: 04c0d3c54ae90b9aedccebd30e09cab8
+    sha256: 3f0a1518e35e090070e7da76609d11ef8dafb655eda3ab9d4956fa85554e8513
   category: dev
   optional: true
 - name: contextily
-  version: 1.6.0
+  version: 1.6.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    geopy: ''
-    joblib: ''
-    matplotlib-base: ''
-    mercantile: ''
-    pillow: ''
-    python: '>=3.8'
-    rasterio: ''
     requests: ''
+    matplotlib-base: ''
+    pillow: ''
+    joblib: ''
+    rasterio: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.0-pyhd8ed1ab_0.conda
+    geopy: ''
+    mercantile: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.2-pyhd8ed1ab_1.conda
   hash:
-    md5: a3e5ccece003758e379be05cb5a08dff
-    sha256: 3e70e8cdffc1b6134076f720e864caa29250160a2c4f726dbf557210554fbf46
+    md5: 04c0d3c54ae90b9aedccebd30e09cab8
+    sha256: 3f0a1518e35e090070e7da76609d11ef8dafb655eda3ab9d4956fa85554e8513
   category: dev
   optional: true
 - name: contourpy
-  version: 1.2.1
+  version: 1.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    numpy: '>=1.23'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.1-py312h68727a3_0.conda
+  hash:
+    md5: f5fbba0394ee45e9a64a73c2a994126a
+    sha256: e977af50b844b5b8cfec358131a4e923f0aa718e8334321cf8d84f5093576259
+  category: main
+  optional: false
+- name: contourpy
+  version: 1.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcxx: '>=18'
+    numpy: '>=1.23'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.1-py312hc47a885_0.conda
+  hash:
+    md5: 94715deb514df3f341f62bc2ffea5637
+    sha256: e05d4c6b4284684a020c386861342fa22706ff747f1f8909b14dbc0fe489dcb2
+  category: main
+  optional: false
+- name: contourpy
+  version: 1.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=18'
+    numpy: '>=1.23'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.1-py312hb23fbb9_0.conda
+  hash:
+    md5: f4408290387836e05ac267cd7ec80c5c
+    sha256: fa1f8505f45eac22f25c48cd46809da0d26bcb028c37517b3474bacddd029b0a
+  category: main
+  optional: false
+- name: cpp-expected
+  version: 1.1.0
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    numpy: '>=1.20'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.1-py312h8572e83_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cpp-expected-1.1.0-hf52228f_0.conda
   hash:
-    md5: 12c6a831ef734f0b2dd4caff514cbb7f
-    sha256: b0731336b9788c247b11a592352f700a647119340b549aba9e933835c7c77df0
+    md5: a7f1500bf47196443b67355d67afec6d
+    sha256: fc809e6894537a77c6cd1e65f593ae1bfbf60f494bce55295212d1a9bacd7fa7
   category: main
   optional: false
-- name: contourpy
-  version: 1.2.1
+- name: cpp-expected
+  version: 1.1.0
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=16'
-    numpy: '>=1.20'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.2.1-py312h9230928_0.conda
+    libcxx: '>=14.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/cpp-expected-1.1.0-hb8565cd_0.conda
   hash:
-    md5: 079df34ce7c71259cfdd394645370891
-    sha256: 3879ed298cc9ec5486d13b7d65da960c813925837fe67fc385c9b31f7eefddc0
+    md5: 53c16c2f79183b459ef6acb6c93f3550
+    sha256: 80c0551e5d297c59991c09f6611331f3d56517894b63c8f6a85d51e601b8ea69
   category: main
   optional: false
-- name: contourpy
-  version: 1.2.1
+- name: cpp-expected
+  version: 1.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=16'
-    numpy: '>=1.20'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.2.1-py312h0fef576_0.conda
+    libcxx: '>=14.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cpp-expected-1.1.0-hffc8910_0.conda
   hash:
-    md5: f825cced50aa6ae9f6ae158a49ecb68c
-    sha256: 89bb5c2f1f5daed13240d5fccfc51cd63b92293cee690c8b0a8f633971e588bb
+    md5: d58ea142acc3d93f6f0176e31e4493ad
+    sha256: 9af3323963a059681eb848218c11ba2208f12bc5416ee357b0d4f9f8bef5ebca
   category: main
   optional: false
+- name: cpython
+  version: 3.12.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: 3.12.8.*
+    python_abi: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.8-py312hd8ed1ab_1.conda
+  hash:
+    md5: caa04d37126e82822468d6bdf50f5ebd
+    sha256: 05413d84485086301e5bd7c03fca2caae91f75474d99d9fc815cec912332452b
+  category: dev
+  optional: true
+- name: cpython
+  version: 3.12.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python_abi: '*'
+    python: 3.12.8.*
+  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.8-py312hd8ed1ab_1.conda
+  hash:
+    md5: caa04d37126e82822468d6bdf50f5ebd
+    sha256: 05413d84485086301e5bd7c03fca2caae91f75474d99d9fc815cec912332452b
+  category: dev
+  optional: true
+- name: cpython
+  version: 3.12.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python_abi: '*'
+    python: 3.12.8.*
+  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.8-py312hd8ed1ab_1.conda
+  hash:
+    md5: caa04d37126e82822468d6bdf50f5ebd
+    sha256: 05413d84485086301e5bd7c03fca2caae91f75474d99d9fc815cec912332452b
+  category: dev
+  optional: true
 - name: crashtest
   version: 0.4.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 709a2295dd907bb34afb57d54320642f
-    sha256: 2f05954a3faf0700c14c1deddc085385160ee32abe111699c78d9cb277e915cc
+    md5: e036e2f76d9c9aebc12510ed23352b6c
+    sha256: af1622b15f8c7411d9c14b8adf970cec16fec8a28b98069fdf42b1cd2259ccc9
   category: main
   optional: false
 - name: crashtest
@@ -3582,11 +3650,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 709a2295dd907bb34afb57d54320642f
-    sha256: 2f05954a3faf0700c14c1deddc085385160ee32abe111699c78d9cb277e915cc
+    md5: e036e2f76d9c9aebc12510ed23352b6c
+    sha256: af1622b15f8c7411d9c14b8adf970cec16fec8a28b98069fdf42b1cd2259ccc9
   category: main
   optional: false
 - name: crashtest
@@ -3594,59 +3662,60 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 709a2295dd907bb34afb57d54320642f
-    sha256: 2f05954a3faf0700c14c1deddc085385160ee32abe111699c78d9cb277e915cc
+    md5: e036e2f76d9c9aebc12510ed23352b6c
+    sha256: af1622b15f8c7411d9c14b8adf970cec16fec8a28b98069fdf42b1cd2259ccc9
   category: main
   optional: false
 - name: cryptography
-  version: 42.0.8
+  version: 44.0.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cffi: '>=1.12'
-    libgcc-ng: '>=12'
-    openssl: '>=3.3.1,<4.0a0'
+    libgcc: '>=13'
+    openssl: '>=3.4.0,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.8-py312hbcc2302_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-44.0.0-py312hda17c39_1.conda
   hash:
-    md5: d6cbf583b33e9473ca9129ad21936507
-    sha256: 3808035ab718df43aa27e5df372cf17685a61c41ddced539e83f38e82372e18d
+    md5: d74f8fee018276daaee383e18b1c6fd1
+    sha256: 33890f1e544216033f9ec127a0e9eba3a5b36351ccade2bd8bb16c0044aa0ce8
   category: main
   optional: false
 - name: cryptography
-  version: 42.0.8
+  version: 44.0.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     cffi: '>=1.12'
-    openssl: '>=3.3.1,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/cryptography-42.0.8-py312h7e81a9d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/cryptography-44.0.0-py312h0995e51_1.conda
   hash:
-    md5: d83cbf7878baeba7565dc77e39d77998
-    sha256: 7b9afc3214afd3600b40e1282fd8379a17405bf2908de34c6f5f0bf2810c9f55
+    md5: a3f1dbf3f6c0d6a1bb6510d9e8bd499e
+    sha256: 19ae789e4bc21326040b1c8323447e83d744f433197c7075d4899c1c96671d60
   category: dev
   optional: true
 - name: cryptography
-  version: 42.0.8
+  version: 44.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     cffi: '>=1.12'
-    openssl: '>=3.3.1,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-42.0.8-py312had01cb0_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-44.0.0-py312hf9bd80e_1.conda
   hash:
-    md5: 1a0472dfb49fb0a9c6b260cf781bc511
-    sha256: 2ed73648a6d202975a38cb9ed011bdec7c7ffe0cb92babe01665e0863377e148
+    md5: 47c45ba25dcf8bd62327b0785e3055ea
+    sha256: 176b52bf58c76eb793b00e23633b27c2f3ab253933a99fdd3462561009cff6d7
   category: dev
   optional: true
 - name: cycler
@@ -3654,11 +3723,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 5cd86562580f274031ede6aa6aa24441
-    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+    md5: 44600c4667a319d67dbe0681fc0bc833
+    sha256: 9827efa891e507a91a8a2acf64e210d2aff394e1cde432ad08e1f8c66b12293c
   category: main
   optional: false
 - name: cycler
@@ -3666,11 +3735,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 5cd86562580f274031ede6aa6aa24441
-    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+    md5: 44600c4667a319d67dbe0681fc0bc833
+    sha256: 9827efa891e507a91a8a2acf64e210d2aff394e1cde432ad08e1f8c66b12293c
   category: main
   optional: false
 - name: cycler
@@ -3678,54 +3747,91 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 5cd86562580f274031ede6aa6aa24441
-    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
+    md5: 44600c4667a319d67dbe0681fc0bc833
+    sha256: 9827efa891e507a91a8a2acf64e210d2aff394e1cde432ad08e1f8c66b12293c
   category: main
   optional: false
 - name: cython
-  version: 3.0.10
+  version: 3.0.11
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.0.11-py312h8fd2918_3.conda
+  hash:
+    md5: 21e433caf1bb1e4c95832f8bb731d64c
+    sha256: 7a888ddda463a3146949540229c70625fbefb05bcb1352cbff990f205b8392b0
+  category: main
+  optional: false
+- name: cython
+  version: 3.0.11
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcxx: '>=17'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/cython-3.0.11-py312h6891801_3.conda
+  hash:
+    md5: 929a7b64e8a1d730a7c938461b2d5756
+    sha256: 673b6be525a81ad77413011882e7744a3475cec32672fbf93a5514077758ac25
+  category: main
+  optional: false
+- name: cython
+  version: 3.0.11
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=17'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.0.11-py312hde4cb15_2.conda
+  hash:
+    md5: bc620580cd4cafd885769a3975c00287
+    sha256: bd50c1d3f13403bbc96c0cd18ae95d492eda85df8ab9febe1719bf01018c6e32
+  category: main
+  optional: false
+- name: dav1d
+  version: 1.2.1
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cython-3.0.10-py312h30efb56_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
   hash:
-    md5: b119273bff37284cbcb9281c1e85e67d
-    sha256: 761ba2d7ff6eb8c63f849df7d1b29d7c9fd231124801aee3cee517e6374b108d
+    md5: 418c6ca5929a611cbd69204907a83995
+    sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
   category: main
   optional: false
-- name: cython
-  version: 3.0.10
+- name: dav1d
+  version: 1.2.1
   manager: conda
   platform: osx-64
-  dependencies:
-    libcxx: '>=16'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/cython-3.0.10-py312hede676d_0.conda
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
   hash:
-    md5: 3008aa88f0dc67e7144734b16e331ee4
-    sha256: a3727f703d7d72bc9b9430fff78183dfcde75513fa64afac290449a8ac0bcd79
+    md5: 9d88733c715300a39f8ca2e936b7808d
+    sha256: ec71a835866b42e946cd2039a5f7a6458851a21890d315476f5e66790ac11c96
   category: main
   optional: false
-- name: cython
-  version: 3.0.10
+- name: dav1d
+  version: 1.2.1
   manager: conda
   platform: osx-arm64
-  dependencies:
-    libcxx: '>=16'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cython-3.0.10-py312h20a0b95_0.conda
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
   hash:
-    md5: 16e35fd892bbb554ad2881063cc19ec4
-    sha256: 654696af2021fc72d398eb7e4791d8382f54de421cb866ba6a53429b21a67c67
+    md5: 5a74cdee497e6b65173e10d94582fae6
+    sha256: 93e077b880a85baec8227e8c72199220c7f87849ad32d02c14fb3807368260b8
   category: main
   optional: false
 - name: dbus
@@ -3743,674 +3849,689 @@ package:
   category: main
   optional: false
 - name: debugpy
-  version: 1.8.2
+  version: 1.8.12
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.2-py312h7070661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.12-py312h2ec8cdc_0.conda
   hash:
-    md5: b19f2a4267351e36728133431f623e98
-    sha256: 8b30358bbb92d302f41298fa42ae2388faccfa290988bde3285af0bfa607522e
+    md5: 6be6dcb4bffd1d456bdad28341d507bd
+    sha256: f88c3a7ff384d1726aea2cb2342cf67f1502915391860335c40ab81d7e381e30
   category: dev
   optional: true
 - name: debugpy
-  version: 1.8.2
+  version: 1.8.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcxx: '>=18'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.12-py312haafddd8_0.conda
+  hash:
+    md5: 7cac208fb32c13a10f9e2153b5d6490c
+    sha256: 7aa87ae1945ab22ff70705c67760908fc7aff795bbab04a101b4387427547599
+  category: dev
+  optional: true
+- name: debugpy
+  version: 1.8.12
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=18'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.12-py312hd8f9ff3_0.conda
+  hash:
+    md5: 92ebf61ce320b7060ead08666dbc9369
+    sha256: 0ba7ba5f5529bd9cf103d4684e2e9af8a7791a8732c3a0ac689f2d6f2223feca
+  category: dev
+  optional: true
+- name: decorator
+  version: 5.1.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: d622d8d7ee8868870f9cbe259f381181
+    sha256: 84e5120c97502a3785e8c3241c3bf51f64b4d445f13b4d2445db00d9816fe479
+  category: dev
+  optional: true
+- name: decorator
+  version: 5.1.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: d622d8d7ee8868870f9cbe259f381181
+    sha256: 84e5120c97502a3785e8c3241c3bf51f64b4d445f13b4d2445db00d9816fe479
+  category: dev
+  optional: true
+- name: decorator
+  version: 5.1.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: d622d8d7ee8868870f9cbe259f381181
+    sha256: 84e5120c97502a3785e8c3241c3bf51f64b4d445f13b4d2445db00d9816fe479
+  category: dev
+  optional: true
+- name: distlib
+  version: 0.3.9
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_1.conda
+  hash:
+    md5: 8d88f4a2242e6b96f9ecff9a6a05b2f1
+    sha256: 0e160c21776bd881b79ce70053e59736f51036784fa43a50da10a04f0c1b9c45
+  category: main
+  optional: false
+- name: distlib
+  version: 0.3.9
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_1.conda
+  hash:
+    md5: 8d88f4a2242e6b96f9ecff9a6a05b2f1
+    sha256: 0e160c21776bd881b79ce70053e59736f51036784fa43a50da10a04f0c1b9c45
+  category: main
+  optional: false
+- name: distlib
+  version: 0.3.9
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_1.conda
+  hash:
+    md5: 8d88f4a2242e6b96f9ecff9a6a05b2f1
+    sha256: 0e160c21776bd881b79ce70053e59736f51036784fa43a50da10a04f0c1b9c45
+  category: main
+  optional: false
+- name: distro
+  version: 1.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 0a2014fd9860f8b1eaa0b1f3d3771a08
+    sha256: 5603c7d0321963bb9b4030eadabc3fd7ca6103a38475b4e0ed13ed6d97c86f4e
+  category: main
+  optional: false
+- name: distro
+  version: 1.9.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 0a2014fd9860f8b1eaa0b1f3d3771a08
+    sha256: 5603c7d0321963bb9b4030eadabc3fd7ca6103a38475b4e0ed13ed6d97c86f4e
+  category: main
+  optional: false
+- name: distro
+  version: 1.9.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 0a2014fd9860f8b1eaa0b1f3d3771a08
+    sha256: 5603c7d0321963bb9b4030eadabc3fd7ca6103a38475b4e0ed13ed6d97c86f4e
+  category: main
+  optional: false
+- name: docker-py
+  version: 7.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    paramiko: '>=2.4.3'
+    python: '>=3.9'
+    pywin32-on-windows: ''
+    requests: '>=2.26.0'
+    urllib3: '>=1.26.0'
+    websocket-client: '>=0.32.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-7.1.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 07ce73ca6f6c1a1df5d498679fc52d9e
+    sha256: 909bad7898ef2933a7efe69a48200e2331a362b0a1edd2d592942cde1f130979
+  category: dev
+  optional: true
+- name: docker-py
+  version: 7.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pywin32-on-windows: ''
+    python: '>=3.9'
+    requests: '>=2.26.0'
+    urllib3: '>=1.26.0'
+    websocket-client: '>=0.32.0'
+    paramiko: '>=2.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-7.1.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 07ce73ca6f6c1a1df5d498679fc52d9e
+    sha256: 909bad7898ef2933a7efe69a48200e2331a362b0a1edd2d592942cde1f130979
+  category: dev
+  optional: true
+- name: docker-py
+  version: 7.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pywin32-on-windows: ''
+    python: '>=3.9'
+    requests: '>=2.26.0'
+    urllib3: '>=1.26.0'
+    websocket-client: '>=0.32.0'
+    paramiko: '>=2.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-7.1.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 07ce73ca6f6c1a1df5d498679fc52d9e
+    sha256: 909bad7898ef2933a7efe69a48200e2331a362b0a1edd2d592942cde1f130979
+  category: dev
+  optional: true
+- name: ecdsa
+  version: 0.19.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    gmpy2: ''
+    python: '>=3.9'
+    six: '>=1.9.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ecdsa-0.19.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3b5baf4fb277368a6e79f2bf7c97a401
+    sha256: a78f5c45a940e4f91ea45972695f57a6c4f77982acac47b1f5dc3467d8be01b6
+  category: dev
+  optional: true
+- name: ecdsa
+  version: 0.19.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gmpy2: ''
+    python: '>=3.9'
+    six: '>=1.9.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ecdsa-0.19.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3b5baf4fb277368a6e79f2bf7c97a401
+    sha256: a78f5c45a940e4f91ea45972695f57a6c4f77982acac47b1f5dc3467d8be01b6
+  category: dev
+  optional: true
+- name: ecdsa
+  version: 0.19.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    gmpy2: ''
+    python: '>=3.9'
+    six: '>=1.9.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ecdsa-0.19.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3b5baf4fb277368a6e79f2bf7c97a401
+    sha256: a78f5c45a940e4f91ea45972695f57a6c4f77982acac47b1f5dc3467d8be01b6
+  category: dev
+  optional: true
+- name: ensureconda
+  version: 1.4.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    appdirs: ''
+    click: '>=5.1'
+    filelock: ''
+    packaging: ''
+    python: '>=3.9'
+    requests: '>=2'
+  url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: a18423d4b24e6480165a38f102ca8b49
+    sha256: 4efc864d9245a30f15bbc6eb12d06a5cf7a11d91d3e2c84630df1ce83f8b9878
+  category: main
+  optional: false
+- name: ensureconda
+  version: 1.4.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    packaging: ''
+    filelock: ''
+    appdirs: ''
+    python: '>=3.9'
+    requests: '>=2'
+    click: '>=5.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: a18423d4b24e6480165a38f102ca8b49
+    sha256: 4efc864d9245a30f15bbc6eb12d06a5cf7a11d91d3e2c84630df1ce83f8b9878
+  category: main
+  optional: false
+- name: ensureconda
+  version: 1.4.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    packaging: ''
+    filelock: ''
+    appdirs: ''
+    python: '>=3.9'
+    requests: '>=2'
+    click: '>=5.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: a18423d4b24e6480165a38f102ca8b49
+    sha256: 4efc864d9245a30f15bbc6eb12d06a5cf7a11d91d3e2c84630df1ce83f8b9878
+  category: main
+  optional: false
+- name: epoxy
+  version: 1.5.10
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=10.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-h166bdaf_1.tar.bz2
+  hash:
+    md5: a089d06164afd2d511347d3f87214e0b
+    sha256: 1e58ee2ed0f4699be202f23d49b9644b499836230da7dd5b2f63e6766acff89e
+  category: dev
+  optional: true
+- name: epoxy
+  version: 1.5.10
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/epoxy-1.5.10-h5eb16cf_1.tar.bz2
+  hash:
+    md5: 721a46794b9ad1301115068189acb750
+    sha256: 0e344e8490237565a5685736421e06b47a1b46dee7151c0973dd48130f8e583a
+  category: dev
+  optional: true
+- name: epoxy
+  version: 1.5.10
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/epoxy-1.5.10-h1c322ee_1.tar.bz2
+  hash:
+    md5: 20dd7359a6052120d52e1e13b4c818b9
+    sha256: 8b93dbebab0fe12ece4767e6a2dc53a6600319ece0b8ba5121715f28c7b0f8d1
+  category: dev
+  optional: true
+- name: exceptiongroup
+  version: 1.2.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+  hash:
+    md5: a16662747cdeb9abbac74d0057cc976e
+    sha256: cbde2c64ec317118fc06b223c5fd87c8a680255e7348dd60e7b292d2e103e701
+  category: dev
+  optional: true
+- name: exceptiongroup
+  version: 1.2.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+  hash:
+    md5: a16662747cdeb9abbac74d0057cc976e
+    sha256: cbde2c64ec317118fc06b223c5fd87c8a680255e7348dd60e7b292d2e103e701
+  category: dev
+  optional: true
+- name: exceptiongroup
+  version: 1.2.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+  hash:
+    md5: a16662747cdeb9abbac74d0057cc976e
+    sha256: cbde2c64ec317118fc06b223c5fd87c8a680255e7348dd60e7b292d2e103e701
+  category: dev
+  optional: true
+- name: executing
+  version: 2.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: ef8b5fca76806159fc25b4f48d8737eb
+    sha256: 28d25ea375ebab4bf7479228f8430db20986187b04999136ff5c722ebd32eb60
+  category: dev
+  optional: true
+- name: executing
+  version: 2.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: ef8b5fca76806159fc25b4f48d8737eb
+    sha256: 28d25ea375ebab4bf7479228f8430db20986187b04999136ff5c722ebd32eb60
+  category: dev
+  optional: true
+- name: executing
+  version: 2.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: ef8b5fca76806159fc25b4f48d8737eb
+    sha256: 28d25ea375ebab4bf7479228f8430db20986187b04999136ff5c722ebd32eb60
+  category: dev
+  optional: true
+- name: expat
+  version: 2.6.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libexpat: 2.6.4
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.4-h5888daf_0.conda
+  hash:
+    md5: 1d6afef758879ef5ee78127eb4cd2c4a
+    sha256: 1848c7db9e264e3b8036ee133d570dd880422983cd20dd9585a505289606d276
+  category: main
+  optional: false
+- name: filelock
+  version: 3.17.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7f402b4a1007ee355bc50ce4d24d4a57
+    sha256: 006d7e5a0c17a6973596dd86bfc80d74ce541144d2aee2d22d46fd41df560a63
+  category: main
+  optional: false
+- name: filelock
+  version: 3.17.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7f402b4a1007ee355bc50ce4d24d4a57
+    sha256: 006d7e5a0c17a6973596dd86bfc80d74ce541144d2aee2d22d46fd41df560a63
+  category: main
+  optional: false
+- name: filelock
+  version: 3.17.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7f402b4a1007ee355bc50ce4d24d4a57
+    sha256: 006d7e5a0c17a6973596dd86bfc80d74ce541144d2aee2d22d46fd41df560a63
+  category: main
+  optional: false
+- name: flake8
+  version: 7.1.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    mccabe: '>=0.7.0,<0.8.0'
+    pycodestyle: '>=2.12.0,<2.13.0'
+    pyflakes: '>=3.2.0,<3.3.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/flake8-7.1.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: c43926857c0c7ba1a29c8c4a221a5e78
+    sha256: 0ae3828483668c892cf3e8d4d81cb1c47a9d2bf534766b8206f6e12ef48c843f
+  category: dev
+  optional: true
+- name: flake8
+  version: 7.1.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    mccabe: '>=0.7.0,<0.8.0'
+    pyflakes: '>=3.2.0,<3.3.0'
+    pycodestyle: '>=2.12.0,<2.13.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/flake8-7.1.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: c43926857c0c7ba1a29c8c4a221a5e78
+    sha256: 0ae3828483668c892cf3e8d4d81cb1c47a9d2bf534766b8206f6e12ef48c843f
+  category: dev
+  optional: true
+- name: flake8
+  version: 7.1.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    mccabe: '>=0.7.0,<0.8.0'
+    pyflakes: '>=3.2.0,<3.3.0'
+    pycodestyle: '>=2.12.0,<2.13.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/flake8-7.1.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: c43926857c0c7ba1a29c8c4a221a5e78
+    sha256: 0ae3828483668c892cf3e8d4d81cb1c47a9d2bf534766b8206f6e12ef48c843f
+  category: dev
+  optional: true
+- name: flask
+  version: 3.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    blinker: '>=1.9'
+    click: '>=8.1.3'
+    importlib-metadata: '>=3.6'
+    itsdangerous: '>=2.2'
+    jinja2: '>=3.1.2'
+    python: '>=3.9'
+    werkzeug: '>=3.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-3.1.0-pyhff2d567_0.conda
+  hash:
+    md5: 3963487fb67f4deb3e16728ad101da7c
+    sha256: 5eb604e7993c519d8ac5bfe9ce0a50709d4c502bafda4d38f0d4d54da2411a36
+  category: dev
+  optional: true
+- name: flask
+  version: 3.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    importlib-metadata: '>=3.6'
+    click: '>=8.1.3'
+    jinja2: '>=3.1.2'
+    blinker: '>=1.9'
+    itsdangerous: '>=2.2'
+    werkzeug: '>=3.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-3.1.0-pyhff2d567_0.conda
+  hash:
+    md5: 3963487fb67f4deb3e16728ad101da7c
+    sha256: 5eb604e7993c519d8ac5bfe9ce0a50709d4c502bafda4d38f0d4d54da2411a36
+  category: dev
+  optional: true
+- name: flask
+  version: 3.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    importlib-metadata: '>=3.6'
+    click: '>=8.1.3'
+    jinja2: '>=3.1.2'
+    blinker: '>=1.9'
+    itsdangerous: '>=2.2'
+    werkzeug: '>=3.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-3.1.0-pyhff2d567_0.conda
+  hash:
+    md5: 3963487fb67f4deb3e16728ad101da7c
+    sha256: 5eb604e7993c519d8ac5bfe9ce0a50709d4c502bafda4d38f0d4d54da2411a36
+  category: dev
+  optional: true
+- name: flask_cors
+  version: 4.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    flask: '>=0.9'
+    python: '>=3.6'
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/flask_cors-4.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: ee54b19f948680ed98645b3e5bee6e47
+    sha256: f7316ced92b144244c9a4e29cf18f4fc3cb2269c12f1e715905c91bb279f1c64
+  category: dev
+  optional: true
+- name: flask_cors
+  version: 4.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    six: ''
+    python: '>=3.6'
+    flask: '>=0.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/flask_cors-4.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: ee54b19f948680ed98645b3e5bee6e47
+    sha256: f7316ced92b144244c9a4e29cf18f4fc3cb2269c12f1e715905c91bb279f1c64
+  category: dev
+  optional: true
+- name: flask_cors
+  version: 4.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    six: ''
+    python: '>=3.6'
+    flask: '>=0.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/flask_cors-4.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: ee54b19f948680ed98645b3e5bee6e47
+    sha256: f7316ced92b144244c9a4e29cf18f4fc3cb2269c12f1e715905c91bb279f1c64
+  category: dev
+  optional: true
+- name: fmt
+  version: 11.0.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.0.2-h434a139_0.conda
+  hash:
+    md5: 995f7e13598497691c1dc476d889bc04
+    sha256: c620e2ab084948985ae9b8848d841f603e8055655513340e04b6cf129099b5ca
+  category: main
+  optional: false
+- name: fmt
+  version: 11.0.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libcxx: '>=16'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.2-py312h28f332c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/fmt-11.0.2-h3c5361c_0.conda
   hash:
-    md5: 4dbee036ef0d52ff63647f0fffa5bab2
-    sha256: 418b7e7d615687aaf2b879443653603fef4659f1d20b45ab50fcf85c656bfab0
-  category: dev
-  optional: true
-- name: debugpy
-  version: 1.8.2
+    md5: e8070546e8739040383f6774e0cd4033
+    sha256: 4502053d2556431caa3a606b527eb1e45967109d6c6ffe094f18c3134cf77db1
+  category: main
+  optional: false
+- name: fmt
+  version: 11.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=16'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.2-py312h5c2e7bc_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-11.0.2-h420ef59_0.conda
   hash:
-    md5: 868257c902dd31ae9b9db6ba78dd1fc6
-    sha256: 975fb000bc719db2802ea78a2eb8ad48ed7f71e347d300e5c4f38fa6331ce96f
-  category: dev
-  optional: true
-- name: decorator
-  version: 5.1.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-  category: dev
-  optional: true
-- name: decorator
-  version: 5.1.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-  category: dev
-  optional: true
-- name: decorator
-  version: 5.1.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-  category: dev
-  optional: true
-- name: distlib
-  version: 0.3.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: 2.7|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: db16c66b759a64dc5183d69cc3745a52
-    sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
-  category: main
-  optional: false
-- name: distlib
-  version: 0.3.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: 2.7|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: db16c66b759a64dc5183d69cc3745a52
-    sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
-  category: main
-  optional: false
-- name: distlib
-  version: 0.3.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: 2.7|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: db16c66b759a64dc5183d69cc3745a52
-    sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
-  category: main
-  optional: false
-- name: distro
-  version: 1.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: bbdb409974cd6cb30071b1d978302726
-    sha256: ae1c13d709c8001331b5b9345e4bcd77e9ae712d25f7958b2ebcbe0b068731b7
-  category: main
-  optional: false
-- name: distro
-  version: 1.9.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: bbdb409974cd6cb30071b1d978302726
-    sha256: ae1c13d709c8001331b5b9345e4bcd77e9ae712d25f7958b2ebcbe0b068731b7
-  category: main
-  optional: false
-- name: distro
-  version: 1.9.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: bbdb409974cd6cb30071b1d978302726
-    sha256: ae1c13d709c8001331b5b9345e4bcd77e9ae712d25f7958b2ebcbe0b068731b7
-  category: main
-  optional: false
-- name: docker-py
-  version: 7.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    paramiko: '>=2.4.3'
-    python: '>=3.8'
-    pywin32-on-windows: ''
-    requests: '>=2.26.0'
-    urllib3: '>=1.26.0'
-    websocket-client: '>=0.32.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3e547e36de765ca8f28a7623fb3f255a
-    sha256: eca0bf5605a6ce79021afa1cd234cc74093a239f86cd311872e4d9b0972b5a85
-  category: dev
-  optional: true
-- name: docker-py
-  version: 7.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    paramiko: '>=2.4.3'
-    python: '>=3.8'
-    pywin32-on-windows: ''
-    requests: '>=2.26.0'
-    urllib3: '>=1.26.0'
-    websocket-client: '>=0.32.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3e547e36de765ca8f28a7623fb3f255a
-    sha256: eca0bf5605a6ce79021afa1cd234cc74093a239f86cd311872e4d9b0972b5a85
-  category: dev
-  optional: true
-- name: docker-py
-  version: 7.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    paramiko: '>=2.4.3'
-    python: '>=3.8'
-    pywin32-on-windows: ''
-    requests: '>=2.26.0'
-    urllib3: '>=1.26.0'
-    websocket-client: '>=0.32.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3e547e36de765ca8f28a7623fb3f255a
-    sha256: eca0bf5605a6ce79021afa1cd234cc74093a239f86cd311872e4d9b0972b5a85
-  category: dev
-  optional: true
-- name: ecdsa
-  version: 0.19.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gmpy2: ''
-    python: '>=3.5'
-    six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ecdsa-0.19.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4a96a225a5901281397a42cc36cc7f6f
-    sha256: e7dce53c95da43ab94a97f292a3ce5805c9cdf4c4e000b529fe009d9f6c8ab2b
-  category: dev
-  optional: true
-- name: ecdsa
-  version: 0.19.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    gmpy2: ''
-    python: '>=3.5'
-    six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ecdsa-0.19.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4a96a225a5901281397a42cc36cc7f6f
-    sha256: e7dce53c95da43ab94a97f292a3ce5805c9cdf4c4e000b529fe009d9f6c8ab2b
-  category: dev
-  optional: true
-- name: ecdsa
-  version: 0.19.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    gmpy2: ''
-    python: '>=3.5'
-    six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ecdsa-0.19.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4a96a225a5901281397a42cc36cc7f6f
-    sha256: e7dce53c95da43ab94a97f292a3ce5805c9cdf4c4e000b529fe009d9f6c8ab2b
-  category: dev
-  optional: true
-- name: ensureconda
-  version: 1.4.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    appdirs: ''
-    click: '>=5.1'
-    filelock: ''
-    packaging: ''
-    python: '>=3.7'
-    requests: '>=2'
-  url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: e54a91c3a65491b13c68f7696425bac8
-    sha256: a115afdc676c95a17ab63bbda84b7b724bc8817ae54fa34f8991339252424959
-  category: main
-  optional: false
-- name: ensureconda
-  version: 1.4.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    appdirs: ''
-    click: '>=5.1'
-    filelock: ''
-    packaging: ''
-    python: '>=3.7'
-    requests: '>=2'
-  url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: e54a91c3a65491b13c68f7696425bac8
-    sha256: a115afdc676c95a17ab63bbda84b7b724bc8817ae54fa34f8991339252424959
-  category: main
-  optional: false
-- name: ensureconda
-  version: 1.4.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    appdirs: ''
-    click: '>=5.1'
-    filelock: ''
-    packaging: ''
-    python: '>=3.7'
-    requests: '>=2'
-  url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: e54a91c3a65491b13c68f7696425bac8
-    sha256: a115afdc676c95a17ab63bbda84b7b724bc8817ae54fa34f8991339252424959
-  category: main
-  optional: false
-- name: exceptiongroup
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-  hash:
-    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
-    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
-  category: dev
-  optional: true
-- name: exceptiongroup
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-  hash:
-    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
-    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
-  category: dev
-  optional: true
-- name: exceptiongroup
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-  hash:
-    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
-    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
-  category: dev
-  optional: true
-- name: executing
-  version: 2.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e16be50e378d8a4533b989035b196ab8
-    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
-  category: dev
-  optional: true
-- name: executing
-  version: 2.0.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e16be50e378d8a4533b989035b196ab8
-    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
-  category: dev
-  optional: true
-- name: executing
-  version: 2.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e16be50e378d8a4533b989035b196ab8
-    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
-  category: dev
-  optional: true
-- name: expat
-  version: 2.6.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libexpat: 2.6.2
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
-  hash:
-    md5: 53fb86322bdb89496d7579fe3f02fd61
-    sha256: 89916c536ae5b85bb8bf0cfa27d751e274ea0911f04e4a928744735c14ef5155
-  category: main
-  optional: false
-- name: expat
-  version: 2.6.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libexpat: 2.6.2
-  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.2-h73e2aa4_0.conda
-  hash:
-    md5: dc0882915da2ec74696ad87aa2350f27
-    sha256: 0fd1befb18d9d937358a90d5b8f97ac2402761e9d4295779cbad9d7adfb47976
-  category: main
-  optional: false
-- name: expat
-  version: 2.6.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libexpat: 2.6.2
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.2-hebf3989_0.conda
-  hash:
-    md5: de0cff0ec74f273c4b6aa281479906c3
-    sha256: 9ac22553a4d595d7e4c9ca9aa09a0b38da65314529a7a7008edc73d3f9e7904a
-  category: main
-  optional: false
-- name: filelock
-  version: 3.15.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0e7e4388e9d5283e22b35a9443bdbcc9
-    sha256: f78d9c0be189a77cb0c67d02f33005f71b89037a85531996583fb79ff3fe1a0a
-  category: main
-  optional: false
-- name: filelock
-  version: 3.15.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0e7e4388e9d5283e22b35a9443bdbcc9
-    sha256: f78d9c0be189a77cb0c67d02f33005f71b89037a85531996583fb79ff3fe1a0a
-  category: main
-  optional: false
-- name: filelock
-  version: 3.15.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0e7e4388e9d5283e22b35a9443bdbcc9
-    sha256: f78d9c0be189a77cb0c67d02f33005f71b89037a85531996583fb79ff3fe1a0a
-  category: main
-  optional: false
-- name: flake8
-  version: 7.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    mccabe: '>=0.7.0,<0.8.0'
-    pycodestyle: '>=2.12.0,<2.13.0'
-    pyflakes: '>=3.2.0,<3.3.0'
-    python: '>=3.8.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/flake8-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2bae9d19ae945a79d8bb32d3cab9109b
-    sha256: 4b2d443b6ca80de9721a9ba8e56b99871081e85bf04244924855ced8c8a3924c
-  category: dev
-  optional: true
-- name: flake8
-  version: 7.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    mccabe: '>=0.7.0,<0.8.0'
-    pycodestyle: '>=2.12.0,<2.13.0'
-    pyflakes: '>=3.2.0,<3.3.0'
-    python: '>=3.8.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/flake8-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2bae9d19ae945a79d8bb32d3cab9109b
-    sha256: 4b2d443b6ca80de9721a9ba8e56b99871081e85bf04244924855ced8c8a3924c
-  category: dev
-  optional: true
-- name: flake8
-  version: 7.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    mccabe: '>=0.7.0,<0.8.0'
-    pycodestyle: '>=2.12.0,<2.13.0'
-    pyflakes: '>=3.2.0,<3.3.0'
-    python: '>=3.8.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/flake8-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2bae9d19ae945a79d8bb32d3cab9109b
-    sha256: 4b2d443b6ca80de9721a9ba8e56b99871081e85bf04244924855ced8c8a3924c
-  category: dev
-  optional: true
-- name: flask
-  version: 3.0.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    blinker: '>=1.6.2'
-    click: '>=8.1.3'
-    importlib-metadata: '>=3.6.0'
-    itsdangerous: '>=2.1.2'
-    jinja2: '>=3.1.2'
-    python: '>=3.8'
-    werkzeug: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/flask-3.0.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: dcdb937144fa20d7757bf512db1ea769
-    sha256: 2fc508f656fe52cb2f9a69c9c62077934d6a81510256dbe85f95beb7d9620238
-  category: dev
-  optional: true
-- name: flask
-  version: 3.0.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    blinker: '>=1.6.2'
-    click: '>=8.1.3'
-    importlib-metadata: '>=3.6.0'
-    itsdangerous: '>=2.1.2'
-    jinja2: '>=3.1.2'
-    python: '>=3.8'
-    werkzeug: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/flask-3.0.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: dcdb937144fa20d7757bf512db1ea769
-    sha256: 2fc508f656fe52cb2f9a69c9c62077934d6a81510256dbe85f95beb7d9620238
-  category: dev
-  optional: true
-- name: flask
-  version: 3.0.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    blinker: '>=1.6.2'
-    click: '>=8.1.3'
-    importlib-metadata: '>=3.6.0'
-    itsdangerous: '>=2.1.2'
-    jinja2: '>=3.1.2'
-    python: '>=3.8'
-    werkzeug: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/flask-3.0.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: dcdb937144fa20d7757bf512db1ea769
-    sha256: 2fc508f656fe52cb2f9a69c9c62077934d6a81510256dbe85f95beb7d9620238
-  category: dev
-  optional: true
-- name: flask_cors
-  version: 4.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    flask: '>=0.9'
-    python: '>=3.6'
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/flask_cors-4.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ee54b19f948680ed98645b3e5bee6e47
-    sha256: f7316ced92b144244c9a4e29cf18f4fc3cb2269c12f1e715905c91bb279f1c64
-  category: dev
-  optional: true
-- name: flask_cors
-  version: 4.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    flask: '>=0.9'
-    python: '>=3.6'
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/flask_cors-4.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ee54b19f948680ed98645b3e5bee6e47
-    sha256: f7316ced92b144244c9a4e29cf18f4fc3cb2269c12f1e715905c91bb279f1c64
-  category: dev
-  optional: true
-- name: flask_cors
-  version: 4.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    flask: '>=0.9'
-    python: '>=3.6'
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/flask_cors-4.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ee54b19f948680ed98645b3e5bee6e47
-    sha256: f7316ced92b144244c9a4e29cf18f4fc3cb2269c12f1e715905c91bb279f1c64
-  category: dev
-  optional: true
-- name: fmt
-  version: 10.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fmt-10.2.1-h00ab1b0_0.conda
-  hash:
-    md5: 35ef8bc24bd34074ebae3c943d551728
-    sha256: 7b9ba098a3661e023c3555e01554354ac4891af8f8998e85f0fcbfdac79fc0d4
-  category: main
-  optional: false
-- name: fmt
-  version: 10.2.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/osx-64/fmt-10.2.1-h7728843_0.conda
-  hash:
-    md5: ab205d53bda43d03f5c5b993ccb406b3
-    sha256: 2faeccfe2b9f7c028cf271f66757365fe43b15a1234084c16f159646a646ccbc
-  category: main
-  optional: false
-- name: fmt
-  version: 10.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-10.2.1-h2ffa867_0.conda
-  hash:
-    md5: 8cccde6755bdd787f9840f38a34b4e7d
-    sha256: 8570ae6fb7cd1179c646e2c48105e91b3ed8ba15855f12965cc5c9719753c06f
+    md5: 0e44849fd4764e9f85ed8caa9f24c118
+    sha256: 62e6508d5bbde4aa36f7b7658ce2d8fdd0e509c0d1661735c1bd1bed00e070c4
   category: main
   optional: false
 - name: folium
-  version: 0.17.0
+  version: 0.19.4
   manager: conda
   platform: linux-64
   dependencies:
     branca: '>=0.6.0'
     jinja2: '>=2.9'
     numpy: ''
-    python: '>=3.8'
+    python: '>=3.9'
     requests: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.17.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.19.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 9b96a3e6e0473b5722fa4fbefcefcded
-    sha256: d5c4153cad0154112daf0db648afe82ad7930523e2cb9f7379bb2d148fac0537
+    md5: 5373736fc7c86a9681319b9511cc3973
+    sha256: 5db2c83bf48c2f1ea758e17a68cfb2ec691ad4a9bc4b196058917461be24b313
   category: main
   optional: false
 - name: folium
-  version: 0.17.0
+  version: 0.19.4
   manager: conda
   platform: osx-64
   dependencies:
-    branca: '>=0.6.0'
-    jinja2: '>=2.9'
     numpy: ''
-    python: '>=3.8'
     requests: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.17.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    jinja2: '>=2.9'
+    branca: '>=0.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.19.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 9b96a3e6e0473b5722fa4fbefcefcded
-    sha256: d5c4153cad0154112daf0db648afe82ad7930523e2cb9f7379bb2d148fac0537
+    md5: 5373736fc7c86a9681319b9511cc3973
+    sha256: 5db2c83bf48c2f1ea758e17a68cfb2ec691ad4a9bc4b196058917461be24b313
   category: main
   optional: false
 - name: folium
-  version: 0.17.0
+  version: 0.19.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    branca: '>=0.6.0'
-    jinja2: '>=2.9'
     numpy: ''
-    python: '>=3.8'
     requests: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.17.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    jinja2: '>=2.9'
+    branca: '>=0.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.19.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 9b96a3e6e0473b5722fa4fbefcefcded
-    sha256: d5c4153cad0154112daf0db648afe82ad7930523e2cb9f7379bb2d148fac0537
+    md5: 5373736fc7c86a9681319b9511cc3973
+    sha256: 5db2c83bf48c2f1ea758e17a68cfb2ec691ad4a9bc4b196058917461be24b313
   category: main
   optional: false
 - name: font-ttf-dejavu-sans-mono
@@ -4422,8 +4543,8 @@ package:
   hash:
     md5: 0c96522c6bdaed4b1566d11387caaf45
     sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-dejavu-sans-mono
   version: '2.37'
   manager: conda
@@ -4433,8 +4554,8 @@ package:
   hash:
     md5: 0c96522c6bdaed4b1566d11387caaf45
     sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-dejavu-sans-mono
   version: '2.37'
   manager: conda
@@ -4444,8 +4565,8 @@ package:
   hash:
     md5: 0c96522c6bdaed4b1566d11387caaf45
     sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-inconsolata
   version: '3.000'
   manager: conda
@@ -4455,8 +4576,8 @@ package:
   hash:
     md5: 34893075a5c9e55cdafac56607368fc6
     sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-inconsolata
   version: '3.000'
   manager: conda
@@ -4466,8 +4587,8 @@ package:
   hash:
     md5: 34893075a5c9e55cdafac56607368fc6
     sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-inconsolata
   version: '3.000'
   manager: conda
@@ -4477,8 +4598,8 @@ package:
   hash:
     md5: 34893075a5c9e55cdafac56607368fc6
     sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-source-code-pro
   version: '2.038'
   manager: conda
@@ -4488,8 +4609,8 @@ package:
   hash:
     md5: 4d59c254e01d9cde7957100457e2d5fb
     sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-source-code-pro
   version: '2.038'
   manager: conda
@@ -4499,8 +4620,8 @@ package:
   hash:
     md5: 4d59c254e01d9cde7957100457e2d5fb
     sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-source-code-pro
   version: '2.038'
   manager: conda
@@ -4510,85 +4631,88 @@ package:
   hash:
     md5: 4d59c254e01d9cde7957100457e2d5fb
     sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-ubuntu
   version: '0.83'
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
   hash:
-    md5: cbbe59391138ea5ad3658c76912e147f
-    sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
-  category: main
-  optional: false
+    md5: 49023d73832ef61042f6a237cb2687e7
+    sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+  category: dev
+  optional: true
 - name: font-ttf-ubuntu
   version: '0.83'
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
   hash:
-    md5: cbbe59391138ea5ad3658c76912e147f
-    sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
-  category: main
-  optional: false
+    md5: 49023d73832ef61042f6a237cb2687e7
+    sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+  category: dev
+  optional: true
 - name: font-ttf-ubuntu
   version: '0.83'
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
   hash:
-    md5: cbbe59391138ea5ad3658c76912e147f
-    sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
-  category: main
-  optional: false
+    md5: 49023d73832ef61042f6a237cb2687e7
+    sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+  category: dev
+  optional: true
 - name: fontconfig
-  version: 2.14.2
+  version: 2.15.0
   manager: conda
   platform: linux-64
   dependencies:
-    expat: '>=2.5.0,<3.0a0'
+    __glibc: '>=2.17,<3.0.a0'
     freetype: '>=2.12.1,<3.0a0'
-    libgcc-ng: '>=12'
-    libuuid: '>=2.32.1,<3.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+    libexpat: '>=2.6.3,<3.0a0'
+    libgcc: '>=13'
+    libuuid: '>=2.38.1,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
   hash:
-    md5: 0f69b688f52ff6da70bccb7ff7001d1d
-    sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
-  category: main
-  optional: false
+    md5: 8f5b0b297b59e1ac160ad4beec99dbee
+    sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
+  category: dev
+  optional: true
 - name: fontconfig
-  version: 2.14.2
+  version: 2.15.0
   manager: conda
   platform: osx-64
   dependencies:
-    expat: '>=2.5.0,<3.0a0'
+    __osx: '>=10.13'
     freetype: '>=2.12.1,<3.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+    libexpat: '>=2.6.3,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.15.0-h37eeddb_1.conda
   hash:
-    md5: 86cc5867dfbee4178118392bae4a3c89
-    sha256: f63e6d1d6aef8ba6de4fc54d3d7898a153479888d40ffdf2e4cfad6f92679d34
-  category: main
-  optional: false
+    md5: 84ccec5ee37eb03dd352db0a3f89ada3
+    sha256: 61a9aa1d2dd115ffc1ab372966dc8b1ac7b69870e6b1744641da276b31ea5c0b
+  category: dev
+  optional: true
 - name: fontconfig
-  version: 2.14.2
+  version: 2.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    expat: '>=2.5.0,<3.0a0'
+    __osx: '>=11.0'
     freetype: '>=2.12.1,<3.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+    libexpat: '>=2.6.3,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.15.0-h1383a14_1.conda
   hash:
-    md5: f77d47ddb6d3cc5b39b9bdf65635afbb
-    sha256: 7094917fc6758186e17c61d8ee8fd2bbbe9f303b4addac61d918fa415c497e2b
-  category: main
-  optional: false
+    md5: 7b29f48742cea5d1ccb5edd839cb5621
+    sha256: f79d3d816fafbd6a2b0f75ebc3251a30d3294b08af9bb747194121f5efa364bc
+  category: dev
+  optional: true
 - name: fonts-conda-ecosystem
   version: '1'
   manager: conda
@@ -4599,8 +4723,8 @@ package:
   hash:
     md5: fee5683a3f04bd15cbd8318b096a27ab
     sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fonts-conda-ecosystem
   version: '1'
   manager: conda
@@ -4611,8 +4735,8 @@ package:
   hash:
     md5: fee5683a3f04bd15cbd8318b096a27ab
     sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fonts-conda-ecosystem
   version: '1'
   manager: conda
@@ -4623,8 +4747,8 @@ package:
   hash:
     md5: fee5683a3f04bd15cbd8318b096a27ab
     sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fonts-conda-forge
   version: '1'
   manager: conda
@@ -4638,57 +4762,58 @@ package:
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
     sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fonts-conda-forge
   version: '1'
   manager: conda
   platform: osx-64
   dependencies:
-    font-ttf-dejavu-sans-mono: ''
+    font-ttf-ubuntu: ''
     font-ttf-inconsolata: ''
     font-ttf-source-code-pro: ''
-    font-ttf-ubuntu: ''
+    font-ttf-dejavu-sans-mono: ''
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
     sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fonts-conda-forge
   version: '1'
   manager: conda
   platform: osx-arm64
   dependencies:
-    font-ttf-dejavu-sans-mono: ''
+    font-ttf-ubuntu: ''
     font-ttf-inconsolata: ''
     font-ttf-source-code-pro: ''
-    font-ttf-ubuntu: ''
+    font-ttf-dejavu-sans-mono: ''
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
     sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fonttools
-  version: 4.53.1
+  version: 4.55.8
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     brotli: ''
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     munkres: ''
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.53.1-py312h41a817b_0.conda
+    unicodedata2: '>=15.1.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.55.8-py312h178313f_0.conda
   hash:
-    md5: da921c56bcf69a8b97216ecec0cc4015
-    sha256: b1d9f95c13b9caa26689875b0af654b7f464e273eea94abdf5b1be1baa6c8870
+    md5: 0fd0743b6d43989c07e41da61f67c41c
+    sha256: f1faed016e9452161e8e07177f7c97109f9db2e23c60fcbcde7c1de0b76e1d33
   category: main
   optional: false
 - name: fonttools
-  version: 4.53.1
+  version: 4.55.8
   manager: conda
   platform: osx-64
   dependencies:
@@ -4697,14 +4822,15 @@ package:
     munkres: ''
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.53.1-py312hbd25219_0.conda
+    unicodedata2: '>=15.1.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.55.8-py312h3520af0_0.conda
   hash:
-    md5: 56b85d2b2f034ed31feaaa0b90c37b7f
-    sha256: bfb83e8a6e95e7d50880cd4811e2312e315d7e8b95b99a405f4056c3162e6ee2
+    md5: b6bdcc7cad1bc4c4e762ec15dd238308
+    sha256: 3ff84d883e5abd275f28e1a6aa59bbedaf83fe4f62812ad07d5614254773a4aa
   category: main
   optional: false
 - name: fonttools
-  version: 4.53.1
+  version: 4.55.8
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4713,10 +4839,11 @@ package:
     munkres: ''
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.53.1-py312h7e5086c_0.conda
+    unicodedata2: '>=15.1.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.55.8-py312h998013c_0.conda
   hash:
-    md5: a8a42a73e820792f338b5cf220dab07e
-    sha256: 981798c317c040bbfecce20f1d0da7c29ca26988fa6940d0310f095a8ce694b2
+    md5: e1088958da94d366609f11bea9fd2e22
+    sha256: 2b916b50259a32963ac8538cb6168a32dfc3f3ad8aca60128c3761f949354307
   category: main
   optional: false
 - name: freetype
@@ -4764,14 +4891,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libexpat: '>=2.5.0,<3.0a0'
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
     libiconv: '>=1.17,<2.0a0'
-    minizip: '>=4.0.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
+    minizip: '>=4.0.7,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
   hash:
-    md5: 12e6988845706b2cfbc3bc35c9a61a95
-    sha256: 9213f60ba710ecfd3632ce47e036775c9f15ce80a6682ff63cbf12d9dddd5382
+    md5: ecb5d11305b8ba1801543002e69d2f2f
+    sha256: c8960e00a6db69b85c16c693ce05484facf20f1a80430552145f652a880e0d2a
   category: main
   optional: false
 - name: freexl
@@ -4779,13 +4907,14 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    libexpat: '>=2.5.0,<3.0a0'
+    __osx: '>=10.13'
+    libexpat: '>=2.6.4,<3.0a0'
     libiconv: '>=1.17,<2.0a0'
-    minizip: '>=4.0.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
+    minizip: '>=4.0.7,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
   hash:
-    md5: 640c34a8084e2a812bcee5b804597fc9
-    sha256: 9d59f1894c3b526e6806e376e979b81d0df23a836415122b86458aef72cda24a
+    md5: 5cb34c1d2ed89fd36f4e3759c966daf0
+    sha256: cf924a5373def22030f73435082efbb3efb1039faeec926b006fb53a6f738f7c
   category: main
   optional: false
 - name: freexl
@@ -4793,13 +4922,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    libexpat: '>=2.5.0,<3.0a0'
+    __osx: '>=11.0'
+    libexpat: '>=2.6.4,<3.0a0'
     libiconv: '>=1.17,<2.0a0'
-    minizip: '>=4.0.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-hfbad9fb_0.conda
+    minizip: '>=4.0.7,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
   hash:
-    md5: 40722e5f48287567cda6fb2ec1f7891b
-    sha256: 9cb4957d1431bc57bc95b1e99a50669d91ac3441226a78f69fa030d52f2bda77
+    md5: dd655a29b40fe0d1bf95c64cf3cb348d
+    sha256: b4146ac9ba1676494e3d812ca39664dd7dd454e4d0984f3665fd6feec318c71c
   category: main
   optional: false
 - name: fribidi
@@ -4837,182 +4967,125 @@ package:
   category: dev
   optional: true
 - name: frozendict
-  version: 2.4.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/frozendict-2.4.4-py312h9a8786e_0.conda
-  hash:
-    md5: ff14ec1103a0817d45e7cf012742ce60
-    sha256: dff551db65137898c1434c4949532a91b997de6a1e77f255216da2c404b04f2f
-  category: main
-  optional: false
-- name: frozendict
-  version: 2.4.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.4-py312hbd25219_0.conda
-  hash:
-    md5: bd7e1462b89760bb59c5d7e636f6d9d2
-    sha256: 735d87670e8f2344d08fa9da819f7be6793fcd4b31b0e868fd4cf0a907d2a5e4
-  category: main
-  optional: false
-- name: frozendict
-  version: 2.4.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.4-py312h7e5086c_0.conda
-  hash:
-    md5: f37df12758d31904693c9087e4841ac9
-    sha256: 59a24e2c4af865022dbc80ae5508a5ff2d62c9859923eec8d7d5fa4f73a1dd69
-  category: main
-  optional: false
-- name: frozenlist
-  version: 1.4.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py312h98912ed_0.conda
-  hash:
-    md5: 2715764dfa5fb00343e03d5a59b64582
-    sha256: ad36b190476451b366e55a43430673ab9aeb1bfc128cad7245226d92373be450
-  category: main
-  optional: false
-- name: frozenlist
-  version: 1.4.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.4.1-py312h41838bb_0.conda
-  hash:
-    md5: 2057c85ac7062a3acf8a66af2523e6bf
-    sha256: 0b8160b6cbfb92a63afee33640ea4e8174e8f6374b1baa55086b0f50d9477c64
-  category: main
-  optional: false
-- name: frozenlist
-  version: 1.4.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.4.1-py312he37b823_0.conda
-  hash:
-    md5: 6cf2f14438b53376e9e1a4e75b44935c
-    sha256: c51735c67461632ff8bc0bbf5a3d0b389b8e9e4686a13642a010dcb514954e35
-  category: main
-  optional: false
-- name: fsspec
-  version: 2024.6.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
-  hash:
-    md5: 996bf792cdb8c0ac38ff54b9fde56841
-    sha256: 2b8e98294c70d9a33ee0ef27539a8a8752a26efeafa0225e85dc876ef5bb49f4
-  category: main
-  optional: false
-- name: fsspec
-  version: 2024.6.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
-  hash:
-    md5: 996bf792cdb8c0ac38ff54b9fde56841
-    sha256: 2b8e98294c70d9a33ee0ef27539a8a8752a26efeafa0225e85dc876ef5bb49f4
-  category: main
-  optional: false
-- name: fsspec
-  version: 2024.6.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
-  hash:
-    md5: 996bf792cdb8c0ac38ff54b9fde56841
-    sha256: 2b8e98294c70d9a33ee0ef27539a8a8752a26efeafa0225e85dc876ef5bb49f4
-  category: main
-  optional: false
-- name: gdal
-  version: 3.9.1
+  version: 2.4.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libgcc-ng: '>=12'
-    libgdal: 3.9.1
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.7,<3.0a0'
-    numpy: '>=1.19,<3'
-    openssl: '>=3.3.1,<4.0a0'
+    libgcc: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.1-py312h86af8fa_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/frozendict-2.4.6-py312h66e93f0_0.conda
   hash:
-    md5: c39ce48769813bd85174fcdfd4e5f806
-    sha256: 37912e310ed07e274bb62d2c47a67d1a9d512eead5ce57de83b0494791b97232
+    md5: 9fa8408745a0621314b7751d11fecc18
+    sha256: a251569d25e9658f87406efda6640e2816659c5d4dd244d1008bb789793cf32e
   category: main
   optional: false
-- name: gdal
-  version: 3.9.1
+- name: frozendict
+  version: 2.4.6
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libcxx: '>=16'
-    libgdal: 3.9.1
-    libxml2: '>=2.12.7,<3.0a0'
-    numpy: '>=1.19,<3'
-    openssl: '>=3.3.1,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.9.1-py312h9b1be66_5.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.6-py312h3d0f464_0.conda
   hash:
-    md5: 8b1661fe468d730194317c826d1745d3
-    sha256: e8b4d43e17535bea63a6814b9192869af74c55ae0925c49e2a6ae8430286fbab
+    md5: 58a8d9e016adc22964bfb0b9a5272e16
+    sha256: ea617933e456f78905682cbed90692ba698524280955f6ff21be0905d8f0cd43
   category: main
   optional: false
-- name: gdal
-  version: 3.9.1
+- name: frozendict
+  version: 2.4.6
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libcxx: '>=16'
-    libgdal: 3.9.1
-    libxml2: '>=2.12.7,<3.0a0'
-    numpy: '>=1.19,<3'
-    openssl: '>=3.3.1,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.9.1-py312hf4c14af_5.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.6-py312h0bf5046_0.conda
   hash:
-    md5: c79e90e82d26de6ddab283284603a368
-    sha256: d6e20d6de2fb574524e57ab2dffab3a012899f753f1c6b558e86f11646371a6f
+    md5: 22df6d6ec0345fc46182ce47e7ee8e24
+    sha256: 357cef10885bd2fb5d5d3197a8565d0c0b86fffd0dbaff58acee29f7d897a935
+  category: main
+  optional: false
+- name: frozenlist
+  version: 1.5.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.5.0-py312h178313f_1.conda
+  hash:
+    md5: fb986e1c089021979dc79606af78ef8f
+    sha256: 501e20626798b6d7f130f4db0fb02c0385d8f4c11ca525925602a4208afb343f
+  category: main
+  optional: false
+- name: frozenlist
+  version: 1.5.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.5.0-py312h3520af0_1.conda
+  hash:
+    md5: 887a4fa613758220fff7641b9d3ead95
+    sha256: 332d78beaec0ab79f176656e71b819d75bb72a9a9c99bb1dc0387c7f0c34f016
+  category: main
+  optional: false
+- name: frozenlist
+  version: 1.5.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.5.0-py312h998013c_1.conda
+  hash:
+    md5: 5eb3715c7e3fa9b533361375bfefe6ee
+    sha256: d503ac8c050abdbd129253973f23be34944978d510de78ef5a3e6aa1e3d9552d
+  category: main
+  optional: false
+- name: fsspec
+  version: 2024.12.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.12.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: e041ad4c43ab5e10c74587f95378ebc7
+    sha256: 3320970c4604989eadf908397a9475f9e6a96a773c185915111399cbfbe47817
+  category: main
+  optional: false
+- name: fsspec
+  version: 2024.12.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.12.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: e041ad4c43ab5e10c74587f95378ebc7
+    sha256: 3320970c4604989eadf908397a9475f9e6a96a773c185915111399cbfbe47817
+  category: main
+  optional: false
+- name: fsspec
+  version: 2024.12.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.12.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: e041ad4c43ab5e10c74587f95378ebc7
+    sha256: 3320970c4604989eadf908397a9475f9e6a96a773c185915111399cbfbe47817
   category: main
   optional: false
 - name: gdk-pixbuf
@@ -5024,7 +5097,7 @@ package:
     libglib: '>=2.80.2,<3.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libtiff: '>=4.6.0,<4.8.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
   hash:
     md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
@@ -5041,7 +5114,7 @@ package:
     libintl: '>=0.22.5,<1.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libtiff: '>=4.6.0,<4.8.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-64/gdk-pixbuf-2.42.12-ha587570_0.conda
   hash:
     md5: ee186d2e8db4605030753dc05025d4a0
@@ -5058,7 +5131,7 @@ package:
     libintl: '>=0.22.5,<1.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libtiff: '>=4.6.0,<4.8.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.42.12-h7ddc832_0.conda
   hash:
     md5: 151309a7e1eb57a3c2ab8088a1d74f3e
@@ -5070,11 +5143,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 6b1f32359fc5d2ab7b491d0029bfffeb
-    sha256: a158e9430662daa29609da21f5d9f18d2093ef37b357c1b594c6f27545aaff3e
+    md5: 8b9328ab4aafb8fde493ab32c5eba731
+    sha256: 933064eaaac79ceadef948223873c433eb5375b8445264cbe569d34035ab4e20
   category: dev
   optional: true
 - name: geographiclib
@@ -5082,11 +5155,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 6b1f32359fc5d2ab7b491d0029bfffeb
-    sha256: a158e9430662daa29609da21f5d9f18d2093ef37b357c1b594c6f27545aaff3e
+    md5: 8b9328ab4aafb8fde493ab32c5eba731
+    sha256: 933064eaaac79ceadef948223873c433eb5375b8445264cbe569d34035ab4e20
   category: dev
   optional: true
 - name: geographiclib
@@ -5094,11 +5167,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 6b1f32359fc5d2ab7b491d0029bfffeb
-    sha256: a158e9430662daa29609da21f5d9f18d2093ef37b357c1b594c6f27545aaff3e
+    md5: 8b9328ab4aafb8fde493ab32c5eba731
+    sha256: 933064eaaac79ceadef948223873c433eb5375b8445264cbe569d34035ab4e20
   category: dev
   optional: true
 - name: geopandas
@@ -5114,10 +5187,10 @@ package:
     pyproj: '>=3.3.0'
     python: '>=3.9'
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_3.conda
   hash:
-    md5: efef4ce75a678216d510d08222845c7f
-    sha256: 6d3f8148d88b1f2c100e03fce441f19577f6a4b69e3a2c57d522b48010d84f5f
+    md5: 1baca589eb35814a392eaad6d152447e
+    sha256: 04f7e616ebbf6352ff852b53c57901e43f14e2b3c92411f99b5547f106bc192e
   category: main
   optional: false
 - name: geopandas
@@ -5125,18 +5198,18 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    folium: ''
-    geopandas-base: 1.0.1
-    mapclassify: '>=2.4.0'
     matplotlib-base: ''
-    pyogrio: '>=0.7.2'
-    pyproj: '>=3.3.0'
-    python: '>=3.9'
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
+    folium: ''
+    python: '>=3.9'
+    pyproj: '>=3.3.0'
+    mapclassify: '>=2.4.0'
+    pyogrio: '>=0.7.2'
+    geopandas-base: 1.0.1
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_3.conda
   hash:
-    md5: efef4ce75a678216d510d08222845c7f
-    sha256: 6d3f8148d88b1f2c100e03fce441f19577f6a4b69e3a2c57d522b48010d84f5f
+    md5: 1baca589eb35814a392eaad6d152447e
+    sha256: 04f7e616ebbf6352ff852b53c57901e43f14e2b3c92411f99b5547f106bc192e
   category: main
   optional: false
 - name: geopandas
@@ -5144,18 +5217,18 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    folium: ''
-    geopandas-base: 1.0.1
-    mapclassify: '>=2.4.0'
     matplotlib-base: ''
-    pyogrio: '>=0.7.2'
-    pyproj: '>=3.3.0'
-    python: '>=3.9'
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
+    folium: ''
+    python: '>=3.9'
+    pyproj: '>=3.3.0'
+    mapclassify: '>=2.4.0'
+    pyogrio: '>=0.7.2'
+    geopandas-base: 1.0.1
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_3.conda
   hash:
-    md5: efef4ce75a678216d510d08222845c7f
-    sha256: 6d3f8148d88b1f2c100e03fce441f19577f6a4b69e3a2c57d522b48010d84f5f
+    md5: 1baca589eb35814a392eaad6d152447e
+    sha256: 04f7e616ebbf6352ff852b53c57901e43f14e2b3c92411f99b5547f106bc192e
   category: main
   optional: false
 - name: geopandas-base
@@ -5168,10 +5241,10 @@ package:
     pandas: '>=1.4.0'
     python: '>=3.9'
     shapely: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_3.conda
   hash:
-    md5: 1b7d46173c29e14dde41f97cf5aa61df
-    sha256: b07d76f79cc3b1dc7f5a73aeeb0f7c9977526d73237df7e200582fdff48045d1
+    md5: e8343d1b635bf09dafdd362d7357f395
+    sha256: 2d031871b57c6d4e5e2d6cc23bd6d4e0084bb52ebca5c1b20bf06d03749e0f24
   category: main
   optional: false
 - name: geopandas-base
@@ -5179,15 +5252,15 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    numpy: '>=1.22'
     packaging: ''
-    pandas: '>=1.4.0'
     python: '>=3.9'
+    numpy: '>=1.22'
+    pandas: '>=1.4.0'
     shapely: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_3.conda
   hash:
-    md5: 1b7d46173c29e14dde41f97cf5aa61df
-    sha256: b07d76f79cc3b1dc7f5a73aeeb0f7c9977526d73237df7e200582fdff48045d1
+    md5: e8343d1b635bf09dafdd362d7357f395
+    sha256: 2d031871b57c6d4e5e2d6cc23bd6d4e0084bb52ebca5c1b20bf06d03749e0f24
   category: main
   optional: false
 - name: geopandas-base
@@ -5195,15 +5268,15 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    numpy: '>=1.22'
     packaging: ''
-    pandas: '>=1.4.0'
     python: '>=3.9'
+    numpy: '>=1.22'
+    pandas: '>=1.4.0'
     shapely: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_3.conda
   hash:
-    md5: 1b7d46173c29e14dde41f97cf5aa61df
-    sha256: b07d76f79cc3b1dc7f5a73aeeb0f7c9977526d73237df7e200582fdff48045d1
+    md5: e8343d1b635bf09dafdd362d7357f395
+    sha256: 2d031871b57c6d4e5e2d6cc23bd6d4e0084bb52ebca5c1b20bf06d03749e0f24
   category: main
   optional: false
 - name: geopy
@@ -5212,11 +5285,11 @@ package:
   platform: linux-64
   dependencies:
     geographiclib: '>=1.52'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_2.conda
   hash:
-    md5: 358c17429c97883b2cb9ab5f64bc161b
-    sha256: 24fce5e30307da0e7961a1e37f64eea4bc060b1496e7a84d1c44ba9ad7c4bfb6
+    md5: 40182a8d62a61d147ec7d3e4c5c36ac2
+    sha256: ac453c9558c48febe452c79281c632b3749baef7c04ed4b62f871709aee2aa03
   category: dev
   optional: true
 - name: geopy
@@ -5224,12 +5297,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.9'
     geographiclib: '>=1.52'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_2.conda
   hash:
-    md5: 358c17429c97883b2cb9ab5f64bc161b
-    sha256: 24fce5e30307da0e7961a1e37f64eea4bc060b1496e7a84d1c44ba9ad7c4bfb6
+    md5: 40182a8d62a61d147ec7d3e4c5c36ac2
+    sha256: ac453c9558c48febe452c79281c632b3749baef7c04ed4b62f871709aee2aa03
   category: dev
   optional: true
 - name: geopy
@@ -5237,51 +5310,52 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.9'
     geographiclib: '>=1.52'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_2.conda
   hash:
-    md5: 358c17429c97883b2cb9ab5f64bc161b
-    sha256: 24fce5e30307da0e7961a1e37f64eea4bc060b1496e7a84d1c44ba9ad7c4bfb6
+    md5: 40182a8d62a61d147ec7d3e4c5c36ac2
+    sha256: ac453c9558c48febe452c79281c632b3749baef7c04ed4b62f871709aee2aa03
   category: dev
   optional: true
 - name: geos
-  version: 3.12.2
+  version: 3.13.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/geos-3.12.2-hac33072_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.0-h5888daf_0.conda
   hash:
-    md5: 621d814955342209dc8e7f87c41f1ba0
-    sha256: 8ccddcf6263f972122d2ea7388b881194dcd9bc8e1092b4440b7a7572c65b226
+    md5: 40b4ab956c90390e407bb177f8a58bab
+    sha256: 5c70d6d16e044859edca85feb9d4f1c3c6062aaf88d650826f5ccdf8c44336de
   category: main
   optional: false
 - name: geos
-  version: 3.12.2
+  version: 3.13.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.2-hf036a51_0.conda
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-64/geos-3.13.0-hac325c4_0.conda
   hash:
-    md5: 69d6f60244f3a1fa8cfc34a9be856f19
-    sha256: 43f959ac8f463b78a66cd6c2fd772bf68228e360559e74e774150aa2541b1f52
+    md5: 905fbe84dd83254e4e0db610123dd32d
+    sha256: 7e3201780fda37f23623e384557eb66047942db1c2fe0a7453c0caf301ec8bbb
   category: main
   optional: false
 - name: geos
-  version: 3.12.2
+  version: 3.13.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.12.2-h00cdb27_0.conda
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.0-hf9b8971_0.conda
   hash:
-    md5: 9fbc852def80f2d9861be720920e9706
-    sha256: dd763dbafab15d06dbb0995dd2d3f72a49539b00f4325cebb31dd8c89bc5bfdf
+    md5: 45b2e9adb9663644b1eefa5300b9eef3
+    sha256: 273381020b72bde1597d4e07e855ed50ffac083512e61ccbdd99d93f03c6cbf2
   category: main
   optional: false
 - name: geotiff
@@ -5290,17 +5364,17 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libstdcxx: '>=13'
+    libtiff: '>=4.6.0,<4.8.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    proj: '>=9.4.0,<9.5.0a0'
+    proj: '>=9.5.0,<9.6.0a0'
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-hf7fa9e8_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-h77b800c_3.conda
   hash:
-    md5: 8ff4fa3ab0b63dc5b214a68839499e41
-    sha256: df00139c22b1b2ab1e1e48bb94c68febcc40a7ca812bd4f228a3e09ac9d2cdf2
+    md5: 4eb52aecb43e7c72f8e4fca0c386354e
+    sha256: 94c7d002c70a4802a78ac2925ad6b36327cff85e0af6af2825b11a968c81ec20
   category: main
   optional: false
 - name: geotiff
@@ -5309,16 +5383,16 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcxx: '>=16'
+    libcxx: '>=17'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libtiff: '>=4.6.0,<4.8.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    proj: '>=9.4.0,<9.5.0a0'
+    proj: '>=9.5.0,<9.6.0a0'
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.3-h4bbec01_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.3-h2b6e260_3.conda
   hash:
-    md5: 94b592c68bb826b1ffee62524b117aa2
-    sha256: 7f5c0d021822e12cd64848caa77d43398cea90381f420d6f973877f3eccc2188
+    md5: bbc58a544b03990b3bc8c2139cc6c34f
+    sha256: 7e58d94340a499c3c62022ba070231f1dcc7c55a98f8f2a7e982d2071dfd421c
   category: main
   optional: false
 - name: geotiff
@@ -5327,95 +5401,30 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
+    libcxx: '>=17'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libtiff: '>=4.6.0,<4.8.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    proj: '>=9.4.0,<9.5.0a0'
+    proj: '>=9.5.0,<9.6.0a0'
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.3-h7e5fb84_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.3-h82bf549_3.conda
   hash:
-    md5: 5e689f0ec059ec6fa91deb388f4d9510
-    sha256: d25259c84a706a2bf9568c96b68e198a1155c8761b6788fe00d4b15ca21f12f7
+    md5: cb84033d7c167a16c4577272b4493bc5
+    sha256: 7ce4d6dced3cd313ea170db69d6929b88d77ebd40715f9f38c3bcba3633d6c65
   category: main
   optional: false
-- name: gettext
-  version: 0.22.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    gettext-tools: 0.22.5
-    libasprintf: 0.22.5
-    libasprintf-devel: 0.22.5
-    libcxx: '>=16'
-    libgettextpo: 0.22.5
-    libgettextpo-devel: 0.22.5
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-    libintl-devel: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.22.5-h5ff76d1_2.conda
-  hash:
-    md5: c09b3dcf2adc5a2a32d11ab90289b8fa
-    sha256: ba9a4680b018a4ca517ec20beb25b09c97e293ecd16b931075e689db10291712
-  category: dev
-  optional: true
-- name: gettext
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    gettext-tools: 0.22.5
-    libasprintf: 0.22.5
-    libasprintf-devel: 0.22.5
-    libcxx: '>=16'
-    libgettextpo: 0.22.5
-    libgettextpo-devel: 0.22.5
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-    libintl-devel: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.22.5-h8fbad5d_2.conda
-  hash:
-    md5: 404e2894e9cb2835246cef47317ff763
-    sha256: 7188b466071698759b125aaed9b4d78940e72e6299b0c6dbad6f35c85cf3d27b
-  category: dev
-  optional: true
-- name: gettext-tools
-  version: 0.22.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-tools-0.22.5-h5ff76d1_2.conda
-  hash:
-    md5: 37e1cb0efeff4d4623a6357e37e0105d
-    sha256: 4db71a66340d068c57e16c574c356db6df54ac0147b5b26d3313093f7854ee6d
-  category: dev
-  optional: true
-- name: gettext-tools
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.22.5-h8fbad5d_2.conda
-  hash:
-    md5: 31117a80d73f4fac856ab09fd9f3c6b5
-    sha256: f60d1671e30ac60598396c11fcec4426f7ddb281bf9e37af2262016b4d812cce
-  category: dev
-  optional: true
 - name: gflags
   version: 2.2.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-    libstdcxx-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
   hash:
-    md5: cddaf2c63ea4a5901cf09524c490ecdc
-    sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
+    md5: d411fc29e338efb48c5fd4576d71d881
+    sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
   category: main
   optional: false
 - name: gflags
@@ -5423,11 +5432,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=10.0.1'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+    __osx: '>=10.13'
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
   hash:
-    md5: 3f59cc77a929537e42120faf104e0d16
-    sha256: 39540f879057ae529cad131644af111a8c3c48b384ec6212de6a5381e0863948
+    md5: a26de8814083a6971f14f9c8c3cb36c2
+    sha256: c0bea66f71a6f4baa8d4f0248e17f65033d558d9e882c0af571b38bcca3e4b46
   category: main
   optional: false
 - name: gflags
@@ -5435,11 +5445,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=11.0.0.rc1'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
+    __osx: '>=11.0'
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
   hash:
-    md5: aab9ddfad863e9ef81229a1f8852211b
-    sha256: 25d4a20af2e5ace95fdec88970f6d190e77e20074d2f6d3cef766198b76a4289
+    md5: 57a511a5905caa37540eb914dfcbf1fb
+    sha256: fd56ed8a1dab72ab90d8a8929b6f916a6d9220ca297ff077f8f04c5ed3408e20
   category: main
   optional: false
 - name: giflib
@@ -5477,86 +5488,128 @@ package:
   category: main
   optional: false
 - name: gitdb
-  version: 4.0.11
+  version: 4.0.12
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     smmap: '>=3.0.1,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
   hash:
-    md5: 623b19f616f2ca0c261441067e18ae40
-    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
+    md5: 7c14f3706e099f8fcd47af2d494616cc
+    sha256: dbbec21a369872c8ebe23cb9a3b9d63638479ee30face165aa0fccc96e93eec3
   category: main
   optional: false
 - name: gitdb
-  version: 4.0.11
+  version: 4.0.12
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     smmap: '>=3.0.1,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
   hash:
-    md5: 623b19f616f2ca0c261441067e18ae40
-    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
+    md5: 7c14f3706e099f8fcd47af2d494616cc
+    sha256: dbbec21a369872c8ebe23cb9a3b9d63638479ee30face165aa0fccc96e93eec3
   category: main
   optional: false
 - name: gitdb
-  version: 4.0.11
+  version: 4.0.12
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     smmap: '>=3.0.1,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
   hash:
-    md5: 623b19f616f2ca0c261441067e18ae40
-    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
+    md5: 7c14f3706e099f8fcd47af2d494616cc
+    sha256: dbbec21a369872c8ebe23cb9a3b9d63638479ee30face165aa0fccc96e93eec3
   category: main
   optional: false
 - name: gitpython
-  version: 3.1.43
+  version: 3.1.44
   manager: conda
   platform: linux-64
   dependencies:
     gitdb: '>=4.0.1,<5'
-    python: '>=3.7'
+    python: '>=3.9'
     typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.44-pyhff2d567_0.conda
   hash:
-    md5: 0b2154c1818111e17381b1df5b4b0176
-    sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
+    md5: 140a4e944f7488467872e562a2a52789
+    sha256: b996e717ca693e4e831d3d3143aca3abb47536561306195002b226fe4dde53c3
   category: main
   optional: false
 - name: gitpython
-  version: 3.1.43
+  version: 3.1.44
   manager: conda
   platform: osx-64
   dependencies:
-    gitdb: '>=4.0.1,<5'
-    python: '>=3.7'
+    python: '>=3.9'
     typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
+    gitdb: '>=4.0.1,<5'
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.44-pyhff2d567_0.conda
   hash:
-    md5: 0b2154c1818111e17381b1df5b4b0176
-    sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
+    md5: 140a4e944f7488467872e562a2a52789
+    sha256: b996e717ca693e4e831d3d3143aca3abb47536561306195002b226fe4dde53c3
   category: main
   optional: false
 - name: gitpython
-  version: 3.1.43
+  version: 3.1.44
   manager: conda
   platform: osx-arm64
   dependencies:
-    gitdb: '>=4.0.1,<5'
-    python: '>=3.7'
+    python: '>=3.9'
     typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
+    gitdb: '>=4.0.1,<5'
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.44-pyhff2d567_0.conda
   hash:
-    md5: 0b2154c1818111e17381b1df5b4b0176
-    sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
+    md5: 140a4e944f7488467872e562a2a52789
+    sha256: b996e717ca693e4e831d3d3143aca3abb47536561306195002b226fe4dde53c3
   category: main
   optional: false
+- name: glib-tools
+  version: 2.82.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libglib: 2.82.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.82.2-h4833e2c_1.conda
+  hash:
+    md5: e2e44caeaef6e4b107577aa46c95eb12
+    sha256: 5d8a48abdb1bc2b54f1380d2805cb9cd6cd9609ed0e5c3ed272aef92ab53b190
+  category: dev
+  optional: true
+- name: glib-tools
+  version: 2.82.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libglib: 2.82.2
+    libintl: '>=0.22.5,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.82.2-hf8faeaf_1.conda
+  hash:
+    md5: 9c64be7c2dbbdde429d12a84c538ef1e
+    sha256: d626c650d320ca14c259a7aa12283c452b3ca1e58191c29b820001725822285e
+  category: dev
+  optional: true
+- name: glib-tools
+  version: 2.82.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libglib: 2.82.2
+    libintl: '>=0.22.5,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.82.2-h1dc7a0c_1.conda
+  hash:
+    md5: bdc35b7b75b7cd2bcfd288e399333f29
+    sha256: b6874fea5674855149f929899126e4298d020945f3d9c6a7955d14ede1855e3a
+  category: dev
+  optional: true
 - name: glog
   version: 0.7.1
   manager: conda
@@ -5643,16 +5696,17 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     gmp: '>=6.3.0,<7.0a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     mpc: '>=1.3.1,<2.0a0'
     mpfr: '>=4.2.1,<5.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.1.5-py312h1d5cde6_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.1.5-py312h7201bc8_3.conda
   hash:
-    md5: 27abd7664bc87595bd98b6306b8393d1
-    sha256: afe8fd8bacbb345bdeba6ae275dba6bda6ce9f5f7e1a0c658fff40373fae4654
+    md5: 673ef4d6611f5b4ca7b5c1f8c65a38dc
+    sha256: addd0bc226ca86c11f1223ab322d12b67501c2b3d93749bdab2068ccaedd8ef0
   category: dev
   optional: true
 - name: gmpy2
@@ -5660,16 +5714,16 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.9'
+    __osx: '>=10.13'
     gmp: '>=6.3.0,<7.0a0'
     mpc: '>=1.3.1,<2.0a0'
     mpfr: '>=4.2.1,<5.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/gmpy2-2.1.5-py312hd98c385_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmpy2-2.1.5-py312h068713c_3.conda
   hash:
-    md5: 61eb95ccf29fae77bc94a70fd8acbd22
-    sha256: 23066e588d3e371c556e5439c1df3399f267c633f85d3b76c6aca9584e634398
+    md5: 02d900885f1af6fcf7646fdf847cad3b
+    sha256: 5f3411b2520ec3a27e6047a0fae057d37cb9caf035e196f85c888320d473ce1e
   category: dev
   optional: true
 - name: gmpy2
@@ -5683,10 +5737,10 @@ package:
     mpfr: '>=4.2.1,<5.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.1.5-py312hfa9fade_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.1.5-py312h524cf62_3.conda
   hash:
-    md5: fe03ded0dd16d91a42d7467e9c1457f1
-    sha256: a8b23b61b0c217d765528849c9c2377fe1967a266d786c3646588bfb1c9a792c
+    md5: ab7a5d10c7b4e249a9fe7bc280909803
+    sha256: 0ea196e4b706321951af1eebdb6a4eb9307faa1fd5361bcf49acb150e71774f7
   category: dev
   optional: true
 - name: graphite2
@@ -5727,175 +5781,219 @@ package:
   category: dev
   optional: true
 - name: graphql-core
-  version: 3.2.3
+  version: 3.2.6
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-    typing_extensions: '>=4,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/graphql-core-3.2.3-pyhd8ed1ab_0.tar.bz2
+    python: ''
+    typing_extensions: '>=4.1,<5'
+  url: https://conda.anaconda.org/conda-forge/noarch/graphql-core-3.2.6-pyh29332c3_0.conda
   hash:
-    md5: 87cafe8c7638a5ac6fd8ec8fb01f1508
-    sha256: 6f7da913ecad98951cadfe512af2c3979fbff752bf714da66760701e5463dd29
+    md5: dc604341f71b370f8a4a0a3b2996cd99
+    sha256: 6395a2a9964f044d891b54a984993c703327129374c0fdf20d88b4506830bc2a
   category: dev
   optional: true
 - name: graphql-core
-  version: 3.2.3
+  version: 3.2.6
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-    typing_extensions: '>=4,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/graphql-core-3.2.3-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+    typing_extensions: '>=4.1,<5'
+  url: https://conda.anaconda.org/conda-forge/noarch/graphql-core-3.2.6-pyh29332c3_0.conda
   hash:
-    md5: 87cafe8c7638a5ac6fd8ec8fb01f1508
-    sha256: 6f7da913ecad98951cadfe512af2c3979fbff752bf714da66760701e5463dd29
+    md5: dc604341f71b370f8a4a0a3b2996cd99
+    sha256: 6395a2a9964f044d891b54a984993c703327129374c0fdf20d88b4506830bc2a
   category: dev
   optional: true
 - name: graphql-core
-  version: 3.2.3
+  version: 3.2.6
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-    typing_extensions: '>=4,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/graphql-core-3.2.3-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+    typing_extensions: '>=4.1,<5'
+  url: https://conda.anaconda.org/conda-forge/noarch/graphql-core-3.2.6-pyh29332c3_0.conda
   hash:
-    md5: 87cafe8c7638a5ac6fd8ec8fb01f1508
-    sha256: 6f7da913ecad98951cadfe512af2c3979fbff752bf714da66760701e5463dd29
+    md5: dc604341f71b370f8a4a0a3b2996cd99
+    sha256: 6395a2a9964f044d891b54a984993c703327129374c0fdf20d88b4506830bc2a
   category: dev
   optional: true
 - name: graphviz
-  version: 11.0.0
+  version: 12.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    cairo: '>=1.18.0,<2.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    adwaita-icon-theme: ''
+    cairo: '>=1.18.2,<2.0a0'
     fonts-conda-ecosystem: ''
     gdk-pixbuf: '>=2.42.12,<3.0a0'
-    gtk2: ''
+    gtk3: '>=3.24.43,<4.0a0'
     gts: '>=0.7.6,<0.8.0a0'
-    libexpat: '>=2.6.2,<3.0a0'
-    libgcc-ng: '>=12'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
     libgd: '>=2.3.3,<2.4.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    librsvg: '>=2.58.0,<3.0a0'
-    libstdcxx-ng: '>=12'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphviz-11.0.0-hc68bbd7_0.conda
+    libglib: '>=2.82.2,<3.0a0'
+    librsvg: '>=2.58.4,<3.0a0'
+    libstdcxx: '>=13'
+    libwebp-base: '>=1.5.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pango: '>=1.56.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/graphviz-12.2.1-h5ae0cbf_1.conda
   hash:
-    md5: 52a531ef95358086a56086c45d97ab75
-    sha256: 7e7ca0901c0d2de455718ec7a0974e2091c38e608f90a4ba98084e4902d93c17
+    md5: df7835d2c73cd1889d377cfd6694ada4
+    sha256: e6866409ba03df392ac5ec6f0d6ff9751a685ed917bfbcd8a73f550c5fe83c2b
   category: dev
   optional: true
 - name: graphviz
-  version: 11.0.0
+  version: 12.2.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    cairo: '>=1.18.0,<2.0a0'
+    adwaita-icon-theme: ''
+    cairo: '>=1.18.2,<2.0a0'
     fonts-conda-ecosystem: ''
     gdk-pixbuf: '>=2.42.12,<3.0a0'
-    gtk2: ''
+    gtk3: '>=3.24.43,<4.0a0'
     gts: '>=0.7.6,<0.8.0a0'
-    libcxx: '>=16'
-    libexpat: '>=2.6.2,<3.0a0'
+    libcxx: '>=18'
+    libexpat: '>=2.6.4,<3.0a0'
     libgd: '>=2.3.3,<2.4.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    librsvg: '>=2.58.0,<3.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/graphviz-11.0.0-hc9017ca_0.conda
+    libglib: '>=2.82.2,<3.0a0'
+    librsvg: '>=2.58.4,<3.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pango: '>=1.56.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/graphviz-12.2.1-h44a0556_1.conda
   hash:
-    md5: 5a2ebaaa6d41dcf3a8bfd2a14a4300f0
-    sha256: 15afc407a9fe216956242fa3a280a61762407e16a65cb79fcbe8f5cc9599e93f
+    md5: f1e519616cb1c137cff9849cfa1beb93
+    sha256: 3a8eef238000e8fcb8f4f31a035869d7b5ad0466f69c72e9064786b54d1812cc
   category: dev
   optional: true
 - name: graphviz
-  version: 11.0.0
+  version: 12.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    cairo: '>=1.18.0,<2.0a0'
+    adwaita-icon-theme: ''
+    cairo: '>=1.18.2,<2.0a0'
     fonts-conda-ecosystem: ''
     gdk-pixbuf: '>=2.42.12,<3.0a0'
-    gtk2: ''
+    gtk3: '>=3.24.43,<4.0a0'
     gts: '>=0.7.6,<0.8.0a0'
-    libcxx: '>=16'
-    libexpat: '>=2.6.2,<3.0a0'
+    libcxx: '>=18'
+    libexpat: '>=2.6.4,<3.0a0'
     libgd: '>=2.3.3,<2.4.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    librsvg: '>=2.58.0,<3.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphviz-11.0.0-h9bb9bc9_0.conda
+    libglib: '>=2.82.2,<3.0a0'
+    librsvg: '>=2.58.4,<3.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pango: '>=1.56.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphviz-12.2.1-hff64154_1.conda
   hash:
-    md5: c004a0e5dfbe0ce38af9ab4684abd236
-    sha256: ced49a72b8f3c92a76d3f07bb75be2a64d3572d433f2711d36003e1b565d1d4e
+    md5: b0b656550a16dfba7efa1479756c5b63
+    sha256: 54e3ce5668b17ea41fed515e57fbd9e805969df468eaf7ff65389d7f53b46d54
   category: dev
   optional: true
-- name: gtk2
-  version: 2.24.33
+- name: gtk3
+  version: 3.24.43
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    at-spi2-atk: '>=2.38.0,<3.0a0'
     atk-1.0: '>=2.38.0'
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
+    cairo: '>=1.18.2,<2.0a0'
+    epoxy: '>=1.5.10,<1.6.0a0'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    gdk-pixbuf: '>=2.42.10,<3.0a0'
-    harfbuzz: '>=8.3.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.78.4,<3.0a0'
-    pango: '>=1.50.14,<2.0a0'
-    xorg-libx11: '>=1.8.7,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-libxrender: '>=0.9.11,<0.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gtk2-2.24.33-h280cfa0_4.conda
+    fribidi: '>=1.0.10,<2.0a0'
+    gdk-pixbuf: '>=2.42.12,<3.0a0'
+    glib-tools: ''
+    harfbuzz: '>=10.2.0,<11.0a0'
+    hicolor-icon-theme: ''
+    libcups: '>=2.3.3,<3.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
+    libglib: '>=2.82.2,<3.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
+    libxkbcommon: '>=1.7.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pango: '>=1.56.0,<2.0a0'
+    wayland: '>=1.23.1,<2.0a0'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxcomposite: '>=0.4.6,<1.0a0'
+    xorg-libxcursor: '>=1.2.3,<2.0a0'
+    xorg-libxdamage: '>=1.1.6,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxfixes: '>=6.0.1,<7.0a0'
+    xorg-libxi: '>=1.8.2,<2.0a0'
+    xorg-libxinerama: '>=1.1.5,<1.2.0a0'
+    xorg-libxrandr: '>=1.5.4,<2.0a0'
+    xorg-libxrender: '>=0.9.12,<0.10.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_3.conda
   hash:
-    md5: 410f86e58e880dcc7b0e910a8e89c05c
-    sha256: b946ba60d177d72157cad8af51723f1d081a4794741d35debe53f8b2c807f3af
+    md5: 56c679bcdb8c1d824e927088725862cb
+    sha256: c8f939497b43d90fa2ac9d99b44ed25759a798c305237300508e526de5e78de7
   category: dev
   optional: true
-- name: gtk2
-  version: 2.24.33
+- name: gtk3
+  version: 3.24.43
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     atk-1.0: '>=2.38.0'
-    cairo: '>=1.18.0,<2.0a0'
-    gdk-pixbuf: '>=2.42.10,<3.0a0'
-    gettext: '>=0.21.1,<1.0a0'
-    libglib: '>=2.78.4,<3.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gtk2-2.24.33-h8ca4665_4.conda
+    cairo: '>=1.18.2,<2.0a0'
+    epoxy: '>=1.5.10,<1.6.0a0'
+    fribidi: '>=1.0.10,<2.0a0'
+    gdk-pixbuf: '>=2.42.12,<3.0a0'
+    glib-tools: ''
+    harfbuzz: '>=10.2.0,<11.0a0'
+    hicolor-icon-theme: ''
+    libasprintf: '>=0.22.5,<1.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgettextpo: '>=0.22.5,<1.0a0'
+    libglib: '>=2.82.2,<3.0a0'
+    libintl: '>=0.22.5,<1.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pango: '>=1.56.0,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gtk3-3.24.43-h82a860e_3.conda
   hash:
-    md5: ff451625250bf843393ca3d660accab3
-    sha256: 5283dfb9a96d78a67e0cbf6e4592411bb19eaf27f2c7c14b47e63162e71317d2
+    md5: fc1a95f558be54a6e8445373dd19fd0a
+    sha256: ebf180c29a34d4a317df75c6e32e90845149387716cbc556c5615856bb9e23d3
   category: dev
   optional: true
-- name: gtk2
-  version: 2.24.33
+- name: gtk3
+  version: 3.24.43
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     atk-1.0: '>=2.38.0'
-    cairo: '>=1.18.0,<2.0a0'
-    gdk-pixbuf: '>=2.42.10,<3.0a0'
-    gettext: '>=0.21.1,<1.0a0'
-    libglib: '>=2.78.4,<3.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gtk2-2.24.33-h7895bb2_4.conda
+    cairo: '>=1.18.2,<2.0a0'
+    epoxy: '>=1.5.10,<1.6.0a0'
+    fribidi: '>=1.0.10,<2.0a0'
+    gdk-pixbuf: '>=2.42.12,<3.0a0'
+    glib-tools: ''
+    harfbuzz: '>=10.2.0,<11.0a0'
+    hicolor-icon-theme: ''
+    libasprintf: '>=0.22.5,<1.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgettextpo: '>=0.22.5,<1.0a0'
+    libglib: '>=2.82.2,<3.0a0'
+    libintl: '>=0.22.5,<1.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pango: '>=1.56.0,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gtk3-3.24.43-he7bb075_3.conda
   hash:
-    md5: 9c1ba062d59f3f49a2d32d9611d72686
-    sha256: fab8403a67273f69780b1e9b5f1db1aff74ff9472acc9f6df6d9b50fc252bd50
+    md5: bf683088766bb687f27d39f5e128d2b0
+    sha256: 5f52152c0af1953c220e9faf8132f010c4eb85a749319889abc2e17e6c430651
   category: dev
   optional: true
 - name: gts
@@ -5939,222 +6037,221 @@ package:
   category: dev
   optional: true
 - name: h5py
-  version: 3.11.0
+  version: 3.12.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cached-property: ''
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libgcc-ng: '>=12'
+    hdf5: '>=1.14.4,<1.14.5.0a0'
+    libgcc: '>=13'
     numpy: '>=1.19,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.11.0-nompi_py312hb7ab980_102.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.12.1-nompi_py312hd203070_103.conda
   hash:
-    md5: 966750c8f347ece01e80aa2114b4a76d
-    sha256: 08f9cea9414fce460e7dd6aa489e6c81af1eebe3766e8ae22fc55b7238e5b803
+    md5: 9bd82d55b98c65f49c44201339245cde
+    sha256: bc385c98d6d2f233ea472b0fb50e9ca796d926f1c15d12bb07fed2cb40905dd4
   category: main
   optional: false
 - name: h5py
-  version: 3.11.0
+  version: 3.12.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     cached-property: ''
-    hdf5: '>=1.14.3,<1.14.4.0a0'
+    hdf5: '>=1.14.4,<1.14.5.0a0'
     numpy: '>=1.19,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.11.0-nompi_py312hfc94b03_102.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.12.1-nompi_py312hf5b0cce_103.conda
   hash:
-    md5: bcdef1c56ae4161ad3fe058b5a3d57e2
-    sha256: ed08cb119ebd51323cddbd996112a85b7eb52d465220105b480295055ce96fbc
+    md5: 284872e119fd9944e9ce94da08b00ec7
+    sha256: d1f17c7197da64816ff50a50635820333f84e6ff9673ca89a4928cc7a3076111
   category: main
   optional: false
 - name: h5py
-  version: 3.11.0
+  version: 3.12.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     cached-property: ''
-    hdf5: '>=1.14.3,<1.14.4.0a0'
+    hdf5: '>=1.14.4,<1.14.5.0a0'
     numpy: '>=1.19,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.11.0-nompi_py312h903599c_102.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.12.1-nompi_py312h34530d4_103.conda
   hash:
-    md5: ed56b709d6e19626753894fc903b8ffe
-    sha256: cfb51250d3b7edfafef71007b94e713a388f951320f1dd766404128eb5ec4edf
+    md5: 343b1fbff8c9cca25ccfd7a61ed44f99
+    sha256: 8d1441742c14e7e989e3845d9251717882d8ae8c49769830fa3e12b94170fe9a
   category: main
   optional: false
 - name: harfbuzz
-  version: 8.5.0
+  version: 10.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    cairo: '>=1.18.0,<2.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.2,<2.0a0'
     freetype: '>=2.12.1,<3.0a0'
     graphite2: ''
-    icu: '>=73.2,<74.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.2,<3.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.5.0-hfac3d4d_0.conda
+    icu: '>=75.1,<76.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
+    libglib: '>=2.82.2,<3.0a0'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-10.2.0-h4bba637_0.conda
   hash:
-    md5: f5126317dd0ce0ba26945e411ecc6960
-    sha256: a141fc55f8bfdab7db03fe9d8e61cb0f8c8b5970ed6540eda2db7186223f4444
+    md5: 9e38e86167e8b1ea0094747d12944ce4
+    sha256: 94426eca8c60b43f57beb3338d3298dda09452c7a42314bbbb4ebfa552542a84
   category: dev
   optional: true
 - name: harfbuzz
-  version: 9.0.0
+  version: 10.2.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    cairo: '>=1.18.0,<2.0a0'
+    cairo: '>=1.18.2,<2.0a0'
     freetype: '>=2.12.1,<3.0a0'
     graphite2: ''
-    icu: '>=73.2,<74.0a0'
-    libcxx: '>=16'
-    libglib: '>=2.80.2,<3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-9.0.0-h053f038_0.conda
+    icu: '>=75.1,<76.0a0'
+    libcxx: '>=18'
+    libexpat: '>=2.6.4,<3.0a0'
+    libglib: '>=2.82.2,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-10.2.0-h5b25545_0.conda
   hash:
-    md5: 0a4256cad662dc36666221a2a8daa34e
-    sha256: eb94445e4ea3e794582f47365d3b429adfddc24209a39bb8102f17198a0661e1
+    md5: 61e64e76917a6c7f62a405f3c8569592
+    sha256: 06253714b6b1541b5e5f695b89d145d60c73968360905aecd312e083f6b9ec6c
   category: dev
   optional: true
 - name: harfbuzz
-  version: 9.0.0
+  version: 10.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    cairo: '>=1.18.0,<2.0a0'
+    cairo: '>=1.18.2,<2.0a0'
     freetype: '>=2.12.1,<3.0a0'
     graphite2: ''
-    icu: '>=73.2,<74.0a0'
-    libcxx: '>=16'
-    libglib: '>=2.80.2,<3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-9.0.0-h1836168_0.conda
+    icu: '>=75.1,<76.0a0'
+    libcxx: '>=18'
+    libexpat: '>=2.6.4,<3.0a0'
+    libglib: '>=2.82.2,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-10.2.0-ha0dd535_0.conda
   hash:
-    md5: b6b6313a34c08e587c04dc2ed9a6c724
-    sha256: 9d2a30e652c0f0e6d7f87a527687d74ea8eaa0274199e08122dd6b400f23d9cb
+    md5: 30377b8ff7d4e8a2c08be6957999c100
+    sha256: e9d148870adbe8efd9913fb036461d337609359b5d4474d0963d8ebe6b9789b2
   category: dev
   optional: true
-- name: hdf4
-  version: 4.2.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
-  hash:
-    md5: bd77f8da987968ec3927990495dc22e4
-    sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
-  category: main
-  optional: false
-- name: hdf4
-  version: 4.2.15
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libcxx: '>=15.0.7'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
-  hash:
-    md5: 7ce543bf38dbfae0de9af112ee178af2
-    sha256: 8c767cc71226e9eb62649c903c68ba73c5f5e7e3696ec0319d1f90586cebec7d
-  category: main
-  optional: false
-- name: hdf4
-  version: 4.2.15
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=15.0.7'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
-  hash:
-    md5: ff5d749fd711dc7759e127db38005924
-    sha256: c3b01e3c3fe4ca1c4d28c287eaa5168a4f2fd3ffd76690082ac919244c22fa90
-  category: main
-  optional: false
 - name: hdf5
-  version: 1.14.3
+  version: 1.14.4
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libaec: '>=1.1.3,<2.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_hdf9ad27_105.conda
+    libcurl: '>=8.10.1,<9.0a0'
+    libgcc: '>=13'
+    libgfortran: ''
+    libgfortran5: '>=13.3.0'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_105.conda
   hash:
-    md5: 7e1729554e209627636a0f6fabcdd115
-    sha256: 2278fa07da6f96e807d402cd55480624d67d2dee202191aaaf278ce5ab23605a
+    md5: d76fff0092b6389a12134ddebc0929bd
+    sha256: 93d2bfc672f3ee0988d277ce463330a467f3686d3f7ee37812a3d8ca11776d77
   category: main
   optional: false
 - name: hdf5
-  version: 1.14.3
+  version: 1.14.4
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libaec: '>=1.1.3,<2.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=18'
     libgfortran: 5.*
     libgfortran5: '>=13.2.0'
-    libzlib: '>=1.2.13,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h687a608_105.conda
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.4-nompi_h1607680_105.conda
   hash:
-    md5: 98544299f6bb2ef4d7362506a3dde886
-    sha256: 98f8350730d09e8ad7b62ca6d6be38ee2324b11bbcd1a5fe2cac619b12cd68d7
+    md5: 12ebafc40b10d4bf519e4c2074c52aef
+    sha256: 56500937894b1ca917e1ae1bea64b873a9eec57d581173579189d0b1f590db26
   category: main
   optional: false
 - name: hdf5
-  version: 1.14.3
+  version: 1.14.4
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libaec: '>=1.1.3,<2.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=18'
     libgfortran: 5.*
     libgfortran5: '>=13.2.0'
-    libzlib: '>=1.2.13,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_hec07895_105.conda
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.4-nompi_ha698983_105.conda
   hash:
-    md5: f9c8c7304d52c8846eab5d6c34219812
-    sha256: 5d87a1b63862e7da78c7bd9c17dea3526c0462c11df9004943cfa4569cc25dd3
+    md5: 7e85ea8b6a35b163a516e8c483960600
+    sha256: 1746cd2465832bf23d1e91b680935655dea9053d51e526deea86b0afb0b9d6a3
   category: main
   optional: false
+- name: hicolor-icon-theme
+  version: '0.17'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
+  hash:
+    md5: bbf6f174dcd3254e19a2f5d2295ce808
+    sha256: 336f29ceea9594f15cc8ec4c45fdc29e10796573c697ee0d57ebb7edd7e92043
+  category: dev
+  optional: true
+- name: hicolor-icon-theme
+  version: '0.17'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/hicolor-icon-theme-0.17-h694c41f_2.tar.bz2
+  hash:
+    md5: f64218f19d9a441e80343cea13be1afb
+    sha256: a5cb0c03d731bfb09b4262a3afdeae33bef98bc73972f1bd6b7e3fcd240bea41
+  category: dev
+  optional: true
+- name: hicolor-icon-theme
+  version: '0.17'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_2.tar.bz2
+  hash:
+    md5: 237b05b7eb284d7eebc3c5d93f5e4bca
+    sha256: 286e33fb452f61133a3a61d002890235d1d1378554218ab063d6870416440281
+  category: dev
+  optional: true
 - name: html5lib
   version: '1.1'
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
+    python: '>=3.9'
     six: '>=1.9'
     webencodings: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyhd8ed1ab_2.conda
   hash:
-    md5: b2355343d6315c892543200231d7154a
-    sha256: 9ad06446fe9847e86cb20d220bf11614afcd2cbe9f58096f08d5d4018877bee4
+    md5: cf25bfddbd3bc275f3d3f9936cee1dd3
+    sha256: 8027e436ad59e2a7392f6036392ef9d6c223798d8a1f4f12d5926362def02367
   category: main
   optional: false
 - name: html5lib
@@ -6162,13 +6259,13 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
-    six: '>=1.9'
     webencodings: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
+    python: '>=3.9'
+    six: '>=1.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyhd8ed1ab_2.conda
   hash:
-    md5: b2355343d6315c892543200231d7154a
-    sha256: 9ad06446fe9847e86cb20d220bf11614afcd2cbe9f58096f08d5d4018877bee4
+    md5: cf25bfddbd3bc275f3d3f9936cee1dd3
+    sha256: 8027e436ad59e2a7392f6036392ef9d6c223798d8a1f4f12d5926362def02367
   category: main
   optional: false
 - name: html5lib
@@ -6176,237 +6273,240 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
-    six: '>=1.9'
     webencodings: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
+    python: '>=3.9'
+    six: '>=1.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyhd8ed1ab_2.conda
   hash:
-    md5: b2355343d6315c892543200231d7154a
-    sha256: 9ad06446fe9847e86cb20d220bf11614afcd2cbe9f58096f08d5d4018877bee4
+    md5: cf25bfddbd3bc275f3d3f9936cee1dd3
+    sha256: 8027e436ad59e2a7392f6036392ef9d6c223798d8a1f4f12d5926362def02367
   category: main
   optional: false
 - name: icu
-  version: '73.2'
+  version: '75.1'
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
   hash:
-    md5: cc47e1facc155f91abd89b11e48e72ff
-    sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
+    md5: 8b189310083baabfb622af68fd9d3ae3
+    sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
   category: main
   optional: false
 - name: icu
-  version: '73.2'
+  version: '75.1'
   manager: conda
   platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
   hash:
-    md5: 5cc301d759ec03f28328428e28f65591
-    sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
+    md5: d68d48a3060eb5abdc1cdc8e2a3a5966
+    sha256: 2e64307532f482a0929412976c8450c719d558ba20c0962832132fd0d07ba7a7
   category: main
   optional: false
 - name: icu
-  version: '73.2'
+  version: '75.1'
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
   hash:
-    md5: 8521bd47c0e11c5902535bb1a17c565f
-    sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
+    md5: 5eb22c1d7b3fc4abb50d92d621583137
+    sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
   category: main
   optional: false
 - name: identify
-  version: 2.6.0
+  version: 2.6.6
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     ukkonen: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.6-pyhd8ed1ab_0.conda
   hash:
-    md5: f80cc5989f445f23b1622d6c455896d9
-    sha256: 4a2889027df94d51be283536ac235feba77eaa42a0d051f65cd07ba824b324a6
+    md5: d751c3b4a973ed15b57be90d68c716d1
+    sha256: bb7483a113966d3d10b6e91edb79e7006f050fd40a842935848c15d12eff56d3
   category: dev
   optional: true
 - name: identify
-  version: 2.6.0
+  version: 2.6.6
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
     ukkonen: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.6-pyhd8ed1ab_0.conda
   hash:
-    md5: f80cc5989f445f23b1622d6c455896d9
-    sha256: 4a2889027df94d51be283536ac235feba77eaa42a0d051f65cd07ba824b324a6
+    md5: d751c3b4a973ed15b57be90d68c716d1
+    sha256: bb7483a113966d3d10b6e91edb79e7006f050fd40a842935848c15d12eff56d3
   category: dev
   optional: true
 - name: identify
-  version: 2.6.0
+  version: 2.6.6
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
     ukkonen: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.6-pyhd8ed1ab_0.conda
   hash:
-    md5: f80cc5989f445f23b1622d6c455896d9
-    sha256: 4a2889027df94d51be283536ac235feba77eaa42a0d051f65cd07ba824b324a6
+    md5: d751c3b4a973ed15b57be90d68c716d1
+    sha256: bb7483a113966d3d10b6e91edb79e7006f050fd40a842935848c15d12eff56d3
   category: dev
   optional: true
 - name: idna
-  version: '3.7'
+  version: '3.10'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
   hash:
-    md5: c0cc1420498b17414d8617d0b9f506ca
-    sha256: 9687ee909ed46169395d4f99a0ee94b80a52f87bed69cd454bb6d37ffeb0ec7b
+    md5: 39a4f67be3286c86d696df570b1201b7
+    sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
   category: main
   optional: false
 - name: idna
-  version: '3.7'
+  version: '3.10'
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
   hash:
-    md5: c0cc1420498b17414d8617d0b9f506ca
-    sha256: 9687ee909ed46169395d4f99a0ee94b80a52f87bed69cd454bb6d37ffeb0ec7b
+    md5: 39a4f67be3286c86d696df570b1201b7
+    sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
   category: main
   optional: false
 - name: idna
-  version: '3.7'
+  version: '3.10'
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
   hash:
-    md5: c0cc1420498b17414d8617d0b9f506ca
-    sha256: 9687ee909ed46169395d4f99a0ee94b80a52f87bed69cd454bb6d37ffeb0ec7b
+    md5: 39a4f67be3286c86d696df570b1201b7
+    sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
   category: main
   optional: false
 - name: importlib-metadata
-  version: 8.0.0
+  version: 8.6.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.0.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
   hash:
-    md5: 3286556cdd99048d198f72c3f6f69103
-    sha256: e40d7e71c37ec95df9a19d39f5bb7a567c325be3ccde06290a71400aab719cac
+    md5: f4b39bf00c69f56ac01e020ebfac066c
+    sha256: 598951ebdb23e25e4cec4bbff0ae369cec65ead80b50bc08b441d8e54de5cf03
   category: main
   optional: false
 - name: importlib-metadata
-  version: 8.0.0
+  version: 8.6.1
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.0.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
   hash:
-    md5: 3286556cdd99048d198f72c3f6f69103
-    sha256: e40d7e71c37ec95df9a19d39f5bb7a567c325be3ccde06290a71400aab719cac
+    md5: f4b39bf00c69f56ac01e020ebfac066c
+    sha256: 598951ebdb23e25e4cec4bbff0ae369cec65ead80b50bc08b441d8e54de5cf03
   category: main
   optional: false
 - name: importlib-metadata
-  version: 8.0.0
+  version: 8.6.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.0.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.6.1-pyha770c72_0.conda
   hash:
-    md5: 3286556cdd99048d198f72c3f6f69103
-    sha256: e40d7e71c37ec95df9a19d39f5bb7a567c325be3ccde06290a71400aab719cac
+    md5: f4b39bf00c69f56ac01e020ebfac066c
+    sha256: 598951ebdb23e25e4cec4bbff0ae369cec65ead80b50bc08b441d8e54de5cf03
   category: main
   optional: false
 - name: importlib_metadata
-  version: 8.0.0
+  version: 8.6.1
   manager: conda
   platform: linux-64
   dependencies:
-    importlib-metadata: '>=8.0.0,<8.0.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.0.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=8.6.1,<8.6.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.6.1-hd8ed1ab_0.conda
   hash:
-    md5: 5f8c8ebbe6413a7838cf6ecf14d5d31b
-    sha256: f786f67bcdd6debb6edc2bc496e2899a560bbcc970e66727d42a805a1a5bf9a3
-  category: main
-  optional: false
+    md5: 7f46575a91b1307441abc235d01cab66
+    sha256: 1e3eb9d65c4d7b87c7347553ef9eef6f994996f90a2299e19b35f5997d3a3e79
+  category: dev
+  optional: true
 - name: importlib_metadata
-  version: 8.0.0
+  version: 8.6.1
   manager: conda
   platform: osx-64
   dependencies:
-    importlib-metadata: '>=8.0.0,<8.0.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.0.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=8.6.1,<8.6.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.6.1-hd8ed1ab_0.conda
   hash:
-    md5: 5f8c8ebbe6413a7838cf6ecf14d5d31b
-    sha256: f786f67bcdd6debb6edc2bc496e2899a560bbcc970e66727d42a805a1a5bf9a3
-  category: main
-  optional: false
+    md5: 7f46575a91b1307441abc235d01cab66
+    sha256: 1e3eb9d65c4d7b87c7347553ef9eef6f994996f90a2299e19b35f5997d3a3e79
+  category: dev
+  optional: true
 - name: importlib_metadata
-  version: 8.0.0
+  version: 8.6.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib-metadata: '>=8.0.0,<8.0.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.0.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=8.6.1,<8.6.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.6.1-hd8ed1ab_0.conda
   hash:
-    md5: 5f8c8ebbe6413a7838cf6ecf14d5d31b
-    sha256: f786f67bcdd6debb6edc2bc496e2899a560bbcc970e66727d42a805a1a5bf9a3
-  category: main
-  optional: false
+    md5: 7f46575a91b1307441abc235d01cab66
+    sha256: 1e3eb9d65c4d7b87c7347553ef9eef6f994996f90a2299e19b35f5997d3a3e79
+  category: dev
+  optional: true
 - name: importlib_resources
-  version: 6.4.0
+  version: 6.5.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
   hash:
-    md5: c5d3907ad8bd7bf557521a1833cf7e6d
-    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
+    md5: c85c76dc67d75619a92f51dfbce06992
+    sha256: acc1d991837c0afb67c75b77fdc72b4bf022aac71fedd8b9ea45918ac9b08a80
   category: main
   optional: false
 - name: importlib_resources
-  version: 6.4.0
+  version: 6.5.2
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
   hash:
-    md5: c5d3907ad8bd7bf557521a1833cf7e6d
-    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
+    md5: c85c76dc67d75619a92f51dfbce06992
+    sha256: acc1d991837c0afb67c75b77fdc72b4bf022aac71fedd8b9ea45918ac9b08a80
   category: main
   optional: false
 - name: importlib_resources
-  version: 6.4.0
+  version: 6.5.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
   hash:
-    md5: c5d3907ad8bd7bf557521a1833cf7e6d
-    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
+    md5: c85c76dc67d75619a92f51dfbce06992
+    sha256: acc1d991837c0afb67c75b77fdc72b4bf022aac71fedd8b9ea45918ac9b08a80
   category: main
   optional: false
 - name: iniconfig
@@ -6414,11 +6514,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: f800d2da156d08e289b14e87e43c1ae5
-    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+    md5: 6837f3eff7dcea42ecd714ce1ac2b108
+    sha256: 0ec8f4d02053cd03b0f3e63168316530949484f80e16f5e2fb199a1d117a89ca
   category: dev
   optional: true
 - name: iniconfig
@@ -6426,11 +6526,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: f800d2da156d08e289b14e87e43c1ae5
-    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+    md5: 6837f3eff7dcea42ecd714ce1ac2b108
+    sha256: 0ec8f4d02053cd03b0f3e63168316530949484f80e16f5e2fb199a1d117a89ca
   category: dev
   optional: true
 - name: iniconfig
@@ -6438,11 +6538,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: f800d2da156d08e289b14e87e43c1ae5
-    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+    md5: 6837f3eff7dcea42ecd714ce1ac2b108
+    sha256: 0ec8f4d02053cd03b0f3e63168316530949484f80e16f5e2fb199a1d117a89ca
   category: dev
   optional: true
 - name: ipykernel
@@ -6475,20 +6575,20 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: ''
-    appnope: ''
-    comm: '>=0.1.1'
-    debugpy: '>=1.6.5'
-    ipython: '>=7.23.1'
-    jupyter_client: '>=6.1.12'
-    jupyter_core: '>=4.12,!=5.0.*'
-    matplotlib-inline: '>=0.1'
-    nest-asyncio: ''
     packaging: ''
     psutil: ''
+    nest-asyncio: ''
+    __osx: ''
+    appnope: ''
     python: '>=3.8'
-    pyzmq: '>=24'
     tornado: '>=6.1'
+    jupyter_client: '>=6.1.12'
+    jupyter_core: '>=4.12,!=5.0.*'
+    ipython: '>=7.23.1'
+    matplotlib-inline: '>=0.1'
+    debugpy: '>=1.6.5'
+    pyzmq: '>=24'
+    comm: '>=0.1.1'
     traitlets: '>=5.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
   hash:
@@ -6501,20 +6601,20 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: ''
-    appnope: ''
-    comm: '>=0.1.1'
-    debugpy: '>=1.6.5'
-    ipython: '>=7.23.1'
-    jupyter_client: '>=6.1.12'
-    jupyter_core: '>=4.12,!=5.0.*'
-    matplotlib-inline: '>=0.1'
-    nest-asyncio: ''
     packaging: ''
     psutil: ''
+    nest-asyncio: ''
+    __osx: ''
+    appnope: ''
     python: '>=3.8'
-    pyzmq: '>=24'
     tornado: '>=6.1'
+    jupyter_client: '>=6.1.12'
+    jupyter_core: '>=4.12,!=5.0.*'
+    ipython: '>=7.23.1'
+    matplotlib-inline: '>=0.1'
+    debugpy: '>=1.6.5'
+    pyzmq: '>=24'
+    comm: '>=0.1.1'
     traitlets: '>=5.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
   hash:
@@ -6523,75 +6623,75 @@ package:
   category: dev
   optional: true
 - name: ipython
-  version: 8.26.0
+  version: 8.32.0
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
+    pexpect: '>4.3'
+    python: ''
     decorator: ''
     exceptiongroup: ''
     jedi: '>=0.16'
     matplotlib-inline: ''
-    pexpect: '>4.3'
     pickleshare: ''
     prompt-toolkit: '>=3.0.41,<3.1.0'
     pygments: '>=2.4.0'
-    python: '>=3.10'
     stack_data: ''
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.32.0-pyh907856f_0.conda
   hash:
-    md5: f64d3520d5d00321c10f4dabb5b903f3
-    sha256: a40c2859a055d98ba234d67b233fb1ba55d86cbe632ec96eecb7c5019c16478b
+    md5: 9de86472b8f207fb098c69daaad50e67
+    sha256: b1b940cfe85d5f0aaed83ef8c9f07ee80daa68acb05feeb5142d620472b01e0d
   category: main
   optional: false
 - name: ipython
-  version: 8.26.0
+  version: 8.32.0
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.10'
     __unix: ''
     decorator: ''
     exceptiongroup: ''
-    jedi: '>=0.16'
     matplotlib-inline: ''
-    pexpect: '>4.3'
-    pickleshare: ''
-    prompt-toolkit: '>=3.0.41,<3.1.0'
-    pygments: '>=2.4.0'
-    python: '>=3.10'
     stack_data: ''
+    pickleshare: ''
+    pygments: '>=2.4.0'
+    jedi: '>=0.16'
+    pexpect: '>4.3'
+    prompt-toolkit: '>=3.0.41,<3.1.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.32.0-pyh907856f_0.conda
   hash:
-    md5: f64d3520d5d00321c10f4dabb5b903f3
-    sha256: a40c2859a055d98ba234d67b233fb1ba55d86cbe632ec96eecb7c5019c16478b
+    md5: 9de86472b8f207fb098c69daaad50e67
+    sha256: b1b940cfe85d5f0aaed83ef8c9f07ee80daa68acb05feeb5142d620472b01e0d
   category: main
   optional: false
 - name: ipython
-  version: 8.26.0
+  version: 8.32.0
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.10'
     __unix: ''
     decorator: ''
     exceptiongroup: ''
-    jedi: '>=0.16'
     matplotlib-inline: ''
-    pexpect: '>4.3'
-    pickleshare: ''
-    prompt-toolkit: '>=3.0.41,<3.1.0'
-    pygments: '>=2.4.0'
-    python: '>=3.10'
     stack_data: ''
+    pickleshare: ''
+    pygments: '>=2.4.0'
+    jedi: '>=0.16'
+    pexpect: '>4.3'
+    prompt-toolkit: '>=3.0.41,<3.1.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.32.0-pyh907856f_0.conda
   hash:
-    md5: f64d3520d5d00321c10f4dabb5b903f3
-    sha256: a40c2859a055d98ba234d67b233fb1ba55d86cbe632ec96eecb7c5019c16478b
+    md5: 9de86472b8f207fb098c69daaad50e67
+    sha256: b1b940cfe85d5f0aaed83ef8c9f07ee80daa68acb05feeb5142d620472b01e0d
   category: main
   optional: false
 - name: isort
@@ -6599,12 +6699,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8,<4.0'
+    python: '>=3.9,<4.0'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 1d25ed2b95b92b026aaa795eabec8d91
-    sha256: 78a7e2037029366d2149f73c8d02e93cac903d535e208cc4517808b0b42e85f2
+    md5: ef7dc847f19fe4859d5aaa33385bf509
+    sha256: 6ebf6e83c2d449760ad5c5cc344711d6404f9e3cf6952811b8678aca5a4ab01f
   category: dev
   optional: true
 - name: isort
@@ -6612,12 +6712,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8,<4.0'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_0.conda
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 1d25ed2b95b92b026aaa795eabec8d91
-    sha256: 78a7e2037029366d2149f73c8d02e93cac903d535e208cc4517808b0b42e85f2
+    md5: ef7dc847f19fe4859d5aaa33385bf509
+    sha256: 6ebf6e83c2d449760ad5c5cc344711d6404f9e3cf6952811b8678aca5a4ab01f
   category: dev
   optional: true
 - name: isort
@@ -6625,12 +6725,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8,<4.0'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_0.conda
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 1d25ed2b95b92b026aaa795eabec8d91
-    sha256: 78a7e2037029366d2149f73c8d02e93cac903d535e208cc4517808b0b42e85f2
+    md5: ef7dc847f19fe4859d5aaa33385bf509
+    sha256: 6ebf6e83c2d449760ad5c5cc344711d6404f9e3cf6952811b8678aca5a4ab01f
   category: dev
   optional: true
 - name: itsdangerous
@@ -6638,11 +6738,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ff7ca04134ee8dde1d7cf491a78ef7c7
-    sha256: 4e933e36e9b0401b62ea8fd63393827ebeb4250de77a56687afb387d504523c5
+    md5: 7ac5f795c15f288984e32add616cdc59
+    sha256: 1684b7b16eec08efef5302ce298c606b163c18272b69a62b666fbaa61516f170
   category: dev
   optional: true
 - name: itsdangerous
@@ -6650,11 +6750,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ff7ca04134ee8dde1d7cf491a78ef7c7
-    sha256: 4e933e36e9b0401b62ea8fd63393827ebeb4250de77a56687afb387d504523c5
+    md5: 7ac5f795c15f288984e32add616cdc59
+    sha256: 1684b7b16eec08efef5302ce298c606b163c18272b69a62b666fbaa61516f170
   category: dev
   optional: true
 - name: itsdangerous
@@ -6662,11 +6762,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ff7ca04134ee8dde1d7cf491a78ef7c7
-    sha256: 4e933e36e9b0401b62ea8fd63393827ebeb4250de77a56687afb387d504523c5
+    md5: 7ac5f795c15f288984e32add616cdc59
+    sha256: 1684b7b16eec08efef5302ce298c606b163c18272b69a62b666fbaa61516f170
   category: dev
   optional: true
 - name: jaraco.classes
@@ -6675,11 +6775,11 @@ package:
   platform: linux-64
   dependencies:
     more-itertools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_2.conda
   hash:
-    md5: 7b756504d362cbad9b73a50a5455cafd
-    sha256: 538b1c6df537a36c63fd0ed83cb1c1c25b07d8d3b5e401991fdaff261a4b5b4d
+    md5: ade6b25a6136661dadd1a43e4350b10b
+    sha256: 3d16a0fa55a29fe723c918a979b2ee927eb0bf9616381cdfd26fa9ea2b649546
   category: main
   optional: false
 - name: jaraco.classes
@@ -6688,11 +6788,11 @@ package:
   platform: osx-64
   dependencies:
     more-itertools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_2.conda
   hash:
-    md5: 7b756504d362cbad9b73a50a5455cafd
-    sha256: 538b1c6df537a36c63fd0ed83cb1c1c25b07d8d3b5e401991fdaff261a4b5b4d
+    md5: ade6b25a6136661dadd1a43e4350b10b
+    sha256: 3d16a0fa55a29fe723c918a979b2ee927eb0bf9616381cdfd26fa9ea2b649546
   category: main
   optional: false
 - name: jaraco.classes
@@ -6701,128 +6801,128 @@ package:
   platform: osx-arm64
   dependencies:
     more-itertools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_2.conda
   hash:
-    md5: 7b756504d362cbad9b73a50a5455cafd
-    sha256: 538b1c6df537a36c63fd0ed83cb1c1c25b07d8d3b5e401991fdaff261a4b5b4d
+    md5: ade6b25a6136661dadd1a43e4350b10b
+    sha256: 3d16a0fa55a29fe723c918a979b2ee927eb0bf9616381cdfd26fa9ea2b649546
   category: main
   optional: false
 - name: jaraco.context
-  version: 5.3.0
+  version: 6.0.1
   manager: conda
   platform: linux-64
   dependencies:
     backports.tarfile: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-5.3.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 72d7ad2dcd0f37eccb2ee35a1c8f6aaa
-    sha256: 9e2aeacb1aed3ab4fc5883a357e8a874e12f687af300f8708ec12de2995e17d2
+    md5: bcc023a32ea1c44a790bbf1eae473486
+    sha256: bfaba92cd33a0ae2488ab64a1d4e062bcf52b26a71f88292c62386ccac4789d7
   category: main
   optional: false
 - name: jaraco.context
-  version: 5.3.0
+  version: 6.0.1
   manager: conda
   platform: osx-64
   dependencies:
     backports.tarfile: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-5.3.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 72d7ad2dcd0f37eccb2ee35a1c8f6aaa
-    sha256: 9e2aeacb1aed3ab4fc5883a357e8a874e12f687af300f8708ec12de2995e17d2
+    md5: bcc023a32ea1c44a790bbf1eae473486
+    sha256: bfaba92cd33a0ae2488ab64a1d4e062bcf52b26a71f88292c62386ccac4789d7
   category: main
   optional: false
 - name: jaraco.context
-  version: 5.3.0
+  version: 6.0.1
   manager: conda
   platform: osx-arm64
   dependencies:
     backports.tarfile: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-5.3.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 72d7ad2dcd0f37eccb2ee35a1c8f6aaa
-    sha256: 9e2aeacb1aed3ab4fc5883a357e8a874e12f687af300f8708ec12de2995e17d2
+    md5: bcc023a32ea1c44a790bbf1eae473486
+    sha256: bfaba92cd33a0ae2488ab64a1d4e062bcf52b26a71f88292c62386ccac4789d7
   category: main
   optional: false
 - name: jaraco.functools
-  version: 4.0.0
+  version: 4.1.0
   manager: conda
   platform: linux-64
   dependencies:
     more-itertools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 547670a612fd335eaa5ffbf0fa75cb64
-    sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
+    md5: eb257d223050a5a27f5fdf5c9debc8ec
+    sha256: 61da3e37149da5c8479c21571eaec61cc4a41678ee872dcb2ff399c30878dddb
   category: main
   optional: false
 - name: jaraco.functools
-  version: 4.0.0
+  version: 4.1.0
   manager: conda
   platform: osx-64
   dependencies:
     more-itertools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 547670a612fd335eaa5ffbf0fa75cb64
-    sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
+    md5: eb257d223050a5a27f5fdf5c9debc8ec
+    sha256: 61da3e37149da5c8479c21571eaec61cc4a41678ee872dcb2ff399c30878dddb
   category: main
   optional: false
 - name: jaraco.functools
-  version: 4.0.0
+  version: 4.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
     more-itertools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 547670a612fd335eaa5ffbf0fa75cb64
-    sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
+    md5: eb257d223050a5a27f5fdf5c9debc8ec
+    sha256: 61da3e37149da5c8479c21571eaec61cc4a41678ee872dcb2ff399c30878dddb
   category: main
   optional: false
 - name: jedi
-  version: 0.19.1
+  version: 0.19.2
   manager: conda
   platform: linux-64
   dependencies:
     parso: '>=0.8.3,<0.9.0'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 81a3be0b2023e1ea8555781f0ad904a2
-    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
+    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
   category: dev
   optional: true
 - name: jedi
-  version: 0.19.1
+  version: 0.19.2
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.9'
     parso: '>=0.8.3,<0.9.0'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 81a3be0b2023e1ea8555781f0ad904a2
-    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
+    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
   category: dev
   optional: true
 - name: jedi
-  version: 0.19.1
+  version: 0.19.2
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.9'
     parso: '>=0.8.3,<0.9.0'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 81a3be0b2023e1ea8555781f0ad904a2
-    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+    md5: a4f4c5dc9b80bc50e0d3dc4e6e8f1bd9
+    sha256: 92c4d217e2dc68983f724aa983cca5464dcb929c566627b26a2511159667dba8
   category: dev
   optional: true
 - name: jeepney
@@ -6838,42 +6938,42 @@ package:
   category: main
   optional: false
 - name: jinja2
-  version: 3.1.4
+  version: 3.1.5
   manager: conda
   platform: linux-64
   dependencies:
     markupsafe: '>=2.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 7b86ecb7d3557821c649b3c31e3eb9f2
-    sha256: 27380d870d42d00350d2d52598cddaf02f9505fb24be09488da0c9b8d1428f2d
+    md5: 2752a6ed44105bfb18c9bef1177d9dcd
+    sha256: 98977694b9ecaa3218662f843425f39501f81973c450f995eec68f1803ed71c3
   category: main
   optional: false
 - name: jinja2
-  version: 3.1.4
+  version: 3.1.5
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.9'
     markupsafe: '>=2.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 7b86ecb7d3557821c649b3c31e3eb9f2
-    sha256: 27380d870d42d00350d2d52598cddaf02f9505fb24be09488da0c9b8d1428f2d
+    md5: 2752a6ed44105bfb18c9bef1177d9dcd
+    sha256: 98977694b9ecaa3218662f843425f39501f81973c450f995eec68f1803ed71c3
   category: main
   optional: false
 - name: jinja2
-  version: 3.1.4
+  version: 3.1.5
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.9'
     markupsafe: '>=2.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.5-pyhd8ed1ab_0.conda
   hash:
-    md5: 7b86ecb7d3557821c649b3c31e3eb9f2
-    sha256: 27380d870d42d00350d2d52598cddaf02f9505fb24be09488da0c9b8d1428f2d
+    md5: 2752a6ed44105bfb18c9bef1177d9dcd
+    sha256: 98977694b9ecaa3218662f843425f39501f81973c450f995eec68f1803ed71c3
   category: main
   optional: false
 - name: jmespath
@@ -6881,11 +6981,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
-    sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
   category: main
   optional: false
 - name: jmespath
@@ -6893,11 +6993,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
-    sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
   category: main
   optional: false
 - name: jmespath
@@ -6905,11 +7005,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
-    sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
+    md5: 972bdca8f30147135f951847b30399ea
+    sha256: 3d2f20ee7fd731e3ff55c189db9c43231bc8bde957875817a609c227bcb295c6
   category: main
   optional: false
 - name: joblib
@@ -6917,12 +7017,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 25df261d4523d9f9783bcdb7208d872f
-    sha256: 8ad719524b1039510fcbd75eb776123189d75e2c09228189257ddbcab86f5b64
+    md5: bf8243ee348f3a10a14ed0cae323e0c1
+    sha256: 51cc2dc491668af0c4d9299b0ab750f16ccf413ec5e2391b924108c1fbacae9b
   category: main
   optional: false
 - name: joblib
@@ -6930,12 +7030,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 25df261d4523d9f9783bcdb7208d872f
-    sha256: 8ad719524b1039510fcbd75eb776123189d75e2c09228189257ddbcab86f5b64
+    md5: bf8243ee348f3a10a14ed0cae323e0c1
+    sha256: 51cc2dc491668af0c4d9299b0ab750f16ccf413ec5e2391b924108c1fbacae9b
   category: main
   optional: false
 - name: joblib
@@ -6943,12 +7043,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 25df261d4523d9f9783bcdb7208d872f
-    sha256: 8ad719524b1039510fcbd75eb776123189d75e2c09228189257ddbcab86f5b64
+    md5: bf8243ee348f3a10a14ed0cae323e0c1
+    sha256: 51cc2dc491668af0c4d9299b0ab750f16ccf413ec5e2391b924108c1fbacae9b
   category: main
   optional: false
 - name: jschema-to-python
@@ -6959,11 +7059,11 @@ package:
     attrs: ''
     jsonpickle: ''
     pbr: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jschema-to-python-1.2.3-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jschema-to-python-1.2.3-pyhff2d567_1.conda
   hash:
-    md5: 686ca7c72f9583791fe424600987411f
-    sha256: 244f9103888438b57ab9f4aac7a8aba8db19947267fd2ddbdaa2222c39f6c8a9
+    md5: b2f293e5b388bb05ea0b10d5597a9cd2
+    sha256: 30df2e45143e0ee194df754083f38c44278788653f74696a39ddf238d6cbce73
   category: dev
   optional: true
 - name: jschema-to-python
@@ -6974,11 +7074,11 @@ package:
     attrs: ''
     jsonpickle: ''
     pbr: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jschema-to-python-1.2.3-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jschema-to-python-1.2.3-pyhff2d567_1.conda
   hash:
-    md5: 686ca7c72f9583791fe424600987411f
-    sha256: 244f9103888438b57ab9f4aac7a8aba8db19947267fd2ddbdaa2222c39f6c8a9
+    md5: b2f293e5b388bb05ea0b10d5597a9cd2
+    sha256: 30df2e45143e0ee194df754083f38c44278788653f74696a39ddf238d6cbce73
   category: dev
   optional: true
 - name: jschema-to-python
@@ -6989,578 +7089,536 @@ package:
     attrs: ''
     jsonpickle: ''
     pbr: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jschema-to-python-1.2.3-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jschema-to-python-1.2.3-pyhff2d567_1.conda
   hash:
-    md5: 686ca7c72f9583791fe424600987411f
-    sha256: 244f9103888438b57ab9f4aac7a8aba8db19947267fd2ddbdaa2222c39f6c8a9
+    md5: b2f293e5b388bb05ea0b10d5597a9cd2
+    sha256: 30df2e45143e0ee194df754083f38c44278788653f74696a39ddf238d6cbce73
   category: dev
   optional: true
 - name: json-c
-  version: '0.17'
+  version: '0.18'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.17-h7ab15ed_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
   hash:
-    md5: 9961b1f100c3b6852bd97c9233d06979
-    sha256: 5646496ca07dfa1486d27ed07282967007811dfc63d6394652e87f94166ecae3
+    md5: 38f5dbc9ac808e31c00650f7be1db93f
+    sha256: 09e706cb388d3ea977fabcee8e28384bdaad8ce1fc49340df5f868a2bd95a7da
   category: main
   optional: false
 - name: json-c
-  version: '0.17'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.17-h8e11ae5_0.conda
-  hash:
-    md5: 266d2e4ebbf37091c8322937392bb540
-    sha256: 2a493095fe1292108ff1799a1b47ababe82d844bfa3abcf2252676c1017a1e04
-  category: main
-  optional: false
-- name: json-c
-  version: '0.17'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.17-h40ed0f5_0.conda
-  hash:
-    md5: 7de5604deb99090c8e8c4863f60568d1
-    sha256: d47138a2829ce47d2e9ec1dbe108d1a6fe58c5d8724ea904985a420ad760f93f
-  category: main
-  optional: false
-- name: jsondiff
-  version: 2.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsondiff-2.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 737c0737e5d262688097097534fb1bd5
-    sha256: 04e6b6fbec9e262781c5c753cee5c6baf5e22767242ec3db54d2208463814df1
-  category: dev
-  optional: true
-- name: jsondiff
-  version: 2.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsondiff-2.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 737c0737e5d262688097097534fb1bd5
-    sha256: 04e6b6fbec9e262781c5c753cee5c6baf5e22767242ec3db54d2208463814df1
-  category: dev
-  optional: true
-- name: jsondiff
-  version: 2.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsondiff-2.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 737c0737e5d262688097097534fb1bd5
-    sha256: 04e6b6fbec9e262781c5c753cee5c6baf5e22767242ec3db54d2208463814df1
-  category: dev
-  optional: true
-- name: jsonpatch
-  version: '1.33'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    jsonpointer: '>=1.9'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
-  hash:
-    md5: bfdb7c5c6ad1077c82a69a8642c87aff
-    sha256: fbb17e33ace3225c6416d1604637c1058906b8223da968cc015128985336b2b4
-  category: main
-  optional: false
-- name: jsonpatch
-  version: '1.33'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    jsonpointer: '>=1.9'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
-  hash:
-    md5: bfdb7c5c6ad1077c82a69a8642c87aff
-    sha256: fbb17e33ace3225c6416d1604637c1058906b8223da968cc015128985336b2b4
-  category: main
-  optional: false
-- name: jsonpatch
-  version: '1.33'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    jsonpointer: '>=1.9'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
-  hash:
-    md5: bfdb7c5c6ad1077c82a69a8642c87aff
-    sha256: fbb17e33ace3225c6416d1604637c1058906b8223da968cc015128985336b2b4
-  category: main
-  optional: false
-- name: jsonpickle
-  version: 3.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    importlib_metadata: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-3.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 31529941fc4955f3273bc1ceebc270eb
-    sha256: 485a56a31da1287ba857b74930a42ee553cfec77ae0ca5c3eac955a9057a0380
-  category: dev
-  optional: true
-- name: jsonpickle
-  version: 3.2.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    importlib_metadata: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-3.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 31529941fc4955f3273bc1ceebc270eb
-    sha256: 485a56a31da1287ba857b74930a42ee553cfec77ae0ca5c3eac955a9057a0380
-  category: dev
-  optional: true
-- name: jsonpickle
-  version: 3.2.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    importlib_metadata: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-3.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 31529941fc4955f3273bc1ceebc270eb
-    sha256: 485a56a31da1287ba857b74930a42ee553cfec77ae0ca5c3eac955a9057a0380
-  category: dev
-  optional: true
-- name: jsonpointer
-  version: 3.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py312h7900ff3_0.conda
-  hash:
-    md5: 320338762418ae59539ae368d4386085
-    sha256: b5d17c5db3c7306d3625745a27359f806a6dd94707d76d74cba541fc1daa2ae3
-  category: main
-  optional: false
-- name: jsonpointer
-  version: 3.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py312hb401068_0.conda
-  hash:
-    md5: 7d360dce2fa56d1701773d26ecccb038
-    sha256: c28d5ee8ddc58858c711f0a4874916ed7d1306fa8b12bb95e3e8bb7183f2e287
-  category: main
-  optional: false
-- name: jsonpointer
-  version: 3.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py312h81bd7bf_0.conda
-  hash:
-    md5: bc1baf9c7772acbd2cb4f8d9190286f5
-    sha256: a7326ba42944287a44a5959dc67b40e002798aa9eed97ef4ec9ad39bbd84c9a3
-  category: main
-  optional: false
-- name: jsonschema
-  version: 4.23.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    attrs: '>=22.2.0'
-    importlib_resources: '>=1.4.0'
-    jsonschema-specifications: '>=2023.03.6'
-    pkgutil-resolve-name: '>=1.3.10'
-    python: '>=3.8'
-    referencing: '>=0.28.4'
-    rpds-py: '>=0.7.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: da304c192ad59975202859b367d0f6a2
-    sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
-  category: dev
-  optional: true
-- name: jsonschema
-  version: 4.23.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    attrs: '>=22.2.0'
-    importlib_resources: '>=1.4.0'
-    jsonschema-specifications: '>=2023.03.6'
-    pkgutil-resolve-name: '>=1.3.10'
-    python: '>=3.8'
-    referencing: '>=0.28.4'
-    rpds-py: '>=0.7.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: da304c192ad59975202859b367d0f6a2
-    sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
-  category: dev
-  optional: true
-- name: jsonschema
-  version: 4.23.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    attrs: '>=22.2.0'
-    importlib_resources: '>=1.4.0'
-    jsonschema-specifications: '>=2023.03.6'
-    pkgutil-resolve-name: '>=1.3.10'
-    python: '>=3.8'
-    referencing: '>=0.28.4'
-    rpds-py: '>=0.7.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: da304c192ad59975202859b367d0f6a2
-    sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
-  category: dev
-  optional: true
-- name: jsonschema-path
-  version: 0.3.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    pathable: '>=0.4.1,<0.5.0'
-    python: '>=3.8.0'
-    pyyaml: '>=5.1'
-    referencing: '>=0.28.0,<0.36.0'
-    requests: '>=2.31.0,<3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-path-0.3.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0f33435114548019a8c6ba1b8bee65a5
-    sha256: faaaf58f59bd14adf20309eba73d20db2c8a86e82a4368257dea5d06ce2de777
-  category: dev
-  optional: true
-- name: jsonschema-path
-  version: 0.3.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    pathable: '>=0.4.1,<0.5.0'
-    python: '>=3.8.0'
-    pyyaml: '>=5.1'
-    referencing: '>=0.28.0,<0.36.0'
-    requests: '>=2.31.0,<3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-path-0.3.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0f33435114548019a8c6ba1b8bee65a5
-    sha256: faaaf58f59bd14adf20309eba73d20db2c8a86e82a4368257dea5d06ce2de777
-  category: dev
-  optional: true
-- name: jsonschema-path
-  version: 0.3.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    pathable: '>=0.4.1,<0.5.0'
-    python: '>=3.8.0'
-    pyyaml: '>=5.1'
-    referencing: '>=0.28.0,<0.36.0'
-    requests: '>=2.31.0,<3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-path-0.3.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0f33435114548019a8c6ba1b8bee65a5
-    sha256: faaaf58f59bd14adf20309eba73d20db2c8a86e82a4368257dea5d06ce2de777
-  category: dev
-  optional: true
-- name: jsonschema-specifications
-  version: 2023.12.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    importlib_resources: '>=1.4.0'
-    python: '>=3.8'
-    referencing: '>=0.31.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0e4efb5f35786a05af4809a2fb1f855
-    sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
-  category: dev
-  optional: true
-- name: jsonschema-specifications
-  version: 2023.12.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    importlib_resources: '>=1.4.0'
-    python: '>=3.8'
-    referencing: '>=0.31.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0e4efb5f35786a05af4809a2fb1f855
-    sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
-  category: dev
-  optional: true
-- name: jsonschema-specifications
-  version: 2023.12.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    importlib_resources: '>=1.4.0'
-    python: '>=3.8'
-    referencing: '>=0.31.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0e4efb5f35786a05af4809a2fb1f855
-    sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
-  category: dev
-  optional: true
-- name: junit-xml
-  version: '1.9'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/junit-xml-1.9-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 7b503c6c097fa8677d6ff17d2bfb623f
-    sha256: b89ace740500f4a311475ae44add2675d72dc42c02971910ea844812edf93736
-  category: dev
-  optional: true
-- name: junit-xml
-  version: '1.9'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/junit-xml-1.9-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 7b503c6c097fa8677d6ff17d2bfb623f
-    sha256: b89ace740500f4a311475ae44add2675d72dc42c02971910ea844812edf93736
-  category: dev
-  optional: true
-- name: junit-xml
-  version: '1.9'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/junit-xml-1.9-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 7b503c6c097fa8677d6ff17d2bfb623f
-    sha256: b89ace740500f4a311475ae44add2675d72dc42c02971910ea844812edf93736
-  category: dev
-  optional: true
-- name: jupyter_client
-  version: 8.6.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    importlib_metadata: '>=4.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    python: '>=3.8'
-    python-dateutil: '>=2.8.2'
-    pyzmq: '>=23.0'
-    tornado: '>=6.2'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3cdbb2fa84490e5fd44c9f9806c0d292
-    sha256: 634f065cdd1d0aacd4bb6848ebf240dcebc8578135d65f4ad4aa42b2276c4e0c
-  category: dev
-  optional: true
-- name: jupyter_client
-  version: 8.6.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    importlib_metadata: '>=4.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    python: '>=3.8'
-    python-dateutil: '>=2.8.2'
-    pyzmq: '>=23.0'
-    tornado: '>=6.2'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3cdbb2fa84490e5fd44c9f9806c0d292
-    sha256: 634f065cdd1d0aacd4bb6848ebf240dcebc8578135d65f4ad4aa42b2276c4e0c
-  category: dev
-  optional: true
-- name: jupyter_client
-  version: 8.6.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    importlib_metadata: '>=4.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    python: '>=3.8'
-    python-dateutil: '>=2.8.2'
-    pyzmq: '>=23.0'
-    tornado: '>=6.2'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3cdbb2fa84490e5fd44c9f9806c0d292
-    sha256: 634f065cdd1d0aacd4bb6848ebf240dcebc8578135d65f4ad4aa42b2276c4e0c
-  category: dev
-  optional: true
-- name: jupyter_core
-  version: 5.7.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    platformdirs: '>=2.5'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.7.2-py312h7900ff3_0.conda
-  hash:
-    md5: eee5a2e3465220ed87196bbb5665f420
-    sha256: 22a6259c2b139191c76ed7633d1865757b3c15007989f6c74304a80f28e5a262
-  category: dev
-  optional: true
-- name: jupyter_core
-  version: 5.7.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    platformdirs: '>=2.5'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.7.2-py312hb401068_0.conda
-  hash:
-    md5: a205e28ce7ab71773dcaaf94f6418612
-    sha256: 3e57d1eaf22c793711367335f9f8b647c011b64a95bfc796b50967a4b2ae27c2
-  category: dev
-  optional: true
-- name: jupyter_core
-  version: 5.7.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    platformdirs: '>=2.5'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.7.2-py312h81bd7bf_0.conda
-  hash:
-    md5: 209b9cb7159212afce5e16d7a3ee3b47
-    sha256: 5ab0e75a30915d34ae27b4a76f1241c2f4cc4419b6b1c838cc1160b9ec8bfaf5
-  category: dev
-  optional: true
-- name: kealib
-  version: 1.5.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.5.3-hee9dde6_1.conda
-  hash:
-    md5: c5b7b29e2b66107553d0366538257a51
-    sha256: d607ddb5906a335cb3665dd81f3adec4af248cf398147693b470b65d887408e7
-  category: main
-  optional: false
-- name: kealib
-  version: 1.5.3
+  version: '0.18'
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/kealib-1.5.3-hb2b617a_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.18-hc62ec3d_0.conda
   hash:
-    md5: e24e1fa559fd29c34593d6a47b459443
-    sha256: 3150dedf047284e8b808a169dfe630d818d8513b79d08a5404b90973c61c6914
+    md5: 2c5a3c42de607dda0cfa0edd541fd279
+    sha256: b58f8002318d6b880a98e1b0aa943789b3b0f49334a3bdb9c19b463a0b799cad
   category: main
   optional: false
-- name: kealib
-  version: 1.5.3
+- name: json-c
+  version: '0.18'
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/kealib-1.5.3-h848a2d4_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
   hash:
-    md5: dafdda3213a216870027af0c76f204c7
-    sha256: f17ee2e89bce1923222148956c3b3ab2e859b60f82568a3241593239a8412546
+    md5: 94f14ef6157687c30feb44e1abecd577
+    sha256: 73179a1cd0b45c09d4f631cb359d9e755e6e573c5d908df42006728e0bf8297c
   category: main
   optional: false
+- name: jsondiff
+  version: 2.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    pyyaml: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/jsondiff-2.2.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 17bcb57d022fa03627dfa6a782009a0c
+    sha256: 6cf0505add010cc07ab07b17288ef305a2717e8d16d88c131bb5d408a2c0d293
+  category: dev
+  optional: true
+- name: jsondiff
+  version: 2.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pyyaml: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsondiff-2.2.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 17bcb57d022fa03627dfa6a782009a0c
+    sha256: 6cf0505add010cc07ab07b17288ef305a2717e8d16d88c131bb5d408a2c0d293
+  category: dev
+  optional: true
+- name: jsondiff
+  version: 2.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pyyaml: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsondiff-2.2.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 17bcb57d022fa03627dfa6a782009a0c
+    sha256: 6cf0505add010cc07ab07b17288ef305a2717e8d16d88c131bb5d408a2c0d293
+  category: dev
+  optional: true
+- name: jsonpatch
+  version: '1.33'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    jsonpointer: '>=1.9'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
+  hash:
+    md5: cb60ae9cf02b9fcb8004dec4089e5691
+    sha256: 304955757d1fedbe344af43b12b5467cca072f83cce6109361ba942e186b3993
+  category: main
+  optional: false
+- name: jsonpatch
+  version: '1.33'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    jsonpointer: '>=1.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
+  hash:
+    md5: cb60ae9cf02b9fcb8004dec4089e5691
+    sha256: 304955757d1fedbe344af43b12b5467cca072f83cce6109361ba942e186b3993
+  category: main
+  optional: false
+- name: jsonpatch
+  version: '1.33'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    jsonpointer: '>=1.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
+  hash:
+    md5: cb60ae9cf02b9fcb8004dec4089e5691
+    sha256: 304955757d1fedbe344af43b12b5467cca072f83cce6109361ba942e186b3993
+  category: main
+  optional: false
+- name: jsonpickle
+  version: 4.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-4.0.0-pyh29332c3_0.conda
+  hash:
+    md5: 326318b423a787eec6cb842fac0158c0
+    sha256: f0b69d1c43ae01c7494020bd800b4791909690b2b12b92c1d9760f2c9af1d5c8
+  category: dev
+  optional: true
+- name: jsonpickle
+  version: 4.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-4.0.0-pyh29332c3_0.conda
+  hash:
+    md5: 326318b423a787eec6cb842fac0158c0
+    sha256: f0b69d1c43ae01c7494020bd800b4791909690b2b12b92c1d9760f2c9af1d5c8
+  category: dev
+  optional: true
+- name: jsonpickle
+  version: 4.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-4.0.0-pyh29332c3_0.conda
+  hash:
+    md5: 326318b423a787eec6cb842fac0158c0
+    sha256: f0b69d1c43ae01c7494020bd800b4791909690b2b12b92c1d9760f2c9af1d5c8
+  category: dev
+  optional: true
+- name: jsonpointer
+  version: 3.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py312h7900ff3_1.conda
+  hash:
+    md5: 6b51f7459ea4073eeb5057207e2e1e3d
+    sha256: 76ccb7bffc7761d1d3133ffbe1f7f1710a0f0d9aaa9f7ea522652e799f3601f4
+  category: main
+  optional: false
+- name: jsonpointer
+  version: 3.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py312hb401068_1.conda
+  hash:
+    md5: 5dcf96bca4649d496d818a0f5cfb962e
+    sha256: 52fcb1db44a935bba26988cc17247a0f71a8ad2fbc2b717274a8c8940856ee0d
+  category: main
+  optional: false
+- name: jsonpointer
+  version: 3.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-3.0.0-py312h81bd7bf_1.conda
+  hash:
+    md5: 80f403c03290e1662be03e026fb5f8ab
+    sha256: f6fb3734e967d1cd0cde32844ee952809f6c0a49895da7ec1c8cfdf97739b947
+  category: main
+  optional: false
+- name: jsonschema
+  version: 4.23.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    attrs: '>=22.2.0'
+    importlib_resources: '>=1.4.0'
+    jsonschema-specifications: '>=2023.03.6'
+    pkgutil-resolve-name: '>=1.3.10'
+    python: '>=3.9'
+    referencing: '>=0.28.4'
+    rpds-py: '>=0.7.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: a3cead9264b331b32fe8f0aabc967522
+    sha256: be992a99e589146f229c58fe5083e0b60551d774511c494f91fe011931bd7893
+  category: dev
+  optional: true
+- name: jsonschema
+  version: 4.23.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    attrs: '>=22.2.0'
+    importlib_resources: '>=1.4.0'
+    pkgutil-resolve-name: '>=1.3.10'
+    jsonschema-specifications: '>=2023.03.6'
+    referencing: '>=0.28.4'
+    rpds-py: '>=0.7.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: a3cead9264b331b32fe8f0aabc967522
+    sha256: be992a99e589146f229c58fe5083e0b60551d774511c494f91fe011931bd7893
+  category: dev
+  optional: true
+- name: jsonschema
+  version: 4.23.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    attrs: '>=22.2.0'
+    importlib_resources: '>=1.4.0'
+    pkgutil-resolve-name: '>=1.3.10'
+    jsonschema-specifications: '>=2023.03.6'
+    referencing: '>=0.28.4'
+    rpds-py: '>=0.7.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: a3cead9264b331b32fe8f0aabc967522
+    sha256: be992a99e589146f229c58fe5083e0b60551d774511c494f91fe011931bd7893
+  category: dev
+  optional: true
+- name: jsonschema-path
+  version: 0.3.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    pathable: '>=0.4.1,<0.5.0'
+    python: ''
+    pyyaml: '>=5.1'
+    referencing: <0.37.0
+    requests: '>=2.31.0,<3.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-path-0.3.4-pyh29332c3_0.conda
+  hash:
+    md5: 2db827e73306cbf15c69ee52b250d68b
+    sha256: 54ae9b11f76c2cf962f07b9711865a6ca482e7f23109cca447160aec51256fda
+  category: dev
+  optional: true
+- name: jsonschema-path
+  version: 0.3.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    pyyaml: '>=5.1'
+    requests: '>=2.31.0,<3.0.0'
+    pathable: '>=0.4.1,<0.5.0'
+    referencing: <0.37.0
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-path-0.3.4-pyh29332c3_0.conda
+  hash:
+    md5: 2db827e73306cbf15c69ee52b250d68b
+    sha256: 54ae9b11f76c2cf962f07b9711865a6ca482e7f23109cca447160aec51256fda
+  category: dev
+  optional: true
+- name: jsonschema-path
+  version: 0.3.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    pyyaml: '>=5.1'
+    requests: '>=2.31.0,<3.0.0'
+    pathable: '>=0.4.1,<0.5.0'
+    referencing: <0.37.0
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-path-0.3.4-pyh29332c3_0.conda
+  hash:
+    md5: 2db827e73306cbf15c69ee52b250d68b
+    sha256: 54ae9b11f76c2cf962f07b9711865a6ca482e7f23109cca447160aec51256fda
+  category: dev
+  optional: true
+- name: jsonschema-specifications
+  version: 2024.10.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    referencing: '>=0.31.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3b519bc21bc80e60b456f1e62962a766
+    sha256: 37127133837444cf0e6d1a95ff5a505f8214ed4e89e8e9343284840e674c6891
+  category: dev
+  optional: true
+- name: jsonschema-specifications
+  version: 2024.10.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    referencing: '>=0.31.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3b519bc21bc80e60b456f1e62962a766
+    sha256: 37127133837444cf0e6d1a95ff5a505f8214ed4e89e8e9343284840e674c6891
+  category: dev
+  optional: true
+- name: jsonschema-specifications
+  version: 2024.10.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    referencing: '>=0.31.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3b519bc21bc80e60b456f1e62962a766
+    sha256: 37127133837444cf0e6d1a95ff5a505f8214ed4e89e8e9343284840e674c6891
+  category: dev
+  optional: true
+- name: junit-xml
+  version: '1.9'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/junit-xml-1.9-pyhd8ed1ab_1.conda
+  hash:
+    md5: 770ac65c221b65dd0c7b6678d15a6969
+    sha256: b744e6885e5c4d87163cda1465c8ee9a16122b4b3d3f38d3b5206e13832ce972
+  category: dev
+  optional: true
+- name: junit-xml
+  version: '1.9'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    six: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/junit-xml-1.9-pyhd8ed1ab_1.conda
+  hash:
+    md5: 770ac65c221b65dd0c7b6678d15a6969
+    sha256: b744e6885e5c4d87163cda1465c8ee9a16122b4b3d3f38d3b5206e13832ce972
+  category: dev
+  optional: true
+- name: junit-xml
+  version: '1.9'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    six: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/junit-xml-1.9-pyhd8ed1ab_1.conda
+  hash:
+    md5: 770ac65c221b65dd0c7b6678d15a6969
+    sha256: b744e6885e5c4d87163cda1465c8ee9a16122b4b3d3f38d3b5206e13832ce972
+  category: dev
+  optional: true
+- name: jupyter_client
+  version: 8.6.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    importlib-metadata: '>=4.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
+    python: '>=3.9'
+    python-dateutil: '>=2.8.2'
+    pyzmq: '>=23.0'
+    tornado: '>=6.2'
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+  hash:
+    md5: 4ebae00eae9705b0c3d6d1018a81d047
+    sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
+  category: dev
+  optional: true
+- name: jupyter_client
+  version: 8.6.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    python-dateutil: '>=2.8.2'
+    jupyter_core: '>=4.12,!=5.0.*'
+    importlib-metadata: '>=4.8.3'
+    traitlets: '>=5.3'
+    tornado: '>=6.2'
+    pyzmq: '>=23.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+  hash:
+    md5: 4ebae00eae9705b0c3d6d1018a81d047
+    sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
+  category: dev
+  optional: true
+- name: jupyter_client
+  version: 8.6.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    python-dateutil: '>=2.8.2'
+    jupyter_core: '>=4.12,!=5.0.*'
+    importlib-metadata: '>=4.8.3'
+    traitlets: '>=5.3'
+    tornado: '>=6.2'
+    pyzmq: '>=23.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+  hash:
+    md5: 4ebae00eae9705b0c3d6d1018a81d047
+    sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
+  category: dev
+  optional: true
+- name: jupyter_core
+  version: 5.7.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+    platformdirs: '>=2.5'
+    python: '>=3.8'
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  hash:
+    md5: 0a2980dada0dd7fd0998f0342308b1b1
+    sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+  category: dev
+  optional: true
+- name: jupyter_core
+  version: 5.7.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+    python: '>=3.8'
+    traitlets: '>=5.3'
+    platformdirs: '>=2.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  hash:
+    md5: 0a2980dada0dd7fd0998f0342308b1b1
+    sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+  category: dev
+  optional: true
+- name: jupyter_core
+  version: 5.7.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __unix: ''
+    python: '>=3.8'
+    traitlets: '>=5.3'
+    platformdirs: '>=2.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  hash:
+    md5: 0a2980dada0dd7fd0998f0342308b1b1
+    sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+  category: dev
+  optional: true
 - name: keyring
-  version: 25.2.1
+  version: 25.6.0
   manager: conda
   platform: linux-64
   dependencies:
     __linux: ''
-    importlib_metadata: '>=4.11.4'
+    importlib-metadata: '>=4.11.4'
     importlib_resources: ''
     jaraco.classes: ''
     jaraco.context: ''
     jaraco.functools: ''
     jeepney: '>=0.4.2'
-    python: '>=3.8'
+    python: '>=3.9'
     secretstorage: '>=3.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.2.1-pyha804496_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyha804496_0.conda
   hash:
-    md5: 8508b734287ac18dd1caa72a0d8127ee
-    sha256: a9608fa7d3ec6a58f01a8901773a28bbe08f2e799476cd2b9aae7f578dff8fab
+    md5: cdd58ab99c214b55d56099108a914282
+    sha256: b6f57c17cf098022c32fe64e85e9615d427a611c48a5947cdfc357490210a124
   category: main
   optional: false
 - name: keyring
-  version: 25.2.1
+  version: 25.6.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: ''
-    importlib_metadata: '>=4.11.4'
     importlib_resources: ''
+    __osx: ''
     jaraco.classes: ''
-    jaraco.context: ''
     jaraco.functools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.2.1-pyh534df25_0.conda
+    jaraco.context: ''
+    python: '>=3.9'
+    importlib-metadata: '>=4.11.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyh534df25_0.conda
   hash:
-    md5: 8c071c544a2fc27cbc75dfa0d7362f0c
-    sha256: 25c638602ef3854a8f1785004124ac3acba2b1ceaa7a2f23f51dfa09b5cd6d3f
+    md5: d2c0c5bda93c249f877c7fceea9e63af
+    sha256: c8b436fa9853bf8b836c96afbb7684a04955b80b37f5d5285fd836b6a8566cc5
   category: main
   optional: false
 - name: keyring
-  version: 25.2.1
+  version: 25.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: ''
-    importlib_metadata: '>=4.11.4'
     importlib_resources: ''
+    __osx: ''
     jaraco.classes: ''
-    jaraco.context: ''
     jaraco.functools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.2.1-pyh534df25_0.conda
+    jaraco.context: ''
+    python: '>=3.9'
+    importlib-metadata: '>=4.11.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyh534df25_0.conda
   hash:
-    md5: 8c071c544a2fc27cbc75dfa0d7362f0c
-    sha256: 25c638602ef3854a8f1785004124ac3acba2b1ceaa7a2f23f51dfa09b5cd6d3f
+    md5: d2c0c5bda93c249f877c7fceea9e63af
+    sha256: c8b436fa9853bf8b836c96afbb7684a04955b80b37f5d5285fd836b6a8566cc5
   category: main
   optional: false
 - name: keyutils
@@ -7576,46 +7634,49 @@ package:
   category: main
   optional: false
 - name: kiwisolver
-  version: 1.4.5
+  version: 1.4.8
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.12.0rc3,<3.13.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py312h8572e83_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.8-py312h84d6215_0.conda
   hash:
-    md5: c1e71f2bc05d8e8e033aefac2c490d05
-    sha256: 2ffd3f6726392591c6794ab130f6701f5ffba0ec8658ef40db5a95ec8d583143
+    md5: 6713467dc95509683bfa3aca08524e8a
+    sha256: 3ce99d721c1543f6f8f5155e53eef11be47b2f5942a8d1060de6854f9d51f246
   category: main
   optional: false
 - name: kiwisolver
-  version: 1.4.5
+  version: 1.4.8
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
-    python: '>=3.12.0rc3,<3.13.0a0'
+    __osx: '>=10.13'
+    libcxx: '>=18'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py312h49ebfd2_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.8-py312h9275861_0.conda
   hash:
-    md5: 21f174a5cfb5964069c374171a979157
-    sha256: 11d9daa79051a7ae52881d11f48816366fd3d46018281431abe507da7b45f69c
+    md5: 88135d68c4ab7e6aedf52765b92acc70
+    sha256: 1c14526352cb9ced9ead72977ebbb5fbb167ed021af463f562b3f057c6d412a9
   category: main
   optional: false
 - name: kiwisolver
-  version: 1.4.5
+  version: 1.4.8
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-    python: '>=3.12.0rc3,<3.13.0a0'
+    __osx: '>=11.0'
+    libcxx: '>=18'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.5-py312h389731b_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.8-py312h2c4a281_0.conda
   hash:
-    md5: 77eeca70c1c4f4187d6b199015c99ee5
-    sha256: ee1a2189dc405f59c27ee1f061076d8761684c0fcd38cccc215630d8debf9f85
+    md5: a94f3ac940c391e7716b6ffd332d7463
+    sha256: 01366fa9d65bedb4069266d08c8a7a2ebbe6f25cedf60eebeeb701067f162f68
   category: main
   optional: false
 - name: krb5
@@ -7669,13 +7730,14 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/lazy-object-proxy-1.10.0-py312h98912ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/lazy-object-proxy-1.10.0-py312h66e93f0_2.conda
   hash:
-    md5: d4a8c72d067aa79b1c463dd38e3e01b6
-    sha256: e408fa0bb69a9201191c98983d9c3b428f825cf53569a12c96aee05e98af6aaa
+    md5: 1eb0dc5b2e8c03b98a46c6f40e8a90b0
+    sha256: cadaada3857bdda958eea09302a1242b253622ebfe4d440d8e701fa8858712ce
   category: dev
   optional: true
 - name: lazy-object-proxy
@@ -7683,12 +7745,13 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/lazy-object-proxy-1.10.0-py312h41838bb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/lazy-object-proxy-1.10.0-py312h01d7ebd_2.conda
   hash:
-    md5: 0e602287949cac6ab5f9c66a115f4ae9
-    sha256: ed9e43868cfde96913a9dee2f7e94bf74d7aad19860dc758d29f8545acc1f9db
+    md5: e1c08b005c5210b855bb95548f3e0aff
+    sha256: a528742621d759c35cb6861a05600b75334220ecaa786eafe0e9fe8b72805d3b
   category: dev
   optional: true
 - name: lazy-object-proxy
@@ -7696,12 +7759,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lazy-object-proxy-1.10.0-py312he37b823_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lazy-object-proxy-1.10.0-py312hea69d52_2.conda
   hash:
-    md5: 659ce18f6337555d5e9285eae7d3360b
-    sha256: e9cfa248be46274d279e5ca0dd36f29e107b8bf5c591703c277726fb569fe0db
+    md5: 003b6dc809c6d361d3b59b75940fdd28
+    sha256: 9c87b536e5969294db3f54a20bec19684cd1ba251849a82d8091ceef373d09b8
   category: dev
   optional: true
 - name: lcms2
@@ -7711,7 +7775,7 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libtiff: '>=4.6.0,<4.8.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
   hash:
     md5: 51bb7010fc86f70eee639b4bb7a894f5
@@ -7724,7 +7788,7 @@ package:
   platform: osx-64
   dependencies:
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libtiff: '>=4.6.0,<4.8.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
   hash:
     md5: 1442db8f03517834843666c422238c9b
@@ -7737,7 +7801,7 @@ package:
   platform: osx-arm64
   dependencies:
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libtiff: '>=4.6.0,<4.8.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
   hash:
     md5: 66f6c134e76fe13cce8a9ea5814b5dd5
@@ -7745,14 +7809,15 @@ package:
   category: main
   optional: false
 - name: ld_impl_linux-64
-  version: '2.40'
+  version: '2.43'
   manager: conda
   platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
   hash:
-    md5: b80f2f396ca2c28b8c14c437a4ed1e74
-    sha256: 764b6950aceaaad0c67ef925417594dd14cd2e22fff864aeef455ac259263d15
+    md5: 048b02e3962f066da18efe3a21b77672
+    sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
   category: main
   optional: false
 - name: lerc
@@ -7793,40 +7858,43 @@ package:
   category: main
   optional: false
 - name: libabseil
-  version: '20240116.2'
+  version: '20240722.0'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.2-cxx17_h59595ed_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_hbbce691_4.conda
   hash:
-    md5: 682bdbe046a68f749769b492f3625c5c
-    sha256: 19b789dc38dff64eee2002675991e63f381eedf5efd5c85f2dac512ed97376d7
+    md5: 488f260ccda0afaf08acb286db439c2f
+    sha256: 143a586aa67d50622ef703de57b9d43f44945836d6568e0e7aa174bd8c45e0d4
   category: main
   optional: false
 - name: libabseil
-  version: '20240116.2'
+  version: '20240722.0'
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.2-cxx17_hc1bcbd7_0.conda
+    __osx: '>=10.13'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_h0e468a2_4.conda
   hash:
-    md5: f2ac89dbd4914f487706282ebf787636
-    sha256: 91c7818fd4d4e1d7e7fb6ace5f72e699112a9207f00f1ee82e62b7a87d239837
+    md5: 03dd3d0563d01c2b82881734ee0eb334
+    sha256: 375e98c007cbe2535b89adccf4d417480d54ce2fb4b559f0b700da294dee3985
   category: main
   optional: false
 - name: libabseil
-  version: '20240116.2'
+  version: '20240722.0'
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.2-cxx17_hebf3989_0.conda
+    __osx: '>=11.0'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_h07bc746_4.conda
   hash:
-    md5: edc3edb68fd9cbb014ac675dc73006c2
-    sha256: d96bd35e162637be3767637352195e6cdfd85d98068564f73f3450b0cb265776
+    md5: c2d95bd7aa8d564a9bd7eca5e571a5b3
+    sha256: 05fa5e5e908962b9c5aba95f962e2ca81d9599c4715aebe5e4ddb72b309d1770
   category: main
   optional: false
 - name: libaec
@@ -7867,65 +7935,66 @@ package:
   category: main
   optional: false
 - name: libarchive
-  version: 3.7.4
+  version: 3.7.7
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
-    libgcc-ng: '>=12'
-    libxml2: '>=2.12.7,<3.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libgcc: '>=13'
+    libxml2: '>=2.13.5,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
     lzo: '>=2.10,<3.0a0'
-    openssl: '>=3.3.0,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.4-hfca40fe_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.7-hadbb8c3_0.conda
   hash:
-    md5: 32ddb97f897740641d8d46a829ce1704
-    sha256: c30970e5e6515c662d00bb74e7c1b09ebe0c8c92c772b952a41a5725e2dcc936
+    md5: 4a099677417658748239616b6ca96bb6
+    sha256: 68afcb4519d08cebf71845aff6038e7273f021efc04ef48246f8d41e4e462a61
   category: main
   optional: false
 - name: libarchive
-  version: 3.7.4
+  version: 3.7.7
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     bzip2: '>=1.0.8,<2.0a0'
     libiconv: '>=1.17,<2.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
     lzo: '>=2.10,<3.0a0'
-    openssl: '>=3.3.0,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.4-h20e244c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.7-h7988bea_0.conda
   hash:
-    md5: 82a85fa38e83366009b7f4b2cef4deb8
-    sha256: 9e46db25e976630e6738b351d76d9b79047ae232638b82f9f45eba774caaef8a
+    md5: 5af9f38826ccc57545a5c55c54cbfd92
+    sha256: 50a5ffeeef306c9f29e2872aa011c28f546a364a8e50350bd05ff0055ad8c599
   category: main
   optional: false
 - name: libarchive
-  version: 3.7.4
+  version: 3.7.7
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     bzip2: '>=1.0.8,<2.0a0'
     libiconv: '>=1.17,<2.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
     lzo: '>=2.10,<3.0a0'
-    openssl: '>=3.3.0,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.4-h83d404f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.7-h7c07d2a_0.conda
   hash:
-    md5: 8b604ee634caafd92f2ff2fab6a1f75a
-    sha256: 5301d7dc52c2e1f87b229606033c475caf87cd94ef5a5efb3af565a62b88127e
+    md5: 49b28e291693b70cf8a7e70f290834d8
+    sha256: 10d5c755761c6823d20c6ddbd42292ef91f34e271b6ba3e78d0c5fa81c22b3ed
   category: main
   optional: false
 - name: libarrow
@@ -7934,30 +8003,30 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-crt-cpp: '>=0.27.2,<0.27.3.0a0'
-    aws-sdk-cpp: '>=1.11.329,<1.11.330.0a0'
+    aws-crt-cpp: '>=0.29.3,<0.29.4.0a0'
+    aws-sdk-cpp: '>=1.11.407,<1.11.408.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     gflags: '>=2.2.2,<2.3.0a0'
     glog: '>=0.7.1,<0.8.0a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libgcc-ng: '>=12'
-    libgoogle-cloud: '>=2.26.0,<2.27.0a0'
-    libgoogle-cloud-storage: '>=2.26.0,<2.27.0a0'
-    libre2-11: '>=2023.9.1,<2024.0a0'
-    libstdcxx-ng: '>=12'
-    libutf8proc: '>=2.8.0,<3.0a0'
+    libgcc: '>=13'
+    libgoogle-cloud: '>=2.30.0,<2.31.0a0'
+    libgoogle-cloud-storage: '>=2.30.0,<2.31.0a0'
+    libre2-11: '>=2024.7.2'
+    libstdcxx: '>=13'
+    libutf8proc: <2.9
     libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=2.0.1,<2.0.2.0a0'
+    orc: '>=2.0.2,<2.0.3.0a0'
     re2: ''
     snappy: '>=1.2.1,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.2-hea66c7c_30_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.2-hccc8d3c_52_cpu.conda
   hash:
-    md5: 775195f66c7a6b8ed54a9e103bd3e82f
-    sha256: 47bba742ebdf29efeabb8c7886053d5999fe59a77ea5b7889aef633dafa57c9f
+    md5: 1f8dfe438d4806e3c8ccafac367ac851
+    sha256: df99f327ee1032e0c3582f9527c3ed965fe2bea042ee3cc5769a5568a3606e79
   category: main
   optional: false
 - name: libarrow
@@ -7966,28 +8035,28 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-crt-cpp: '>=0.27.2,<0.27.3.0a0'
-    aws-sdk-cpp: '>=1.11.329,<1.11.330.0a0'
+    aws-crt-cpp: '>=0.29.3,<0.29.4.0a0'
+    aws-sdk-cpp: '>=1.11.407,<1.11.408.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     glog: '>=0.7.1,<0.8.0a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libcxx: '>=14'
-    libgoogle-cloud: '>=2.26.0,<2.27.0a0'
-    libgoogle-cloud-storage: '>=2.26.0,<2.27.0a0'
-    libre2-11: '>=2023.9.1,<2024.0a0'
-    libutf8proc: '>=2.8.0,<3.0a0'
+    libcxx: '>=17'
+    libgoogle-cloud: '>=2.30.0,<2.31.0a0'
+    libgoogle-cloud-storage: '>=2.30.0,<2.31.0a0'
+    libre2-11: '>=2024.7.2'
+    libutf8proc: <2.9
     libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=2.0.1,<2.0.2.0a0'
+    orc: '>=2.0.2,<2.0.3.0a0'
     re2: ''
     snappy: '>=1.2.1,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.2-hd7665df_30_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.2-hff4c71d_52_cpu.conda
   hash:
-    md5: baa3f2717b29f2060ca29a5c706a393c
-    sha256: d4ba20025c31f011ce002aaaa684aa173f603b19727861071540b1e3c99b6dab
+    md5: 9b3e790cd4df47ed85fe10d89f4ae2ad
+    sha256: d26011347953c6a12826de1021ddabb37cfcf4db21d3146a6c8e63dec9e647dc
   category: main
   optional: false
 - name: libarrow
@@ -7996,28 +8065,28 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-crt-cpp: '>=0.27.2,<0.27.3.0a0'
-    aws-sdk-cpp: '>=1.11.329,<1.11.330.0a0'
+    aws-crt-cpp: '>=0.29.3,<0.29.4.0a0'
+    aws-sdk-cpp: '>=1.11.407,<1.11.408.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     glog: '>=0.7.1,<0.8.0a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libcxx: '>=14'
-    libgoogle-cloud: '>=2.26.0,<2.27.0a0'
-    libgoogle-cloud-storage: '>=2.26.0,<2.27.0a0'
-    libre2-11: '>=2023.9.1,<2024.0a0'
-    libutf8proc: '>=2.8.0,<3.0a0'
+    libcxx: '>=17'
+    libgoogle-cloud: '>=2.30.0,<2.31.0a0'
+    libgoogle-cloud-storage: '>=2.30.0,<2.31.0a0'
+    libre2-11: '>=2024.7.2'
+    libutf8proc: <2.9
     libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=2.0.1,<2.0.2.0a0'
+    orc: '>=2.0.2,<2.0.3.0a0'
     re2: ''
     snappy: '>=1.2.1,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.2-hf22df12_30_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.2-h97e12a9_52_cpu.conda
   hash:
-    md5: bf503b669f14d9d037edbeb11f21dcc1
-    sha256: 1e475098a921c2657cbf0c2694d2dc9d1ed92511cae894f7b8f0fff2a66472b7
+    md5: 93eced965c69854014546ae88ca49cc8
+    sha256: d20ee2b31e7360d687960b7c8ecf667cc7fef66babb4c2f88f3251a62c1159cc
   category: main
   optional: false
 - name: libarrow-acero
@@ -8028,12 +8097,12 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     gflags: '>=2.2.2,<2.3.0a0'
     libarrow: 14.0.2
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.2-h44f6110_30_cpu.conda
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.2-h5d0bfc1_52_cpu.conda
   hash:
-    md5: f1b619d3e7fbb092b21c66e1cef4e4e2
-    sha256: f81a4d1b03ce25a8c566a3986dffb99b6eec55dd941b9a8a58b661270c41e268
+    md5: 9279fa5a3b12d65a3fdfd1f24830aa26
+    sha256: f17ec704eeb22c5efe73ddc312ecfcd0e4b338d62e8d3af008eb19966a9f8ade
   category: main
   optional: false
 - name: libarrow-acero
@@ -8043,11 +8112,11 @@ package:
   dependencies:
     __osx: '>=10.13'
     libarrow: 14.0.2
-    libcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.2-h5768557_30_cpu.conda
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.2-h97d8b74_52_cpu.conda
   hash:
-    md5: a88323c3317614c90e5a4fdaf3d79e1f
-    sha256: 3a225529fb8a02817939f70811cb738f4bf1360317362204736b82c18e115d6b
+    md5: fb0bc2ff1cf8ca362fc0199a52ae1af1
+    sha256: d691f756d5c326380cc2852b51cdcaf5dc103849bc44598d95829b8c89d294d7
   category: main
   optional: false
 - name: libarrow-acero
@@ -8057,11 +8126,11 @@ package:
   dependencies:
     __osx: '>=11.0'
     libarrow: 14.0.2
-    libcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.2-h7f2d090_30_cpu.conda
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.2-h5833ebf_52_cpu.conda
   hash:
-    md5: 4482469fb87498e88c9ceb0853aea147
-    sha256: 866fd29f3b21611b1011c60b056ff143b9d8aea3fce19ec1cb37fc16d3e5a636
+    md5: 3eb545dd1cf8cc6159508fca783ea54d
+    sha256: edccf5e1aebe159ead1d733e798f02e7ef86f3d71e6b55e6c62563345ecd962a
   category: main
   optional: false
 - name: libarrow-dataset
@@ -8073,13 +8142,13 @@ package:
     gflags: '>=2.2.2,<2.3.0a0'
     libarrow: 14.0.2
     libarrow-acero: 14.0.2
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     libparquet: 14.0.2
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.2-h44f6110_30_cpu.conda
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.2-h5d0bfc1_52_cpu.conda
   hash:
-    md5: b747bdb4e8969e74362054b82bd3763d
-    sha256: 3e56cf35bf909363a218a8e61b6a0fb13d1e00e6eefd29ebf9a28fd607b190c4
+    md5: 430c5c0c381b6329972d02464339c496
+    sha256: ac6a9e351d860838ebe131e1a843bf2bf19f649f14654f1f083d2326b0141073
   category: main
   optional: false
 - name: libarrow-dataset
@@ -8090,12 +8159,12 @@ package:
     __osx: '>=10.13'
     libarrow: 14.0.2
     libarrow-acero: 14.0.2
-    libcxx: '>=14'
+    libcxx: '>=17'
     libparquet: 14.0.2
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.2-h5768557_30_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.2-h97d8b74_52_cpu.conda
   hash:
-    md5: 2a948e62f2cedd3daae8434ddcf3244e
-    sha256: 31517cf2423c7c60d46834f0bae6964c074c38c924a7dd83cd20cc0cfe6fcc3a
+    md5: 5262b5872182745387ed883f12dc1161
+    sha256: 410b0d3eff94471296057c96e10617b499f1531e33ee2ff6708b02c90c37f11f
   category: main
   optional: false
 - name: libarrow-dataset
@@ -8106,12 +8175,12 @@ package:
     __osx: '>=11.0'
     libarrow: 14.0.2
     libarrow-acero: 14.0.2
-    libcxx: '>=14'
+    libcxx: '>=17'
     libparquet: 14.0.2
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.2-h7f2d090_30_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.2-h5833ebf_52_cpu.conda
   hash:
-    md5: e76a852a6f7217ddbee3524b81a7418f
-    sha256: a608bd060d7030382b6a2aa58ecd6992ebb122a98447c96d60fc949755506a29
+    md5: f784986633a174ce2961ac636e9efea2
+    sha256: defd6b86699f96d7003d26ebd206c5bc887945480812b8f4a81f6402317924a2
   category: main
   optional: false
 - name: libarrow-flight
@@ -8121,17 +8190,17 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     gflags: '>=2.2.2,<2.3.0a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
     libarrow: 14.0.2
-    libgcc-ng: '>=12'
-    libgrpc: '>=1.62.2,<1.63.0a0'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-    ucx: '>=1.16.0,<1.17.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.2-h55b8332_30_cpu.conda
+    libgcc: '>=13'
+    libgrpc: '>=1.67.1,<1.68.0a0'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libstdcxx: '>=13'
+    ucx: '>=1.17.0,<1.18.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.2-he7f0889_52_cpu.conda
   hash:
-    md5: 8178c5bc6f63b6434391092606b8ab4c
-    sha256: 79ec64aa6edd27daa0a19d1a15b0a39e257dbcbe46837d5e5b68eb44ee613c4b
+    md5: 7f9cbce1e819c5eb0f80f80751ca5458
+    sha256: 6f4c9a0a86da645f6f8e6c4ff8a8674a4d108529ba3d58d5524238246f1cd8e6
   category: main
   optional: false
 - name: libarrow-flight
@@ -8140,15 +8209,15 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libabseil: '>=20240116.2,<20240117.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
     libarrow: 14.0.2
-    libcxx: '>=14'
-    libgrpc: '>=1.62.2,<1.63.0a0'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.2-h0503de3_30_cpu.conda
+    libcxx: '>=17'
+    libgrpc: '>=1.67.1,<1.68.0a0'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.2-hadc88be_52_cpu.conda
   hash:
-    md5: 8fc28a7c158ea7a680ed086f5f108665
-    sha256: 9162b60d2a0863b1a1b8e70453e8ac4d371620e1beaf82bcf38a11553c0fdb24
+    md5: 2c351b1f5753a46b318aa6bc2d65d73c
+    sha256: 8217bc043d0b1a9c6d37384cf3f974ade6f8df5ac94d99344794f375881be028
   category: main
   optional: false
 - name: libarrow-flight
@@ -8157,15 +8226,15 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libabseil: '>=20240116.2,<20240117.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
     libarrow: 14.0.2
-    libcxx: '>=14'
-    libgrpc: '>=1.62.2,<1.63.0a0'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.2-h995e30c_30_cpu.conda
+    libcxx: '>=17'
+    libgrpc: '>=1.67.1,<1.68.0a0'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.2-hf98a671_52_cpu.conda
   hash:
-    md5: fd090c8345eb24494a089856d2b352fd
-    sha256: 0b4483b345b07400ed260b42148b0c6e3029ff6d536004dcc650db5cc67994c5
+    md5: 099f9167b6aaf3f27538bc7ced57d704
+    sha256: 0249a77e0c6f18a69fbed5fc62cc94e2f69a346c44c43f426ba15e8ce30c0768
   category: main
   optional: false
 - name: libarrow-flight-sql
@@ -8177,13 +8246,13 @@ package:
     gflags: '>=2.2.2,<2.3.0a0'
     libarrow: 14.0.2
     libarrow-flight: 14.0.2
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.2-h61825be_30_cpu.conda
+    libgcc: '>=13'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.2-he7b089f_52_cpu.conda
   hash:
-    md5: bb474bc482eb712eabf3f2bbbe5f54de
-    sha256: c4e970422c84059ca1d73b7b659a30f4db16d190648e662701d839362146ca9f
+    md5: 39d6fd40fd33a3402865e378d5184053
+    sha256: 7d4213d8024f88fa3c95ba1c1ea2c4ea80211d3dd333576dc7a0214bb492fe2a
   category: main
   optional: false
 - name: libarrow-flight-sql
@@ -8194,12 +8263,12 @@ package:
     __osx: '>=10.13'
     libarrow: 14.0.2
     libarrow-flight: 14.0.2
-    libcxx: '>=14'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.2-h35165ce_30_cpu.conda
+    libcxx: '>=17'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.2-heffbc13_52_cpu.conda
   hash:
-    md5: 062c4564308cf2d25b4833e0cceb0a7d
-    sha256: dc28725c760d5176c3ab34e816b89520a5a2b3d81aacd1c97c6f0886901e5fda
+    md5: c0339c0b736a721807d2390c1ab8b7dc
+    sha256: 1d3f3e6f36e22eef1eafe535bbfc006b13d87cdcb8abde6b943f636b7d39da04
   category: main
   optional: false
 - name: libarrow-flight-sql
@@ -8210,12 +8279,12 @@ package:
     __osx: '>=11.0'
     libarrow: 14.0.2
     libarrow-flight: 14.0.2
-    libcxx: '>=14'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.2-hb50bbf7_30_cpu.conda
+    libcxx: '>=17'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.2-h0f5b584_52_cpu.conda
   hash:
-    md5: fbd774dc9020cf3ec90f5579a8661467
-    sha256: 3f975619f4e91799213976a38ddb17c76497670903a0543d54ce8154576a8c96
+    md5: 51b47cbeae6806d0c2d1711078adbee6
+    sha256: f6a2c37f17f09c9ec6a68318ec0d65b94727d0fe87baf4a64429257e335cb3e4
   category: main
   optional: false
 - name: libarrow-gandiva
@@ -8226,17 +8295,17 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     gflags: '>=2.2.2,<2.3.0a0'
     libarrow: 14.0.2
-    libgcc-ng: '>=12'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libre2-11: '>=2023.9.1,<2024.0a0'
-    libstdcxx-ng: '>=12'
-    libutf8proc: '>=2.8.0,<3.0a0'
-    openssl: '>=3.3.1,<4.0a0'
+    libgcc: '>=13'
+    libllvm17: '>=17.0.6,<17.1.0a0'
+    libre2-11: '>=2024.7.2'
+    libstdcxx: '>=13'
+    libutf8proc: <2.9
+    openssl: '>=3.3.2,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.2-hfcb4b9d_30_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.2-h18fa613_52_cpu.conda
   hash:
-    md5: c32b163fb41398a37446ef14a8033c25
-    sha256: 3734a66492fabf1560196599e0b6d1516c8f021002e7106ddcf60e18424745c2
+    md5: 29ea30d64ac9114516f4c4c0823dc783
+    sha256: 6b6f310ef28b805b84f64629760c718f9c67ca32e2b4cf600cb8a2a54ee72fd7
   category: main
   optional: false
 - name: libarrow-gandiva
@@ -8246,16 +8315,16 @@ package:
   dependencies:
     __osx: '>=10.13'
     libarrow: 14.0.2
-    libcxx: '>=14'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libre2-11: '>=2023.9.1,<2024.0a0'
-    libutf8proc: '>=2.8.0,<3.0a0'
-    openssl: '>=3.3.1,<4.0a0'
+    libcxx: '>=17'
+    libllvm17: '>=17.0.6,<17.1.0a0'
+    libre2-11: '>=2024.7.2'
+    libutf8proc: <2.9
+    openssl: '>=3.3.2,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.2-hde8f4f9_30_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.2-h13f1c6c_52_cpu.conda
   hash:
-    md5: 09df0cfe63f7b03bf63477d653b84b1e
-    sha256: deee0c647e45c0082d24764e84bc6bb34a04f38a4bb6294630ac362d93bcb45e
+    md5: 099acb8f06d017983edcdfcba6c30186
+    sha256: 5d9e0ab9c537037dac3aa62a4b35dade7a73031e4e5f20e8fb23cc58857d0148
   category: main
   optional: false
 - name: libarrow-gandiva
@@ -8265,16 +8334,16 @@ package:
   dependencies:
     __osx: '>=11.0'
     libarrow: 14.0.2
-    libcxx: '>=14'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libre2-11: '>=2023.9.1,<2024.0a0'
-    libutf8proc: '>=2.8.0,<3.0a0'
-    openssl: '>=3.3.1,<4.0a0'
+    libcxx: '>=17'
+    libllvm17: '>=17.0.6,<17.1.0a0'
+    libre2-11: '>=2024.7.2'
+    libutf8proc: <2.9
+    openssl: '>=3.3.2,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.2-h854e664_30_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.2-h6d50e30_52_cpu.conda
   hash:
-    md5: ec5b74650a81f3d5e616f2939d7f2e82
-    sha256: fdcbe60565ea02442ab7fb472fc5d44883aa978873d9e293d322bb01b6aba981
+    md5: 43c0d9fb72bfb28263199616aa0411c3
+    sha256: aab297810e06641817f246da43e909581bc7161ecdedc6ecfb513c19aa385a43
   category: main
   optional: false
 - name: libarrow-substrait
@@ -8287,13 +8356,13 @@ package:
     libarrow: 14.0.2
     libarrow-acero: 14.0.2
     libarrow-dataset: 14.0.2
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.2-h61825be_30_cpu.conda
+    libgcc: '>=13'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.2-he7b089f_52_cpu.conda
   hash:
-    md5: eaba2f03375c504968f41eb71fc95df4
-    sha256: 27254e1e13a2011053264f5d898d0366906ec248a6337b39f6483f068c4283b4
+    md5: c336ae13e9a0da1f9ddab96620931fae
+    sha256: 289ae886fc9658120f08fd290d67400c8f08a5ad08f224a44c54dbbbe792bd8a
   category: main
   optional: false
 - name: libarrow-substrait
@@ -8305,12 +8374,12 @@ package:
     libarrow: 14.0.2
     libarrow-acero: 14.0.2
     libarrow-dataset: 14.0.2
-    libcxx: '>=14'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.2-h35165ce_30_cpu.conda
+    libcxx: '>=17'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.2-heffbc13_52_cpu.conda
   hash:
-    md5: 496b27d9fa02f05f311abcfa0b023967
-    sha256: d50ecf19d5c59b015cbc849044c4a483c15164fdc272c4f5f47e1951bddf7ead
+    md5: 49e74fe7f996e054afcbfdda6ed2a3d4
+    sha256: 4033d1702f3f8ba675c80ad23461e8f2864d821e28547ed5d43212619ebd7c96
   category: main
   optional: false
 - name: libarrow-substrait
@@ -8322,70 +8391,99 @@ package:
     libarrow: 14.0.2
     libarrow-acero: 14.0.2
     libarrow-dataset: 14.0.2
-    libcxx: '>=14'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.2-hfe31399_30_cpu.conda
+    libcxx: '>=17'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.2-h8cfa146_52_cpu.conda
   hash:
-    md5: a60e1afdd9dc54fcdc178339bda37e87
-    sha256: f8b4218e978d4232227f11b5838aa90df76efc08732007ca88438e7958c7698d
+    md5: 79ac56f353f2fc18564ea4e19fc67101
+    sha256: 0478d1e098fa55c34c064e9e6da36b1f3026228bdfcab5fae87c81e1182a2be6
   category: main
   optional: false
 - name: libasprintf
   version: 0.22.5
   manager: conda
   platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-h5ff76d1_2.conda
+  dependencies:
+    __osx: '>=10.13'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-hdfe23c8_3.conda
   hash:
-    md5: ad803793d7168331f1395685cbdae212
-    sha256: 4babb29b8d39ae8b341c094c134a1917c595846e5f974c9d0cb64d3f734b46b1
+    md5: 55363e1d53635b3497cdf753ab0690c1
+    sha256: 9c6f3e2558e098dbbc63c9884b4af368ea6cc4185ea027563ac4f5ee8571b143
   category: dev
   optional: true
 - name: libasprintf
   version: 0.22.5
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8fbad5d_2.conda
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8414b35_3.conda
   hash:
-    md5: 1b27402397a76115679c4855ab2ece41
-    sha256: 04bbe4374719906cd08b639a3f34828030f405c33b47c757b47fd55aa7310179
+    md5: 472b673c083175195965a48f2f4808f8
+    sha256: 819bf95543470658f48db53a267a3fabe1616797c4031cf88e63f451c5029e6f
   category: dev
   optional: true
-- name: libasprintf-devel
-  version: 0.22.5
+- name: libavif16
+  version: 1.1.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aom: '>=3.9.1,<3.10.0a0'
+    dav1d: '>=1.2.1,<1.2.2.0a0'
+    libgcc: '>=13'
+    rav1e: '>=0.6.6,<1.0a0'
+    svt-av1: '>=2.3.0,<2.3.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.1-h1909e37_2.conda
+  hash:
+    md5: 21e468ed3786ebcb2124b123aa2484b7
+    sha256: e06da844b007a64a9ac35d4e3dc4dbc66583f79b57d08166cf58f2f08723a6e8
+  category: main
+  optional: false
+- name: libavif16
+  version: 1.1.1
   manager: conda
   platform: osx-64
   dependencies:
-    libasprintf: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-devel-0.22.5-h5ff76d1_2.conda
+    __osx: '>=10.13'
+    aom: '>=3.9.1,<3.10.0a0'
+    dav1d: '>=1.2.1,<1.2.2.0a0'
+    rav1e: '>=0.6.6,<1.0a0'
+    svt-av1: '>=2.3.0,<2.3.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.1.1-h71406da_2.conda
   hash:
-    md5: c7182eda3bc727384e2f98f4d680fa7d
-    sha256: 39fa757378b49993142013c1f69dd56248cc3703c2f04c5bcf4cc4acdc644ae3
-  category: dev
-  optional: true
-- name: libasprintf-devel
-  version: 0.22.5
+    md5: 804f440fd71e1a903215710826cf98aa
+    sha256: 8e3d479f13a85ee73c3152704c1d9e0430065f4824bae625f2f35c463c172831
+  category: main
+  optional: false
+- name: libavif16
+  version: 1.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    libasprintf: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-devel-0.22.5-h8fbad5d_2.conda
+    __osx: '>=11.0'
+    aom: '>=3.9.1,<3.10.0a0'
+    dav1d: '>=1.2.1,<1.2.2.0a0'
+    rav1e: '>=0.6.6,<1.0a0'
+    svt-av1: '>=2.3.0,<2.3.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.1.1-h45b7238_2.conda
   hash:
-    md5: 480c106e87d4c4791e6b55a6d1678866
-    sha256: f5331486854a5fe80bb837891efb28a28623f762327372cb4cbc264c9c4bf9e2
-  category: dev
-  optional: true
+    md5: 7571064a60bc193ff5c25f36ed23394a
+    sha256: c671365e8c822d29b53f20c4573fdbc70f18b50ff9a4b5b2b6b3c8f7ad2ac2a9
+  category: main
+  optional: false
 - name: libblas
   version: 3.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.27,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-22_linux64_openblas.conda
+    libopenblas: '>=0.3.28,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-28_h59b9bed_openblas.conda
   hash:
-    md5: 1a2a0cd3153464fee6646f3dd6dad9b8
-    sha256: 082b8ac20d43a7bbcdc28b3b1cd40e4df3a8b5daf0a2d23d68953a44d2d12c1b
+    md5: 73e2a99fdeb8531d50168987378fda8a
+    sha256: 93fbcf2800b859b7ca5add3ab5d3aa11c6a6ff4b942a1cea4bf644f78488edb8
   category: main
   optional: false
 - name: libblas
@@ -8393,11 +8491,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    libopenblas: '>=0.3.27,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-22_osx64_openblas.conda
+    libopenblas: '>=0.3.28,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-28_h7f60823_openblas.conda
   hash:
-    md5: b80966a8c8dd0b531f8e65f709d732e8
-    sha256: d72060239f904b3a81d2329efcf84dc62c2dfd66dbc4efc8dcae1afdf8f02b59
+    md5: c9f0b30e5ab2f4ddc450b95743d2070d
+    sha256: c44341975c7d0b4b02c2676af30a723b109698b2939928b80c45efc2aa36ef2d
   category: main
   optional: false
 - name: libblas
@@ -8405,11 +8503,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    libopenblas: '>=0.3.27,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-22_osxarm64_openblas.conda
+    libopenblas: '>=0.3.28,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-28_h10e41b3_openblas.conda
   hash:
-    md5: aeaf35355ef0f37c7c1ba35b7b7db55f
-    sha256: 8620e13366076011cfcc6b2565c7a2d362c5d3f0423f54b9ef9bfc17b1a012a4
+    md5: 166166d84a0e9571dc50210baf993b46
+    sha256: 5bea855a1a7435ce2238535aa4b13db8af8ee301d99a42b083b63fa64c1ea144
   category: main
   optional: false
 - name: libbrotlicommon
@@ -8417,33 +8515,36 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
   hash:
-    md5: aec6c91c7371c26392a06708a73c70e5
-    sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
+    md5: 41b599ed2b02abcfdd84302bff174b23
+    sha256: d9db2de60ea917298e658143354a530e9ca5f9c63471c65cf47ab39fd2f429e3
   category: main
   optional: false
 - name: libbrotlicommon
   version: 1.1.0
   manager: conda
   platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
   hash:
-    md5: 9e6c31441c9aa24e41ace40d6151aab6
-    sha256: f57c57c442ef371982619f82af8735f93a4f50293022cfd1ffaf2ff89c2e0b2a
+    md5: 58f2c4bdd56c46cc7451596e4ae68e0b
+    sha256: b377056470a9fb4a100aa3c51b3581aab6496ba84d21cd99bcc1d5ef0359b1b6
   category: main
   optional: false
 - name: libbrotlicommon
   version: 1.1.0
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
   hash:
-    md5: cd68f024df0304be41d29a9088162b02
-    sha256: 556f0fddf4bd4d35febab404d98cb6862ce3b7ca843e393da0451bfc4654cf07
+    md5: d0bf1dff146b799b319ea0434b93f779
+    sha256: 839dacb741bdbb25e58f42088a2001b649f4f12195aeb700b5ddfca3267749e5
   category: main
   optional: false
 - name: libbrotlidec
@@ -8451,12 +8552,13 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libbrotlicommon: 1.1.0
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
   hash:
-    md5: f07002e225d7a60a694d42a7bf5ff53f
-    sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
+    md5: 9566f0bd264fbd463002e759b8a82401
+    sha256: 2892d512cad096cb03f1b66361deeab58b64e15ba525d6592bb6d609e7045edf
   category: main
   optional: false
 - name: libbrotlidec
@@ -8464,11 +8566,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     libbrotlicommon: 1.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
   hash:
-    md5: 9ee0bab91b2ca579e10353738be36063
-    sha256: b11939c4c93c29448660ab5f63273216969d1f2f315dd9be60f3c43c4e61a50c
+    md5: 34709a1f5df44e054c4a12ab536c5459
+    sha256: 4d49ea72e2f44d2d7a8be5472e4bd0bc2c6b89c55569de2c43576363a0685c0c
   category: main
   optional: false
 - name: libbrotlidec
@@ -8476,11 +8579,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     libbrotlicommon: 1.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
   hash:
-    md5: ee1a519335cc10d0ec7e097602058c0a
-    sha256: c1c85937828ad3bc434ac60b7bcbde376f4d2ea4ee42d15d369bf2a591775b4a
+    md5: 55e66e68ce55523a6811633dd1ac74e2
+    sha256: 6c6862eb274f21a7c0b60e5345467a12e6dda8b9af4438c66d496a2c1a538264
   category: main
   optional: false
 - name: libbrotlienc
@@ -8488,12 +8592,13 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libbrotlicommon: 1.1.0
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
   hash:
-    md5: 5fc11c6020d421960607d821310fcd4d
-    sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
+    md5: 06f70867945ea6a84d35836af780f1de
+    sha256: 779f58174e99de3600e939fa46eddb453ec5d3c60bb46cdaa8b4c127224dbf29
   category: main
   optional: false
 - name: libbrotlienc
@@ -8501,11 +8606,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     libbrotlicommon: 1.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
   hash:
-    md5: 8a421fe09c6187f0eb5e2338a8a8be6d
-    sha256: bc964c23e1a60ca1afe7bac38a9c1f2af3db4a8072c9f2eac4e4de537a844ac7
+    md5: 691f0dcb36f1ae67f5c489f20ae987ea
+    sha256: 477d236d389473413a1ccd2bec1b66b2f1d2d7d1b4a57bb56421b7b611a56cd1
   category: main
   optional: false
 - name: libbrotlienc
@@ -8513,11 +8619,26 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     libbrotlicommon: 1.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hd74edd7_2.conda
   hash:
-    md5: d7e077f326a98b2cc60087eaff7c730b
-    sha256: 690dfc98e891ee1871c54166d30f6e22edfc2d7d6b29e7988dde5f1ce271c81a
+    md5: 4f3a434504c67b2c42565c0b85c1885c
+    sha256: eeb1eb0d58b9d02bc1b98dc0a058f104ab168eb2f7d1c7bfa0570a12cfcdb7b7
+  category: main
+  optional: false
+- name: libcap
+  version: '2.71'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    attr: '>=2.5.1,<2.6.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.71-h39aace5_0.conda
+  hash:
+    md5: dd19e4e3043f6948bd7454b946ee0983
+    sha256: 2bbefac94f4ab8ff7c64dc843238b6c8edcc9ff1f2b5a0a48407a904dc7ccfb2
   category: main
   optional: false
 - name: libcblas
@@ -8526,10 +8647,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-22_linux64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-28_he106b2a_openblas.conda
   hash:
-    md5: 4b31699e0ec5de64d5896e580389c9a1
-    sha256: da1b2faa017663c8f5555c1c5518e96ac4cd8e0be2a673c1c9e2cb8507c8fe46
+    md5: 4e20a1c00b4e8a984aac0f6cce59e3ac
+    sha256: de293e117db53e5d78b579136509c35a5e4ad11529c05f9af83cf89be4d30de1
   category: main
   optional: false
 - name: libcblas
@@ -8538,10 +8659,10 @@ package:
   platform: osx-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-22_osx64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-28_hff6cab4_openblas.conda
   hash:
-    md5: b9fef82772330f61b2b0201c72d2c29b
-    sha256: 6a2ba9198e2320c3e22fe3d121310cf8a8ac663e94100c5693b34523fcb3cc04
+    md5: bf672fd5b62c531028cda585c6ee91b1
+    sha256: 3940ad1fe20fac8a21fe699ade336a649d0509bc6ff9bfc080b258f68cd056df
   category: main
   optional: false
 - name: libcblas
@@ -8550,10 +8671,10 @@ package:
   platform: osx-arm64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-22_osxarm64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-28_hb3479ef_openblas.conda
   hash:
-    md5: 37b3682240a69874a22658dedbca37d9
-    sha256: 2c7902985dc77db1d7252b4e838d92a34b1729799ae402988d62d077868f6cca
+    md5: 30942dea911ce333765003a8adec4e8a
+    sha256: f08adea59381babb3568e6d23e52aff874cbc25f299821647ab1127d1e1332ca
   category: main
   optional: false
 - name: libcrc32c
@@ -8593,151 +8714,212 @@ package:
     sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
   category: main
   optional: false
-- name: libcurl
-  version: 8.8.0
+- name: libcups
+  version: 2.3.3
   manager: conda
   platform: linux-64
   dependencies:
-    krb5: '>=1.21.3,<1.22.0a0'
+    krb5: '>=1.21.1,<1.22.0a0'
     libgcc-ng: '>=12'
-    libnghttp2: '>=1.58.0,<2.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.8.0-hca28451_1.conda
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<2.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
   hash:
-    md5: b8afb3e3cb3423cc445cf611ab95fdb0
-    sha256: 6b5b64cdcdb643368ebe236de07eedee99b025bb95129bbe317c46e5bdc693f3
+    md5: d4529f4dff3057982a7617c7ac58fde3
+    sha256: bc67b9b21078c99c6bd8595fe7e1ed6da1f721007726e717f0449de7032798c4
+  category: dev
+  optional: true
+- name: libcurl
+  version: 8.11.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    krb5: '>=1.21.3,<1.22.0a0'
+    libgcc: '>=13'
+    libnghttp2: '>=1.64.0,<2.0a0'
+    libssh2: '>=1.11.1,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.11.1-h332b0f4_0.conda
+  hash:
+    md5: 2b3e0081006dc21e8bf53a91c83a055c
+    sha256: 3cd4075b2a7b5562e46c8ec626f6f9ca57aeecaa94ff7df57eca26daa94c9906
   category: main
   optional: false
 - name: libcurl
-  version: 8.8.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    krb5: '>=1.21.3,<1.22.0a0'
-    libnghttp2: '>=1.58.0,<2.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.8.0-hf9fcc65_1.conda
-  hash:
-    md5: 11711bab5306a6534797a68b3c4c2bed
-    sha256: 25e2b044e6978f1714a4b2844f34a45fc8a0c60185db8d332906989d70b65927
-  category: main
-  optional: false
-- name: libcurl
-  version: 8.8.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    krb5: '>=1.21.3,<1.22.0a0'
-    libnghttp2: '>=1.58.0,<2.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.8.0-h7b6f9a7_1.conda
-  hash:
-    md5: e9580b0bb247a2ccf937b16161478f19
-    sha256: 9da82a9bd72e9872941da32be54543076c92dbeb2aba688a1c24adbc1c699e64
-  category: main
-  optional: false
-- name: libcxx
-  version: 18.1.8
+  version: 8.11.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-hef8daea_0.conda
+    krb5: '>=1.21.3,<1.22.0a0'
+    libnghttp2: '>=1.64.0,<2.0a0'
+    libssh2: '>=1.11.1,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.11.1-h5dec5d8_0.conda
   hash:
-    md5: 4101cde4241c92aeac310d65e6791579
-    sha256: d5e7755fe7175e6632179801f2e71c67eec033f1610a48e14510df679c038aa3
+    md5: 2f80e92674f4a92e9f8401494496ee62
+    sha256: a4ee3da1a5fd753a382d129dffb079a1e8a244e5c7ff3f7aadc15bf127f8b5e5
   category: main
   optional: false
-- name: libcxx
-  version: 18.1.8
+- name: libcurl
+  version: 8.11.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-18.1.8-h167917d_0.conda
+    krb5: '>=1.21.3,<1.22.0a0'
+    libnghttp2: '>=1.64.0,<2.0a0'
+    libssh2: '>=1.11.1,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.11.1-h73640d1_0.conda
   hash:
-    md5: c891c2eeabd7d67fbc38e012cc6045d6
-    sha256: a598062f2d1522fc3727c16620fbc2bc913c1069342671428a92fcf4eb02ec12
+    md5: 46d7524cabfdd199bffe63f8f19a552b
+    sha256: f47c35938144c23278987c7d12096f6a42d7c850ffc277222b032073412383b6
   category: main
   optional: false
-- name: libdeflate
-  version: '1.20'
+- name: libcxx
+  version: 19.1.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.7-hf95d169_0.conda
+  hash:
+    md5: 4b8f8dc448d814169dbc58fc7286057d
+    sha256: 6b2fa3fb1e8cd2000b0ed259e0c4e49cbef7b76890157fac3e494bc659a20330
+  category: main
+  optional: false
+- name: libcxx
+  version: 19.1.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.7-ha82da77_0.conda
+  hash:
+    md5: 5b3e1610ff8bd5443476b91d618f5b77
+    sha256: 776092346da87a2a23502e14d91eb0c32699c4a1522b7331537bd1c3751dcff5
+  category: main
+  optional: false
+- name: libde265
+  version: 1.0.15
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.20-hd590300_0.conda
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libde265-1.0.15-h00ab1b0_0.conda
   hash:
-    md5: 8e88f9389f1165d7c0936fe40d9a9a79
-    sha256: f8e0f25c382b1d0b87a9b03887a34dbd91485453f1ea991fef726dba57373612
+    md5: 407fee7a5d7ab2dca12c9ca7f62310ad
+    sha256: 7cf7e294e1a7c8219065885e186d8f52002fb900bf384d815f159b5874204e3d
   category: main
   optional: false
-- name: libdeflate
-  version: '1.20'
+- name: libde265
+  version: 1.0.15
   manager: conda
   platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.20-h49d49c5_0.conda
+  dependencies:
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libde265-1.0.15-h7728843_0.conda
   hash:
-    md5: d46104f6a896a0bc6a1d37b88b2edf5c
-    sha256: 8c2087952db55c4118dd2e29381176a54606da47033fd61ebb1b0f4391fcd28d
+    md5: a270b0e1a2a3326cc21eee82c42efffc
+    sha256: a67544ca45a082da0c868fbcd1a0f49fc6f92281aa9aedd20bdce9e7c7e45817
+  category: main
+  optional: false
+- name: libde265
+  version: 1.0.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libde265-1.0.15-h2ffa867_0.conda
+  hash:
+    md5: 7c718ee6d8497702145612fa0898a12d
+    sha256: 13747fa634f7f16d7f222b7d3869e3c1aab9d3a2791edeb2fc632a87663950e0
   category: main
   optional: false
 - name: libdeflate
-  version: '1.20'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.20-h93a5062_0.conda
-  hash:
-    md5: 97efeaeba2a9a82bdf46fc6d025e3a57
-    sha256: 6d16cccb141b6bb05c38107b335089046664ea1d6611601d3f6e7e4227a99925
-  category: main
-  optional: false
-- name: libedit
-  version: 3.1.20191231
+  version: '1.22'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-    ncurses: '>=6.2,<7.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
   hash:
-    md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
-    sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+    md5: b422943d5d772b7cc858b36ad2a92db5
+    sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
   category: main
   optional: false
-- name: libedit
-  version: 3.1.20191231
+- name: libdeflate
+  version: '1.22'
   manager: conda
   platform: osx-64
   dependencies:
-    ncurses: '>=6.2,<7.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
   hash:
-    md5: 6016a8a1d0e63cac3de2c352cd40208b
-    sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+    md5: a15785ccc62ae2a8febd299424081efb
+    sha256: 681035346974c3315685dc40898e26f65f1c00cbb0b5fd80cc2599e207a34b31
   category: main
   optional: false
-- name: libedit
-  version: 3.1.20191231
+- name: libdeflate
+  version: '1.22'
   manager: conda
   platform: osx-arm64
   dependencies:
-    ncurses: '>=6.2,<7.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
   hash:
-    md5: 30e4362988a2623e9eb34337b83e01f9
-    sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+    md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
+    sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
+  category: main
+  optional: false
+- name: libedit
+  version: 3.1.20250104
+  manager: conda
+  platform: linux-64
+  dependencies:
+    ncurses: '>=6.5,<7.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  hash:
+    md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+    sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+  category: main
+  optional: false
+- name: libedit
+  version: 3.1.20250104
+  manager: conda
+  platform: osx-64
+  dependencies:
+    ncurses: '>=6.5,<7.0a0'
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
+  hash:
+    md5: 1f4ed31220402fcddc083b4bff406868
+    sha256: 6cc49785940a99e6a6b8c6edbb15f44c2dd6c789d9c283e5ee7bdfedd50b4cd6
+  category: main
+  optional: false
+- name: libedit
+  version: 3.1.20250104
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    ncurses: '>=6.5,<7.0a0'
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+  hash:
+    md5: 44083d2d2c2025afca315c7a172eab2b
+    sha256: 66aa216a403de0bb0c1340a88d1a06adaff66bae2cfd196731aa24db9859d631
   category: main
   optional: false
 - name: libev
@@ -8812,37 +8994,40 @@ package:
   category: main
   optional: false
 - name: libexpat
-  version: 2.6.2
+  version: 2.6.4
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
   hash:
-    md5: e7ba12deb7020dd080c6c70e7b6f6a3d
-    sha256: 331bb7c7c05025343ebd79f86ae612b9e1e74d2687b8f3179faec234f986ce19
+    md5: db833e03127376d461e1e13e76f09b6c
+    sha256: 56541b98447b58e52d824bd59d6382d609e11de1f8adf20b23143e353d2b8d26
   category: main
   optional: false
 - name: libexpat
-  version: 2.6.2
+  version: 2.6.4
   manager: conda
   platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.4-h240833e_0.conda
   hash:
-    md5: 3d1d51c8f716d97c864d12f7af329526
-    sha256: a188a77b275d61159a32ab547f7d17892226e7dac4518d2c6ac3ac8fc8dfde92
+    md5: 20307f4049a735a78a29073be1be2626
+    sha256: d10f43d0c5df6c8cf55259bce0fe14d2377eed625956cddce06f58827d288c59
   category: main
   optional: false
 - name: libexpat
-  version: 2.6.2
+  version: 2.6.4
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
   hash:
-    md5: e3cde7cfa87f82f7cb13d482d5e0ad09
-    sha256: ba7173ac30064ea901a4c9fb5a51846dcc25512ceb565759be7d18cbf3e5415e
+    md5: 38d2656dd914feb0cab8c629370768bf
+    sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
   category: main
   optional: false
 - name: libffi
@@ -8879,17 +9064,43 @@ package:
     sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
   category: main
   optional: false
-- name: libgcc-ng
-  version: 14.1.0
+- name: libgcc
+  version: 14.2.0
   manager: conda
   platform: linux-64
   dependencies:
     _libgcc_mutex: '0.1'
     _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h77fa898_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
   hash:
-    md5: ca0fad6a41ddaef54a153b78eccb5037
-    sha256: b8e869ac96591cda2704bf7e77a301025e405227791a0bddf14a3dac65125538
+    md5: 3cb76c3f10d3bc7f1105b2fc9db984df
+    sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
+  category: main
+  optional: false
+- name: libgcc-ng
+  version: 14.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc: 14.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+  hash:
+    md5: e39480b9ca41323497b05492a63bc35b
+    sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
+  category: main
+  optional: false
+- name: libgcrypt-lib
+  version: 1.11.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libgpg-error: '>=1.51,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.0-hb9d3cd8_2.conda
+  hash:
+    md5: e55712ff40a054134d51b89afca57dbc
+    sha256: ffc3602f9298da248786f46b00d0594d26a18feeb1b07ce88f3d7d61075e39e6
   category: main
   optional: false
 - name: libgd
@@ -8897,24 +9108,22 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    expat: ''
-    fontconfig: '>=2.14.2,<3.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libgcc-ng: '>=12'
+    icu: '>=75.1,<76.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp: ''
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h119a65a_9.conda
+    libpng: '>=1.6.45,<1.7.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
   hash:
-    md5: cfebc557e54905dadc355c0e9f003004
-    sha256: b74f95a6e1f3b31a74741b39cba83ed99fc82d17243c0fd3b5ab16ddd48ab89d
+    md5: 68fc66282364981589ef36868b1a7c78
+    sha256: 19e5be91445db119152217e8e8eec4fd0499d854acc7d8062044fb55a70971cd
   category: dev
   optional: true
 - name: libgd
@@ -8922,24 +9131,22 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    expat: ''
-    fontconfig: '>=2.14.2,<3.0a0'
+    __osx: '>=10.13'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
+    icu: '>=75.1,<76.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp: ''
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgd-2.3.3-h0dceb68_9.conda
+    libpng: '>=1.6.45,<1.7.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgd-2.3.3-h8555400_11.conda
   hash:
-    md5: 1feb43971521d430bf826f8398598c5b
-    sha256: 4ed8546ff3356fc42f0e155446a060b14ee4aa96802e2da586532861deb3b917
+    md5: 0eea404372aa41cf95e71c604534b2a2
+    sha256: af8ca696b229236e4a692220a26421a4f3d28a6ceff16723cd1fe12bc7e6517c
   category: dev
   optional: true
 - name: libgd
@@ -8947,182 +9154,147 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    expat: ''
-    fontconfig: '>=2.14.2,<3.0a0'
+    __osx: '>=11.0'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
+    icu: '>=75.1,<76.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp: ''
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgd-2.3.3-hfdf3952_9.conda
+    libpng: '>=1.6.45,<1.7.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgd-2.3.3-hb2c3a21_11.conda
   hash:
-    md5: 0d847466f115fbdaaf2b6926f2e33278
-    sha256: cfdecfaa27807abc2728bd8c60b923ce1b44020553e122e9a56fc3acb77acaec
+    md5: 4581aa3cfcd1a90967ed02d4a9f3db4b
+    sha256: be038eb8dfe296509aee2df21184c72cb76285b0340448525664bc396aa6146d
   category: dev
   optional: true
-- name: libgdal
-  version: 3.9.1
+- name: libgdal-core
+  version: 3.10.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     blosc: '>=1.21.6,<2.0a0'
-    cfitsio: '>=4.4.1,<4.4.2.0a0'
-    freexl: '>=2.0.0,<3.0a0'
-    geos: '>=3.12.2,<3.12.3.0a0'
+    geos: '>=3.13.0,<3.13.1.0a0'
     geotiff: '>=1.7.3,<1.8.0a0'
     giflib: '>=5.2.2,<5.3.0a0'
-    hdf4: '>=4.2.15,<4.2.16.0a0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    json-c: '>=0.17,<0.18.0a0'
-    kealib: '>=1.5.3,<1.6.0a0'
+    json-c: '>=0.18,<0.19.0a0'
     lerc: '>=4.0.0,<5.0a0'
-    libaec: '>=1.1.3,<2.0a0'
-    libarchive: '>=3.7.4,<3.8.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libdeflate: '>=1.20,<1.21.0a0'
-    libexpat: '>=2.6.2,<3.0a0'
-    libgcc-ng: '>=12'
+    libarchive: '>=3.7.7,<3.8.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libdeflate: '>=1.22,<1.23.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
+    libheif: '>=1.18.2,<1.19.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
-    libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libpq: '>=16.3,<17.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
+    libpng: '>=1.6.44,<1.7.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.46.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libsqlite: '>=3.47.2,<4.0a0'
+    libstdcxx: '>=13'
+    libtiff: '>=4.7.0,<4.8.0a0'
     libuuid: '>=2.38.1,<3.0a0'
     libwebp-base: '>=1.4.0,<2.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    openssl: '>=3.3.1,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     pcre2: '>=10.44,<10.45.0a0'
-    poppler: '>=24.7.0,<24.8.0a0'
-    postgresql: ''
-    proj: '>=9.4.1,<9.5.0a0'
-    tiledb: '>=2.24.2,<2.25.0a0'
+    proj: '>=9.5.1,<9.6.0a0'
     xerces-c: '>=3.2.5,<3.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.1-ha654e03_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.0-h7250d82_6.conda
   hash:
-    md5: d1b70328bd7ff0d7b6da052ca33cfe60
-    sha256: 0ec8d98784e8f5a5f529339bce31669d76a2d4ae4cd427ff770ada68744f38c9
+    md5: 4e14dd6eef7e961a54258cab6482a656
+    sha256: 9de9ffb786deb0addb0d00e7b24b6b98e20cf366bb0318f80844c730554952f6
   category: main
   optional: false
-- name: libgdal
-  version: 3.9.1
+- name: libgdal-core
+  version: 3.10.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     blosc: '>=1.21.6,<2.0a0'
-    cfitsio: '>=4.4.1,<4.4.2.0a0'
-    freexl: '>=2.0.0,<3.0a0'
-    geos: '>=3.12.2,<3.12.3.0a0'
+    geos: '>=3.13.0,<3.13.1.0a0'
     geotiff: '>=1.7.3,<1.8.0a0'
     giflib: '>=5.2.2,<5.3.0a0'
-    hdf4: '>=4.2.15,<4.2.16.0a0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    json-c: '>=0.17,<0.18.0a0'
-    kealib: '>=1.5.3,<1.6.0a0'
+    json-c: '>=0.18,<0.19.0a0'
     lerc: '>=4.0.0,<5.0a0'
-    libaec: '>=1.1.3,<2.0a0'
-    libarchive: '>=3.7.4,<3.8.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
-    libdeflate: '>=1.20,<1.21.0a0'
-    libexpat: '>=2.6.2,<3.0a0'
+    libarchive: '>=3.7.7,<3.8.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=18'
+    libdeflate: '>=1.22,<1.23.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libheif: '>=1.18.2,<1.19.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
-    libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libpq: '>=16.3,<17.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
+    libpng: '>=1.6.44,<1.7.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.46.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libsqlite: '>=3.47.2,<4.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
     libwebp-base: '>=1.4.0,<2.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    openssl: '>=3.3.1,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     pcre2: '>=10.44,<10.45.0a0'
-    poppler: '>=24.7.0,<24.8.0a0'
-    postgresql: ''
-    proj: '>=9.4.1,<9.5.0a0'
-    tiledb: '>=2.24.2,<2.25.0a0'
+    proj: '>=9.5.1,<9.6.0a0'
     xerces-c: '>=3.2.5,<3.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.9.1-h52f6243_5.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.10.0-h04043bc_6.conda
   hash:
-    md5: 07fa5077cefae304f36bde4e309559ad
-    sha256: 62f060e1a3d72b4d6d922b421766342065eb7d38ca12660eb9430df2c617e198
+    md5: 0fdc13a5e28a7150d2ded1a3c7334625
+    sha256: 1082353a1f37c334ddeca585cb5d8cc4a86ba074e29ac24ce81da16dcf47fbfb
   category: main
   optional: false
-- name: libgdal
-  version: 3.9.1
+- name: libgdal-core
+  version: 3.10.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     blosc: '>=1.21.6,<2.0a0'
-    cfitsio: '>=4.4.1,<4.4.2.0a0'
-    freexl: '>=2.0.0,<3.0a0'
-    geos: '>=3.12.2,<3.12.3.0a0'
+    geos: '>=3.13.0,<3.13.1.0a0'
     geotiff: '>=1.7.3,<1.8.0a0'
     giflib: '>=5.2.2,<5.3.0a0'
-    hdf4: '>=4.2.15,<4.2.16.0a0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    json-c: '>=0.17,<0.18.0a0'
-    kealib: '>=1.5.3,<1.6.0a0'
+    json-c: '>=0.18,<0.19.0a0'
     lerc: '>=4.0.0,<5.0a0'
-    libaec: '>=1.1.3,<2.0a0'
-    libarchive: '>=3.7.4,<3.8.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
-    libdeflate: '>=1.20,<1.21.0a0'
-    libexpat: '>=2.6.2,<3.0a0'
+    libarchive: '>=3.7.7,<3.8.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=18'
+    libdeflate: '>=1.22,<1.23.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libheif: '>=1.18.2,<1.19.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
-    libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libpq: '>=16.3,<17.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
+    libpng: '>=1.6.44,<1.7.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.46.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libsqlite: '>=3.47.2,<4.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
     libwebp-base: '>=1.4.0,<2.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    openssl: '>=3.3.1,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     pcre2: '>=10.44,<10.45.0a0'
-    poppler: '>=24.7.0,<24.8.0a0'
-    postgresql: ''
-    proj: '>=9.4.1,<9.5.0a0'
-    tiledb: '>=2.24.2,<2.25.0a0'
+    proj: '>=9.5.1,<9.6.0a0'
     xerces-c: '>=3.2.5,<3.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.9.1-h750986c_5.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.10.0-h9ccd308_6.conda
   hash:
-    md5: ebd483d02a846d8051612ed7d59c3da7
-    sha256: 0dd3f7f4155c4c970ea560e51262d557aea907d8b442e256d3c7d0255bbb7662
+    md5: cd753bb7543fc897ceaedcdabe8d580f
+    sha256: d44ed8fa3feff35d7f8213046b686942e087dc026dfb5d8dc2484d968d0843df
   category: main
   optional: false
 - name: libgettextpo
@@ -9130,12 +9302,13 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     libiconv: '>=1.17,<2.0a0'
     libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-h5ff76d1_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-hdfe23c8_3.conda
   hash:
-    md5: 54cc9d12c29c2f0516f2ef4987de53ae
-    sha256: 139d1861e21c41b950ebf9e395db2492839337a3b481ad2901a4a6800c555e37
+    md5: ba6eeccaee150e24a544be8ae71aeca1
+    sha256: 8f7631d03a093272a5a8423181ac2c66514503e082e5494a2e942737af8a34ad
   category: dev
   optional: true
 - name: libgettextpo
@@ -9143,42 +9316,27 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     libiconv: '>=1.17,<2.0a0'
     libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8fbad5d_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8414b35_3.conda
   hash:
-    md5: a66fad933e22d22599a6dd149d359d25
-    sha256: c3f5580e172c3fc03d33e8994024f08b709a239bd599792e51435fa7a06beb64
+    md5: c8cd7295cfb7bda5cbabea4fef904349
+    sha256: bc446fad58155e96a01b28e99254415c2151bdddf57f9a2c00c44e6f0298bb62
   category: dev
   optional: true
-- name: libgettextpo-devel
-  version: 0.22.5
+- name: libgfortran
+  version: 14.2.0
   manager: conda
-  platform: osx-64
+  platform: linux-64
   dependencies:
-    libgettextpo: 0.22.5
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-devel-0.22.5-h5ff76d1_2.conda
+    libgfortran5: 14.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
   hash:
-    md5: 1e0384c52cd8b54812912e7234e66056
-    sha256: 57940f6a872ffcf5a3406e96bdbd9d25854943e4dd84acee56178ffb728a9671
-  category: dev
-  optional: true
-- name: libgettextpo-devel
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libgettextpo: 0.22.5
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-devel-0.22.5-h8fbad5d_2.conda
-  hash:
-    md5: 1113aa220b042b7ce8d077ea8f696f98
-    sha256: b1be0bb8a726e2c47a025ff348e6ba8b51ef668f6ace06694657025d84ae66e2
-  category: dev
-  optional: true
+    md5: f1fd30127802683586f768875127a987
+    sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
+  category: main
+  optional: false
 - name: libgfortran
   version: 5.0.0
   manager: conda
@@ -9203,28 +9361,16 @@ package:
     sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
   category: main
   optional: false
-- name: libgfortran-ng
-  version: 14.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgfortran5: 14.1.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_0.conda
-  hash:
-    md5: f4ca84fbd6d06b0a052fb2d5b96dde41
-    sha256: ef624dacacf97b2b0af39110b36e2fd3e39e358a1a6b7b21b85c9ac22d8ffed9
-  category: main
-  optional: false
 - name: libgfortran5
-  version: 14.1.0
+  version: 14.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=14.1.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_0.conda
+    libgcc: '>=14.2.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
   hash:
-    md5: 6456c2620c990cd8dde2428a27ba0bc5
-    sha256: a67d66b1e60a8a9a9e4440cee627c959acb4810cb182e089a4b0729bfdfbdf90
+    md5: 9822b874ea29af082e5d36098d25427d
+    sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
   category: main
   optional: false
 - name: libgfortran5
@@ -9252,23 +9398,24 @@ package:
   category: main
   optional: false
 - name: libglib
-  version: 2.80.3
+  version: 2.82.2
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libffi: '>=3.4,<4.0a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     pcre2: '>=10.44,<10.45.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.3-h8a4344b_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_1.conda
   hash:
-    md5: 6ea440297aacee4893f02ad759e6ffbc
-    sha256: 5f5854a7cee117d115009d8f22a70d5f9e28f09cb6e453e8f1dd712e354ecec9
+    md5: 37d1af619d999ee8f1f73cf5a06f4e2f
+    sha256: f0804a9e46ae7b32ca698d26c1c95aa82a91f71b6051883d4a46bea725be9ea4
   category: main
   optional: false
 - name: libglib
-  version: 2.80.3
+  version: 2.82.2
   manager: conda
   platform: osx-64
   dependencies:
@@ -9278,14 +9425,14 @@ package:
     libintl: '>=0.22.5,<1.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     pcre2: '>=10.44,<10.45.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.3-h736d271_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.82.2-h5c976ab_1.conda
   hash:
-    md5: 0919d467624606fbc05c38c458f3f42a
-    sha256: bfd5a28140d31f9310efcdfd1136f36d7ca718a297690a1a8869b3a1966675ae
-  category: main
-  optional: false
+    md5: 05e05255a2e9c5e9c1b6322d84b4999b
+    sha256: 78fab559eefc52856331462304a4c55c054fa8f0b0feb31ff5496d06c08342ba
+  category: dev
+  optional: true
 - name: libglib
-  version: 2.80.3
+  version: 2.82.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -9295,81 +9442,81 @@ package:
     libintl: '>=0.22.5,<1.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     pcre2: '>=10.44,<10.45.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.3-h59d46d9_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.82.2-hdff4504_1.conda
   hash:
-    md5: 2fd194003b4e69ab690f18994a71fd70
-    sha256: 92f9ca586a0d8070ae2c8924cbc7cc4fd79d47ff9cce58336984c86a197ab181
-  category: main
-  optional: false
+    md5: 849da57c370384ce48bef2e050488882
+    sha256: d002aeaa51424e331f8504a54b6ba4388a6011a0ebcac29296f3d14282bf733b
+  category: dev
+  optional: true
 - name: libgomp
-  version: 14.1.0
+  version: 14.2.0
   manager: conda
   platform: linux-64
   dependencies:
     _libgcc_mutex: '0.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
   hash:
-    md5: ae061a5ed5f05818acdf9adab72c146d
-    sha256: 7699df61a1f6c644b3576a40f54791561f2845983120477a16116b951c9cdb05
+    md5: cc3573974587f12dda90d96e3e55a702
+    sha256: 1911c29975ec99b6b906904040c855772ccb265a1c79d5d75c8ceec4ed89cd63
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 2.26.0
+  version: 2.30.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libgrpc: '>=1.62.2,<1.63.0a0'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.26.0-h26d7fe4_0.conda
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libgcc: '>=13'
+    libgrpc: '>=1.67.1,<1.68.0a0'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libstdcxx: '>=13'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.30.0-h804f50b_1.conda
   hash:
-    md5: 7b9d4c93870fb2d644168071d4d76afb
-    sha256: c6caa2d4c375c6c5718e6223bb20ccf6305313c0fef2a66499b4f6cdaa299635
+    md5: 0a1c61bdbf27a966bbb0c8bf9df37b02
+    sha256: 2766d13648adf974638a016c258890de1eaecf79186f67ca2d43b2687d27d5c4
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 2.26.0
+  version: 2.30.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libabseil: '>=20240116.2,<20240117.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
-    libgrpc: '>=1.62.2,<1.63.0a0'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.26.0-h721cda5_0.conda
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=18'
+    libgrpc: '>=1.67.1,<1.68.0a0'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.30.0-hd00c612_1.conda
   hash:
-    md5: 7f7f4537746da4470385ec3a496730a4
-    sha256: f514519dc7a48cfd81e5c2dd436223b221f80c03f224253739e22d60d896f632
+    md5: 5abc1fd3e6b08617d090a03ac6dcf961
+    sha256: 886a2b1595bb2fa95f013e142f03eddd468486707d76165ad5a341b656ab1a9f
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 2.26.0
+  version: 2.30.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libabseil: '>=20240116.2,<20240117.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
-    libgrpc: '>=1.62.2,<1.63.0a0'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.26.0-hfe08963_0.conda
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=18'
+    libgrpc: '>=1.67.1,<1.68.0a0'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.30.0-h8d8be31_1.conda
   hash:
-    md5: db7ab92239aeb06c3c52de90cc1e6f7a
-    sha256: 6753beade8465987399e85ca47c94814e8e24c58cf0ff5591545e6cbe7172ec5
+    md5: 69843fcf53962f47205996fc284ec29e
+    sha256: 9e2c138ccf300d909b4bc2487dfcda779bf9c3307948ce1d72c385008e0862fd
   category: main
   optional: false
 - name: libgoogle-cloud-storage
-  version: 2.26.0
+  version: 2.30.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -9377,19 +9524,19 @@ package:
     libabseil: ''
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libcurl: ''
-    libgcc-ng: '>=12'
-    libgoogle-cloud: 2.26.0
-    libstdcxx-ng: '>=12'
+    libgcc: '>=13'
+    libgoogle-cloud: 2.30.0
+    libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
     openssl: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.26.0-ha262f82_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.30.0-h0121fbd_1.conda
   hash:
-    md5: 89b53708fd67762b26c38c8ecc5d323d
-    sha256: 7c16bf2e5aa6b5e42450c218fdfa7d5ff1da952c5a5c821c001ab3fd940c2aed
+    md5: afbbf507f8c96faa95a2efa376ad484c
+    sha256: b171fc442de5ee010f515c4cb913cabc916619953188cb8d54fc38b8915e4cf3
   category: main
   optional: false
 - name: libgoogle-cloud-storage
-  version: 2.26.0
+  version: 2.30.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -9397,18 +9544,18 @@ package:
     libabseil: ''
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libcurl: ''
-    libcxx: '>=16'
-    libgoogle-cloud: 2.26.0
+    libcxx: '>=18'
+    libgoogle-cloud: 2.30.0
     libzlib: '>=1.3.1,<2.0a0'
     openssl: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.26.0-h9e84e37_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.30.0-h3f2b517_1.conda
   hash:
-    md5: b1e5017003917b69d5c046fc7ac0dcc3
-    sha256: d2081318e2962225c7b00fee355f66737553828eac42ddfbab968f59b039213a
+    md5: a2d97c91e722e844449e77c46189b064
+    sha256: e90836e026b3eb3750cb698560005f698705e830768bc549332ac4ad942b890d
   category: main
   optional: false
 - name: libgoogle-cloud-storage
-  version: 2.26.0
+  version: 2.30.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -9416,73 +9563,144 @@ package:
     libabseil: ''
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libcurl: ''
-    libcxx: '>=16'
-    libgoogle-cloud: 2.26.0
+    libcxx: '>=18'
+    libgoogle-cloud: 2.30.0
     libzlib: '>=1.3.1,<2.0a0'
     openssl: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.26.0-h1466eeb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.30.0-h7081f7f_1.conda
   hash:
-    md5: 385940a9a022e911e88f4e9ea45e47b3
-    sha256: b4c37ebd74a1453ee1cf561e40354544866d1816fa12637b7076377d0ef205ae
+    md5: 66517c46cacd189a6dae3f17fc030d36
+    sha256: 2bada39ddba63e6f6f5dba708f8fc6570b8f9ba20fe0e2bdda2dd24538c7ae3b
   category: main
   optional: false
-- name: libgrpc
-  version: 1.62.2
+- name: libgpg-error
+  version: '1.51'
   manager: conda
   platform: linux-64
   dependencies:
-    c-ares: '>=1.28.1,<2.0a0'
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libre2-11: '>=2023.9.1,<2024.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.2-h15f2491_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.51-hbd13f7d_1.conda
   hash:
-    md5: 8dabe607748cb3d7002ad73cd06f1325
-    sha256: 28241ed89335871db33cb6010e9ccb2d9e9b6bb444ddf6884f02f0857363c06a
+    md5: 168cc19c031482f83b23c4eebbb94e26
+    sha256: 9e0c09c1faf2151ade3ccb64e52d3c1f2dde85c00e37c6a3e6a8bced2aba68be
   category: main
   optional: false
 - name: libgrpc
-  version: 1.62.2
+  version: 1.67.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    c-ares: '>=1.32.3,<2.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libgcc: '>=13'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libre2-11: '>=2024.7.2'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+    re2: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
+  hash:
+    md5: 4606a4647bfe857e3cfe21ca12ac3afb
+    sha256: 870550c1faf524e9a695262cd4c31441b18ad542f16893bd3c5dbc93106705f7
+  category: main
+  optional: false
+- name: libgrpc
+  version: 1.67.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    c-ares: '>=1.28.1,<2.0a0'
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libcxx: '>=16'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libre2-11: '>=2023.9.1,<2024.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.2.1,<4.0a0'
+    c-ares: '>=1.34.2,<2.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcxx: '>=17'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libre2-11: '>=2024.7.2'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.62.2-h384b2fc_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.67.1-he6e0b18_0.conda
   hash:
-    md5: 9421f67cf8b4bc976fe5d0c3ab42de18
-    sha256: 7c228040e7dac4e5e7e6935a4decf6bc2155cc05fcfb0811d25ccb242d0036ba
+    md5: 05ea1754e8da5d0e8faf9ec599505834
+    sha256: 0884aaa894617fac40c0e0d03a03d2ea6ea486fe9692a0ff854cbe4b080e4c6a
   category: main
   optional: false
 - name: libgrpc
-  version: 1.62.2
+  version: 1.67.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    c-ares: '>=1.28.1,<2.0a0'
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libcxx: '>=16'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libre2-11: '>=2023.9.1,<2024.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.2.1,<4.0a0'
+    __osx: '>=11.0'
+    c-ares: '>=1.34.2,<2.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcxx: '>=17'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libre2-11: '>=2024.7.2'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.62.2-h9c18a4f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-hc70892a_0.conda
   hash:
-    md5: e624fc11026dbb84c549435eccd08623
-    sha256: d2c5b5a828f6f1242c11e8c91968f48f64446f7dd5cbfa1197545e465eb7d47a
+    md5: 624e27571fde34f8acc2afec840ac435
+    sha256: d2393fcd3c3584e5d58da4122f48bcf297567d2f6f14b3d1fcbd34fdd5040694
+  category: main
+  optional: false
+- name: libheif
+  version: 1.18.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    aom: '>=3.9.1,<3.10.0a0'
+    dav1d: '>=1.2.1,<1.2.2.0a0'
+    libavif16: '>=1.1.1,<2.0a0'
+    libde265: '>=1.0.15,<1.0.16.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    x265: '>=3.5,<3.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.18.2-gpl_hffcb242_100.conda
+  hash:
+    md5: 76ac2c07b62d45c192940f010eea11fa
+    sha256: 82af131dc112f4f36ca9226f30a7b1b3e05ed4fb3f85003e8f1af72b6a8e44bc
+  category: main
+  optional: false
+- name: libheif
+  version: 1.18.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    aom: '>=3.9.1,<3.10.0a0'
+    dav1d: '>=1.2.1,<1.2.2.0a0'
+    libavif16: '>=1.1.1,<2.0a0'
+    libcxx: '>=16'
+    libde265: '>=1.0.15,<1.0.16.0a0'
+    x265: '>=3.5,<3.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libheif-1.18.2-gpl_h57a3ca0_100.conda
+  hash:
+    md5: b08c6fdf99e131e906935a01b63e113c
+    sha256: e3aaa419f3d7ff2e21710991c1dd4484ed301942dcbcb5052e6835ddfd08abed
+  category: main
+  optional: false
+- name: libheif
+  version: 1.18.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aom: '>=3.9.1,<3.10.0a0'
+    dav1d: '>=1.2.1,<1.2.2.0a0'
+    libavif16: '>=1.1.1,<2.0a0'
+    libcxx: '>=16'
+    libde265: '>=1.0.15,<1.0.16.0a0'
+    x265: '>=3.5,<3.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.18.2-gpl_he913df3_100.conda
+  hash:
+    md5: 29911afbc2ec42a42914d5255dea52e6
+    sha256: 34a70c5889989013b199c6266a30362539af9e24211a6963a0cb0d7ba786f12d
   category: main
   optional: false
 - name: libiconv
@@ -9524,49 +9742,25 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     libiconv: '>=1.17,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-h5ff76d1_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-hdfe23c8_3.conda
   hash:
-    md5: 3fb6774cb8cdbb93a6013b67bcf9716d
-    sha256: 280aaef0ed84637ee869012ad9ad9ed208e068dd9b8cf010dafeea717dad7203
-  category: main
-  optional: false
+    md5: 52d4d643ed26c07599736326c46bf12f
+    sha256: 0dbb662440a73e20742f12d88e51785a5a5117b8b150783a032b8818a8c043af
+  category: dev
+  optional: true
 - name: libintl
   version: 0.22.5
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     libiconv: '>=1.17,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8fbad5d_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8414b35_3.conda
   hash:
-    md5: 3d216d0add050129007de3342be7b8c5
-    sha256: 21bc79bdf34ffd20cb84d2a8bd82d7d0e2a1b94b9e72773f0fb207e5b4f1ff63
-  category: main
-  optional: false
-- name: libintl-devel
-  version: 0.22.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-h5ff76d1_2.conda
-  hash:
-    md5: ea0a07e556d6b238db685cae6e3585d0
-    sha256: e3f15a85c6e63633a5ff503d56366bab31cd2e07ea21559889bc7eb19564106d
-  category: dev
-  optional: true
-- name: libintl-devel
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8fbad5d_2.conda
-  hash:
-    md5: 962b3348c68efd25da253e94590ea9a2
-    sha256: e52b2d0c5711f64b523756ccd9b800ee6f10a6317432b20a417dc3792e0a794a
+    md5: 3b98ec32e91b3b59ad53dbb9c96dd334
+    sha256: 7c1d238d4333af385e594c89ebcb520caad7ed83a735c901099ec0970a87a891
   category: dev
   optional: true
 - name: libjpeg-turbo
@@ -9610,14 +9804,14 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libexpat: '>=2.6.2,<3.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
     uriparser: '>=0.9.8,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hbbc8833_1019.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
   hash:
-    md5: d0c709fb86b5836c7c26d4c4b984402f
-    sha256: 09cb7b678b3706ab9e9f201de87dbf0604a3c1c28ea30c06c2ca3ecd6108404b
+    md5: e8c7620cc49de0c6a2349b6dd6e39beb
+    sha256: 721c3916d41e052ffd8b60e77f2da6ee47ff0d18babfca48ccf93606f1e0656a
   category: main
   optional: false
 - name: libkml
@@ -9626,14 +9820,14 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcxx: '>=16'
+    libcxx: '>=17'
     libexpat: '>=2.6.2,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     uriparser: '>=0.9.8,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hfcbc525_1019.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-h9ee1731_1021.conda
   hash:
-    md5: 0471719878015ffbae8129b7918a5fd1
-    sha256: 411ae3bd793547ec057ca88e75eecef568606f23d607b1a1449d487d3cd06ffa
+    md5: b098eeacf7e78f09c8771f5088b97bbb
+    sha256: dba3732e9a3b204e5af01c5ddba8630f4a337693b1c5375c2981a88b580116bd
   category: main
   optional: false
 - name: libkml
@@ -9642,14 +9836,14 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
+    libcxx: '>=17'
     libexpat: '>=2.6.2,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     uriparser: '>=0.9.8,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-h00ed6cc_1019.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-he250239_1021.conda
   hash:
-    md5: 77fe090a6ec2042e354ba9da1447ce83
-    sha256: cbcfffd021ec117e1837f8bb1427a1d8276ff2ab50349f42f947a39f914f4eab
+    md5: 891bb2a18eaef684f37bd4fb942cd8b2
+    sha256: e578ba448489465b8fea743e214272a9fcfccb0d152ba1ff57657aaa76a0cd7d
   category: main
   optional: false
 - name: liblapack
@@ -9658,10 +9852,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-22_linux64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-28_h7ac8fdf_openblas.conda
   hash:
-    md5: b083767b6c877e24ee597d93b87ab838
-    sha256: db246341d42f9100d45adeb1a7ba8b1ef5b51ceb9056fd643e98046a3259fde6
+    md5: 069f40bfbf1dc55c83ddb07fc6a6ef8d
+    sha256: 9530e6840690b78360946390a1d29624734a6b624f02c26631fb451592cbb8ef
   category: main
   optional: false
 - name: liblapack
@@ -9670,10 +9864,10 @@ package:
   platform: osx-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-22_osx64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-28_h236ab99_openblas.conda
   hash:
-    md5: f21b282ff7ba14df6134a0fe6ab42b1b
-    sha256: e36744f3e780564d6748b5dd05e15ad6a1af9184cf32ab9d1304c13a6bc3e16b
+    md5: edbfe8906ba99637eebb9ebe675a57d3
+    sha256: 862267d20bd7a248cef3dad1fefe5b31d44503943bd9745de42e8be17c86c806
   category: main
   optional: false
 - name: liblapack
@@ -9682,50 +9876,10 @@ package:
   platform: osx-arm64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-22_osxarm64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-28_hc9a63f6_openblas.conda
   hash:
-    md5: f2794950bc005e123b2c21f7fa3d7a6e
-    sha256: 2b1b24c98d15a6a3ad54cf7c8fef1ddccf84b7c557cde08235aaeffd1ff50ee8
-  category: main
-  optional: false
-- name: libllvm14
-  version: 14.0.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
-  hash:
-    md5: 73301c133ded2bf71906aa2104edae8b
-    sha256: 225cc7c3b20ac1db1bdb37fa18c95bf8aecef4388e984ab2f7540a9f4382106a
-  category: main
-  optional: false
-- name: libllvm14
-  version: 14.0.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libcxx: '>=15'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
-  hash:
-    md5: ed06753e2ba7c66ed0ca7f19578fcb68
-    sha256: 0df3902a300cfe092425f86144d5e00ef67be3cd1cc89fd63084d45262a772ad
-  category: main
-  optional: false
-- name: libllvm14
-  version: 14.0.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=15'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
-  hash:
-    md5: 9f3dce5d26ea56a9000cd74c034582bd
-    sha256: 6f603914fe8633a615f0d2f1383978eb279eeb552079a78449c9fbb43f22a349
+    md5: 45f26652530b558c21083ceb7adaf273
+    sha256: 79c75a02bff20f8b001e6aecfee8d22a51552c3986e7037fca68e5ed071cc213
   category: main
   optional: false
 - name: libllvm15
@@ -9773,264 +9927,334 @@ package:
     sha256: 63e22ccd4c1b80dfc7da169c65c62a878a46ef0e5771c3b0c091071e718ae1b1
   category: main
   optional: false
-- name: libmamba
-  version: 1.5.8
+- name: libllvm17
+  version: 17.0.6
   manager: conda
   platform: linux-64
   dependencies:
-    fmt: '>=10.2.1,<11.0a0'
-    libarchive: '>=3.7.2,<3.8.0a0'
-    libcurl: '>=8.6.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libsolv: '>=0.7.23'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.2.1,<4.0a0'
-    reproc: '>=14.2,<15.0a0'
-    reproc-cpp: '>=14.2,<15.0a0'
-    yaml-cpp: '>=0.8.0,<0.9.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmamba-1.5.8-had39da4_0.conda
-  hash:
-    md5: def669885dc103d8acb7ac2ac35e0b2f
-    sha256: 79c275862cc084c9f0dc1a13bd42313d48202181d5d64615b3046bf2380ef57d
-  category: main
-  optional: false
-- name: libmamba
-  version: 1.5.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    fmt: '>=10.2.1,<11.0a0'
-    libarchive: '>=3.7.2,<3.8.0a0'
-    libcurl: '>=8.6.0,<9.0a0'
-    libcxx: '>=16'
-    libsolv: '>=0.7.23'
-    openssl: '>=3.2.1,<4.0a0'
-    reproc: '>=14.2,<15.0a0'
-    reproc-cpp: '>=14.2,<15.0a0'
-    yaml-cpp: '>=0.8.0,<0.9.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libmamba-1.5.8-ha449628_0.conda
-  hash:
-    md5: f4eafddd38618657afefb7540d4c1a20
-    sha256: 48ef28e63407a42f0b0553b64aa0cdeadaa441bd588cd89a4988755baec07654
-  category: main
-  optional: false
-- name: libmamba
-  version: 1.5.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    fmt: '>=10.2.1,<11.0a0'
-    libarchive: '>=3.7.2,<3.8.0a0'
-    libcurl: '>=8.6.0,<9.0a0'
-    libcxx: '>=16'
-    libsolv: '>=0.7.23'
-    openssl: '>=3.2.1,<4.0a0'
-    reproc: '>=14.2,<15.0a0'
-    reproc-cpp: '>=14.2,<15.0a0'
-    yaml-cpp: '>=0.8.0,<0.9.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmamba-1.5.8-h90c426b_0.conda
-  hash:
-    md5: e02e82b493ab683be580380193db1b64
-    sha256: a6182bd735fe6a8bdd511096931a991b7d431cbfa2358f3aebb98132f063c89d
-  category: main
-  optional: false
-- name: libmambapy
-  version: 1.5.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    fmt: '>=10.2.1,<11.0a0'
-    libgcc-ng: '>=12'
-    libmamba: 1.5.8
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.2.1,<4.0a0'
-    pybind11-abi: '4'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    yaml-cpp: '>=0.8.0,<0.9.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmambapy-1.5.8-py312hd9e9ff6_0.conda
-  hash:
-    md5: ab74748421323fd59d9fda55e45b979e
-    sha256: 429c8fd6f7be1040a52cedaa8cd7aa02a42ccc8a27baa0a4394516401e9d7b28
-  category: main
-  optional: false
-- name: libmambapy
-  version: 1.5.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    fmt: '>=10.2.1,<11.0a0'
-    libcxx: '>=16'
-    libmamba: 1.5.8
-    openssl: '>=3.2.1,<4.0a0'
-    pybind11-abi: '4'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    yaml-cpp: '>=0.8.0,<0.9.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libmambapy-1.5.8-py312h67f5953_0.conda
-  hash:
-    md5: c7d0f9c38601b87f6ebb0ba00fb02e5c
-    sha256: cb3f1fe02ef2c6bb39129e43af7dfcf1a3d98a4d4c21e5eed5a1f3ef1c0557fb
-  category: main
-  optional: false
-- name: libmambapy
-  version: 1.5.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    fmt: '>=10.2.1,<11.0a0'
-    libcxx: '>=16'
-    libmamba: 1.5.8
-    openssl: '>=3.2.1,<4.0a0'
-    pybind11-abi: '4'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    yaml-cpp: '>=0.8.0,<0.9.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmambapy-1.5.8-py312h344e357_0.conda
-  hash:
-    md5: 9167478ca4942d118d3b79f6149c758f
-    sha256: 7cb94cf454c20cf25cf0c394e812ca7f86ceae47bb45f5b11518dd204f752cf0
-  category: main
-  optional: false
-- name: libnetcdf
-  version: 4.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    blosc: '>=1.21.5,<2.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    hdf4: '>=4.2.15,<4.2.16.0a0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libaec: '>=1.1.3,<2.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.7,<3.0a0'
-    libzip: '>=1.10.1,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    zlib: ''
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libxml2: '>=2.13.5,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h135f659_114.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm17-17.0.6-ha7bfdaf_3.conda
   hash:
-    md5: a908e463c710bd6b10a9eaa89fdf003c
-    sha256: 055572a4c8a1c3f9ac60071ee678f5ea49cfd7ac60a636d817988a6f9d6de6ae
+    md5: ed3e154faccbf6393bf0bc9ea0423dce
+    sha256: 4fb1d91048b7714c65b01dc8fd5e9ed3fdf7e48c0b2ed390c75dd376cf682316
   category: main
   optional: false
-- name: libnetcdf
-  version: 4.9.2
+- name: libllvm17
+  version: 17.0.6
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    blosc: '>=1.21.5,<2.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    hdf4: '>=4.2.15,<4.2.16.0a0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libaec: '>=1.1.3,<2.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
     libcxx: '>=16'
-    libxml2: '>=2.12.7,<3.0a0'
-    libzip: '>=1.10.1,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    zlib: ''
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h7334405_114.conda
+    libxml2: '>=2.12.1,<3.0.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm17-17.0.6-hbedff68_1.conda
   hash:
-    md5: 32ffbe5b0b0134e49f6347f4de8c5dcc
-    sha256: a4af96274a6c72d97e84dfc728ecc765af300de805d962a835c0841bb6a8f331
+    md5: fcd38f0553a99fa279fb66a5bfc2fb28
+    sha256: 605460ecc4ccc04163d0b06c99693864e5bcba7a9f014a5263c9856195282265
   category: main
   optional: false
-- name: libnetcdf
-  version: 4.9.2
+- name: libllvm17
+  version: 17.0.6
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    blosc: '>=1.21.5,<2.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    hdf4: '>=4.2.15,<4.2.16.0a0'
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    libaec: '>=1.1.3,<2.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
-    libxml2: '>=2.12.7,<3.0a0'
-    libzip: '>=1.10.1,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    zlib: ''
+    libcxx: '>=18'
+    libxml2: '>=2.13.5,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_he469be0_114.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-hc4b4ae8_3.conda
   hash:
-    md5: 8fd3ce6d910ed831c130c391c4364d3f
-    sha256: aeac591ba859f9cf775993e8b7f21e50803405d41ef363dc4981d114e8df88a8
+    md5: 2a75227e917a3ec0a064155f1ed11b06
+    sha256: 9b4da9f025bc946f5e1c8c104d7790b1af0c6e87eb03f29dea97fa1639ff83f2
   category: main
   optional: false
-- name: libnghttp2
-  version: 1.58.0
+- name: liblzma
+  version: 5.6.4
   manager: conda
   platform: linux-64
   dependencies:
-    c-ares: '>=1.23.0,<2.0a0'
-    libev: '>=4.33,<5.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.4-hb9d3cd8_0.conda
   hash:
-    md5: 700ac6ea6d53d5510591c4344d5c989a
-    sha256: 1910c5306c6aa5bcbd623c3c930c440e9c77a5a019008e1487810e3c1d3716cb
+    md5: 42d5b6a0f30d3c10cd88cb8584fda1cb
+    sha256: cad52e10319ca4585bc37f0bc7cce99ec7c15dc9168e42ccb96b741b0a27db3f
   category: main
   optional: false
-- name: libnghttp2
-  version: 1.58.0
+- name: liblzma
+  version: 5.6.4
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    c-ares: '>=1.23.0,<2.0a0'
-    libcxx: '>=16.0.6'
-    libev: '>=4.33,<5.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.6.4-hd471939_0.conda
   hash:
-    md5: faecc55c2a8155d9ff1c0ff9a0fef64f
-    sha256: 412fd768e787e586602f8e9ea52bf089f3460fc630f6987f0cbd89b70e9a4380
+    md5: db9d7b0152613f097cdb61ccf9f70ef5
+    sha256: a895b5b16468a6ed436f022d72ee52a657f9b58214b91fabfab6230e3592a6dd
   category: main
   optional: false
-- name: libnghttp2
-  version: 1.58.0
+- name: liblzma
+  version: 5.6.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    c-ares: '>=1.23.0,<2.0a0'
-    libcxx: '>=16.0.6'
-    libev: '>=4.33,<5.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.6.4-h39f12f2_0.conda
   hash:
-    md5: 1813e066bfcef82de579a0be8a766df4
-    sha256: fc97aaaf0c6d0f508be313d86c2705b490998d382560df24be918b8e977802cd
+    md5: e3fd1f8320a100f2b210e690a57cd615
+    sha256: 560c59d3834cc652a84fb45531bd335ad06e271b34ebc216e380a89798fe8e2c
   category: main
   optional: false
-- name: libnl
-  version: 3.9.0
+- name: liblzma-devel
+  version: 5.6.4
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.9.0-hd590300_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    liblzma: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.6.4-hb9d3cd8_0.conda
   hash:
-    md5: d27c451db4f1d3c983c78167d2fdabc2
-    sha256: aae03117811e704c3f3666e8374dd2e632f1d78bef0c27330e7298b24004819e
+    md5: 5ab1a0df19c8f3ec00d5e63458e0a420
+    sha256: 34928b36a3946902196a6786db80c8a4a97f6c9418838d67be90a1388479a682
+  category: main
+  optional: false
+- name: liblzma-devel
+  version: 5.6.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    liblzma: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-devel-5.6.4-hd471939_0.conda
+  hash:
+    md5: 06eccf9183d7bfeb45888e07804e6297
+    sha256: 0f8c5679cce617a3c45f58a4e984cf2ec920a9b98f4e522fc3e0e6a69a31bf26
+  category: main
+  optional: false
+- name: liblzma-devel
+  version: 5.6.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    liblzma: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.6.4-h39f12f2_0.conda
+  hash:
+    md5: 5789af7c91332d5d5693d3afd499b9eb
+    sha256: b5585156354258a85c7739039b6793e42324d29a24952fac8a9311cf2b6fff7a
+  category: main
+  optional: false
+- name: libmamba
+  version: 2.0.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cpp-expected: '>=1.1.0,<1.2.0a0'
+    fmt: '>=11.0.2,<12.0a0'
+    libarchive: '>=3.7.7,<3.8.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
+    libgcc: '>=13'
+    libsolv: '>=0.7.30,<0.8.0a0'
+    libstdcxx: '>=13'
+    nlohmann_json: '>=3.11.3,<3.12.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+    reproc: '>=14.2.5.0inf.0,<14.3.0a0'
+    reproc-cpp: '>=14.2.5.0inf.0,<14.3.0a0'
+    simdjson: '>=3.11.3,<3.12.0a0'
+    spdlog: '>=1.15.0,<1.16.0a0'
+    yaml-cpp: '>=0.8.0,<0.9.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmamba-2.0.5-h49b8a8d_1.conda
+  hash:
+    md5: c56f41d3378eee2b0507ec9e2b5b2ad5
+    sha256: dae82359fb4f07f7e712d08b61a836efb176818c3317a301e51934f3e1f3bee0
+  category: main
+  optional: false
+- name: libmamba
+  version: 2.0.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    cpp-expected: '>=1.1.0,<1.2.0a0'
+    fmt: '>=11.0.2,<12.0a0'
+    libarchive: '>=3.7.7,<3.8.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
+    libcxx: '>=18'
+    libsolv: '>=0.7.30,<0.8.0a0'
+    nlohmann_json: '>=3.11.3,<3.12.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+    reproc: '>=14.2.5.0inf.0,<14.3.0a0'
+    reproc-cpp: '>=14.2.5.0inf.0,<14.3.0a0'
+    simdjson: '>=3.11.3,<3.12.0a0'
+    spdlog: '>=1.15.0,<1.16.0a0'
+    yaml-cpp: '>=0.8.0,<0.9.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libmamba-2.0.5-h415aaf8_1.conda
+  hash:
+    md5: ff0e535989e951e8da50f7c65a86af5f
+    sha256: a00d6e83c5ac617f3e4e273e18a1e10856336d42dbfecba5fef5c64dadeb608f
+  category: main
+  optional: false
+- name: libmamba
+  version: 2.0.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cpp-expected: '>=1.1.0,<1.2.0a0'
+    fmt: '>=11.0.2,<12.0a0'
+    libarchive: '>=3.7.7,<3.8.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
+    libcxx: '>=18'
+    libsolv: '>=0.7.30,<0.8.0a0'
+    nlohmann_json: '>=3.11.3,<3.12.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+    reproc: '>=14.2.5.0inf.0,<14.3.0a0'
+    reproc-cpp: '>=14.2.5.0inf.0,<14.3.0a0'
+    simdjson: '>=3.11.3,<3.12.0a0'
+    spdlog: '>=1.15.0,<1.16.0a0'
+    yaml-cpp: '>=0.8.0,<0.9.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmamba-2.0.5-hdf44a08_1.conda
+  hash:
+    md5: 1b5babb299a9d5567addf0195e3b99ad
+    sha256: 8003e2d867b47618d7ece1481b21a55e9f2aa5cc3a8311a81da9233601b6cdad
+  category: main
+  optional: false
+- name: libmambapy
+  version: 2.0.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    fmt: '>=11.0.2,<12.0a0'
+    libgcc: '>=13'
+    libmamba: 2.0.5
+    libstdcxx: '>=13'
+    openssl: '>=3.4.0,<4.0a0'
+    pybind11-abi: '4'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    yaml-cpp: '>=0.8.0,<0.9.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmambapy-2.0.5-py312hbaee817_1.conda
+  hash:
+    md5: 310c821fb94307f11583169e34b957a8
+    sha256: 3f18ca26c39eae37b50c5b7bc2409f6641bc9d8b6a57a7bb151c32e5ee2cfac9
+  category: main
+  optional: false
+- name: libmambapy
+  version: 2.0.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    fmt: '>=11.0.2,<12.0a0'
+    libcxx: '>=18'
+    libmamba: 2.0.5
+    openssl: '>=3.4.0,<4.0a0'
+    pybind11-abi: '4'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    yaml-cpp: '>=0.8.0,<0.9.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libmambapy-2.0.5-py312h4e4b3da_1.conda
+  hash:
+    md5: 8399df08ca05c4e10b218084adeb7532
+    sha256: 76a9940ae1711a2a304ef29c76a419cbcab2a8670e48dbdbb3fb0628d0ed3a23
+  category: main
+  optional: false
+- name: libmambapy
+  version: 2.0.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    fmt: '>=11.0.2,<12.0a0'
+    libcxx: '>=18'
+    libmamba: 2.0.5
+    openssl: '>=3.4.0,<4.0a0'
+    pybind11-abi: '4'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    yaml-cpp: '>=0.8.0,<0.9.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmambapy-2.0.5-py312h86ad8a2_1.conda
+  hash:
+    md5: ce50f0cce054d412f6438fe800c66884
+    sha256: 877177931220f5446812255447a8d509aeeccbe1065cd55f2c28d23af51e0a79
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.64.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    c-ares: '>=1.32.3,<2.0a0'
+    libev: '>=4.33,<5.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+  hash:
+    md5: 19e57602824042dfd0446292ef90488b
+    sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.64.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    c-ares: '>=1.34.2,<2.0a0'
+    libcxx: '>=17'
+    libev: '>=4.33,<5.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
+  hash:
+    md5: ab21007194b97beade22ceb7a3f6fee5
+    sha256: 0dcfdcf3a445d2d7de4f3b186ab0a794dc872f4ea21622f9b997be72712c027f
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.64.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    c-ares: '>=1.34.2,<2.0a0'
+    libcxx: '>=17'
+    libev: '>=4.33,<5.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+  hash:
+    md5: 3408c02539cee5f1141f9f11450b6a51
+    sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
+  category: main
+  optional: false
+- name: libnl
+  version: 3.11.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
+  hash:
+    md5: db63358239cbe1ff86242406d440e44a
+    sha256: ba7c5d294e3d80f08ac5a39564217702d1a752e352e486210faff794ac5001b4
   category: main
   optional: false
 - name: libnsl
@@ -10046,47 +10270,48 @@ package:
   category: main
   optional: false
 - name: libopenblas
-  version: 0.3.27
+  version: 0.3.28
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_hac2b453_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libgfortran: ''
+    libgfortran5: '>=14.2.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
   hash:
-    md5: ae05ece66d3924ac3d48b4aa3fa96cec
-    sha256: 714cb82d7c4620ea2635a92d3df263ab841676c9b183d0c01992767bb2451c39
+    md5: 62857b389e42b36b686331bec0922050
+    sha256: 99ba271d8a80a1af2723f2e124ffd91d850074c0389c067e6d96d72a2dbfeabe
   category: main
   optional: false
 - name: libopenblas
-  version: 0.3.27
+  version: 0.3.28
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libgfortran: 5.*
-    libgfortran5: '>=12.3.0'
-    llvm-openmp: '>=16.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_h8869122_1.conda
+    libgfortran5: '>=13.2.0'
+    llvm-openmp: '>=18.1.8'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
   hash:
-    md5: c0798ad76ddd730dade6ff4dff66e0b5
-    sha256: 83b0b9d3d09889b3648a81d2c18a2d78c405b03b115107941f0496a8b358ce6d
+    md5: cd2c572c02a73b88c4d378eb31110e85
+    sha256: cef5856952688ce9303f85f5bc62c99e8c2256b4c679f63afdfb381f222e90c7
   category: main
   optional: false
 - name: libopenblas
-  version: 0.3.27
+  version: 0.3.28
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libgfortran: 5.*
-    libgfortran5: '>=12.3.0'
-    llvm-openmp: '>=16.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.27-openmp_h517c56d_1.conda
+    libgfortran5: '>=13.2.0'
+    llvm-openmp: '>=18.1.8'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
   hash:
-    md5: 71b8a34d70aa567a990162f327e81505
-    sha256: 46cfcc592b5255262f567cd098be3c61da6bca6c24d640e878dc8342b0f6d069
+    md5: 40803a48d947c8639da6704e9a44d3ce
+    sha256: 62bb669c37a845129096f73d446cdb6bb170e4927f2fea2b661329680dbbc373
   category: main
   optional: false
 - name: libparquet
@@ -10097,14 +10322,14 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     gflags: '>=2.2.2,<2.3.0a0'
     libarrow: 14.0.2
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libthrift: '>=0.19.0,<0.19.1.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.2-hfd5bfe4_30_cpu.conda
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libthrift: '>=0.21.0,<0.21.1.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.2-hd082c85_52_cpu.conda
   hash:
-    md5: 82695f6b86997d13bc1c1f9be353b5bf
-    sha256: 999c8268398ae547e6bcaa0ee450c30248c58db61113dade56e4cefd2899e4b9
+    md5: 2ef3c2382ef37b72fe2e48082c24d29e
+    sha256: 2b52c433d47bd213e334b634c1dfd830857dd6a968a3e2d209e5f1d42add89aa
   category: main
   optional: false
 - name: libparquet
@@ -10114,13 +10339,13 @@ package:
   dependencies:
     __osx: '>=10.13'
     libarrow: 14.0.2
-    libcxx: '>=14'
-    libthrift: '>=0.19.0,<0.19.1.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.2-h99dd538_30_cpu.conda
+    libcxx: '>=17'
+    libthrift: '>=0.21.0,<0.21.1.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.2-h2be9fba_52_cpu.conda
   hash:
-    md5: 1ff78336ec2bfbfc597d2b1ff5f790b0
-    sha256: bfcd5ecb0ea91b5f34c2082999a125dc0b801ad2592c9a9a9cd05a61477447f4
+    md5: 9ccc0631f3ce06c50203c3b4ec881954
+    sha256: 10956f2dc8a89915f515b58240651525325004ff2d39de7828565eecde6c35e6
   category: main
   optional: false
 - name: libparquet
@@ -10130,231 +10355,197 @@ package:
   dependencies:
     __osx: '>=11.0'
     libarrow: 14.0.2
-    libcxx: '>=14'
-    libthrift: '>=0.19.0,<0.19.1.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.2-h7c5c30a_30_cpu.conda
+    libcxx: '>=17'
+    libthrift: '>=0.21.0,<0.21.1.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.2-h8aa6169_52_cpu.conda
   hash:
-    md5: 59f1312e7e7b0d3dcdb62d5fa947247f
-    sha256: ab1baafafc3821e55e40c6f50c68000e0555d5207eb2fd0be70d1f6dfaff9fa1
+    md5: 42cac887efa238b90c80447f9297e1b6
+    sha256: 772211cf489e8a4d322cabdb2ba4a673effc8dae888cc1670bd376380a4eab9d
   category: main
   optional: false
 - name: libpng
-  version: 1.6.43
+  version: 1.6.46
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.46-h943b412_0.conda
   hash:
-    md5: 009981dd9cfcaa4dbfa25ffaed86bcae
-    sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
+    md5: adcf7bacff219488e29cfa95a2abd8f7
+    sha256: a46436dadd12d58155280d68876dba2d8a3badbc8074956d14fe6530c7c7eda6
   category: main
   optional: false
 - name: libpng
-  version: 1.6.43
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
-  hash:
-    md5: 65dcddb15965c9de2c0365cb14910532
-    sha256: 13e646d24b5179e6b0a5ece4451a587d759f55d9a360b7015f8f96eff4524b8f
-  category: main
-  optional: false
-- name: libpng
-  version: 1.6.43
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.43-h091b4b1_0.conda
-  hash:
-    md5: 77e684ca58d82cae9deebafb95b1a2b8
-    sha256: 66c4713b07408398f2221229a1c1d5df57d65dc0902258113f2d9ecac4772495
-  category: main
-  optional: false
-- name: libpq
-  version: '16.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libgcc-ng: '>=12'
-    openssl: '>=3.3.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.3-ha72fbe1_0.conda
-  hash:
-    md5: bac737ae28b79cfbafd515258d97d29e
-    sha256: 117ba1e11f07b1ca0671641bd6d1f2e7fc6e27db1c317a0cdb4799ffa69f47db
-  category: main
-  optional: false
-- name: libpq
-  version: '16.3'
+  version: 1.6.46
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    krb5: '>=1.21.2,<1.22.0a0'
-    openssl: '>=3.3.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.3-h4501773_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.46-h3c4a55f_0.conda
   hash:
-    md5: 74f18d32d7cc71584c8b05fd1ee555a0
-    sha256: 039da003586fdcdb40b8c8ffa25d5ded33316ba3a32ec79afde098a68b8a3acc
+    md5: 82ecce167bb9c069b12968b7b1bee609
+    sha256: a293b883b5b334555c643bb3b076018127d7e49d26d59787392b23effae4a3d9
   category: main
   optional: false
-- name: libpq
-  version: '16.3'
+- name: libpng
+  version: 1.6.46
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    krb5: '>=1.21.2,<1.22.0a0'
-    openssl: '>=3.3.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.3-h7afe498_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.46-h3783ad8_0.conda
   hash:
-    md5: b0f5315a3f630ade192cb9b569ce54ba
-    sha256: ef7c3bca8ee224e7bb282d85fa573180a8ef4eab943c313cb5b799ce506651bf
+    md5: 15d480fb9dad036eaa4de0b51eab3ccc
+    sha256: db78a711561bb6df274ef421472d948dfd1093404db3915e891ae6d7fd37fadc
   category: main
   optional: false
 - name: libprotobuf
-  version: 4.25.3
+  version: 5.28.2
   manager: conda
   platform: linux-64
   dependencies:
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
   hash:
-    md5: 6945825cebd2aeb16af4c69d97c32c13
-    sha256: 70e0eef046033af2e8d21251a785563ad738ed5281c74e21c31c457780845dcd
+    md5: ab0bff36363bec94720275a681af8b83
+    sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
   category: main
   optional: false
 - name: libprotobuf
-  version: 4.25.3
+  version: 5.28.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libcxx: '>=16'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcxx: '>=17'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.28.2-h8b30cf6_0.conda
   hash:
-    md5: 57b7ee4f1fd8573781cfdabaec4a7782
-    sha256: 3f126769fb5820387d436370ad48600e05d038a28689fdf9988b64e1059947a8
+    md5: 2302089e5bcb04ce891ce765c963befb
+    sha256: e240c2003e301ede0a0f4af7688adb8456559ffaa4af2eed3fce879c22c80a0e
   category: main
   optional: false
 - name: libprotobuf
-  version: 4.25.3
+  version: 5.28.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libcxx: '>=16'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.3-hbfab5d5_0.conda
+    __osx: '>=11.0'
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcxx: '>=17'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
   hash:
-    md5: 5f70b2b945a9741cba7e6dfe735a02a7
-    sha256: d754519abc3ddbdedab2a38d0639170f5347c1573eef80c707f3a8dc5dff706a
+    md5: d2cb5991f2fb8eb079c80084435e9ce6
+    sha256: f732a6fa918428e2d5ba61e78fe11bb44a002cc8f6bb74c94ee5b1297fefcfd8
   category: main
   optional: false
 - name: libre2-11
-  version: 2023.09.01
+  version: 2024.07.02
   manager: conda
   platform: linux-64
   dependencies:
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h5a48ba9_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_2.conda
   hash:
-    md5: 41c69fba59d495e8cf5ffda48a607e35
-    sha256: 3f3c65fe0e9e328b4c1ebc2b622727cef3e5b81b18228cfa6cf0955bc1ed8eff
+    md5: b2fede24428726dd867611664fb372e8
+    sha256: 4420f8362c71251892ba1eeb957c5e445e4e1596c0c651c28d0d8b415fe120c7
   category: main
   optional: false
 - name: libre2-11
-  version: 2023.09.01
+  version: 2024.07.02
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.09.01-h81f5012_2.conda
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2024.07.02-h0e468a2_2.conda
   hash:
-    md5: c5c36ec64e3c86504728c38b79011d08
-    sha256: 384b72a09bd4bb29c1aa085110b2f940dba431587ffb4e2c1a28f605887a1867
+    md5: 975743594ba5382fe7e71cda599ac6e8
+    sha256: 8d29abd9b800f55b56e60b5acb02fab3f3269f5518a7fb4286ca93ca7fef0eff
   category: main
   optional: false
 - name: libre2-11
-  version: 2023.09.01
+  version: 2024.07.02
   manager: conda
   platform: osx-arm64
   dependencies:
-    libabseil: '>=20240116.1,<20240117.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.09.01-h7b2c953_2.conda
+    __osx: '>=11.0'
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h07bc746_2.conda
   hash:
-    md5: 0b7b2ced046d6b5fe6e9d46b1ee0324c
-    sha256: c8a0a6e7a627dc9c66ffb8858f8f6d499f67fd269b6636b25dc5169760610f05
+    md5: 6b1e3624d3488016ca4f1ca0c412efaa
+    sha256: 112a73ad483353751d4c5d63648c69a4d6fcebf5e1b698a860a3f5124fc3db96
   category: main
   optional: false
 - name: librsvg
-  version: 2.58.1
+  version: 2.58.4
   manager: conda
   platform: linux-64
   dependencies:
-    cairo: '>=1.18.0,<2.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.2,<2.0a0'
     freetype: '>=2.12.1,<3.0a0'
     gdk-pixbuf: '>=2.42.12,<3.0a0'
-    harfbuzz: '>=8.5.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.2,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.1-hadf69e7_0.conda
+    harfbuzz: '>=10.1.0,<11.0a0'
+    libgcc: '>=13'
+    libglib: '>=2.82.2,<3.0a0'
+    libpng: '>=1.6.44,<1.7.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
+    pango: '>=1.54.0,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-h49af25d_2.conda
   hash:
-    md5: 73fc255d740d23da4f554b58dc4909fd
-    sha256: c3b6c48e50a3ff8522d868215dcccfbd8f2720e512084b12f4bfcb6a668c5552
+    md5: b9846db0abffb09847e2cb0fec4b4db6
+    sha256: 475013475a3209c24a82f9e80c545d56ccca2fa04df85952852f3d73caa38ff9
   category: dev
   optional: true
 - name: librsvg
-  version: 2.58.1
+  version: 2.58.4
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    cairo: '>=1.18.0,<2.0a0'
+    cairo: '>=1.18.2,<2.0a0'
     gdk-pixbuf: '>=2.42.12,<3.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/librsvg-2.58.1-h368d7ee_0.conda
+    libglib: '>=2.82.2,<3.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
+    pango: '>=1.54.0,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/librsvg-2.58.4-h21a6cfa_2.conda
   hash:
-    md5: 9da7b482dcbacc85708f138f9900df06
-    sha256: e5570f68f7d58c0e52eafcd927286c626c5a5f6b8efa41b14a44c96a13a6fe85
+    md5: 0aa68f5a6ebfd2254daae40170439f03
+    sha256: 482cde0a3828935edc31c529e15c2686425f64b07a7e52551b6ed672360f2a15
   category: dev
   optional: true
 - name: librsvg
-  version: 2.58.1
+  version: 2.58.4
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    cairo: '>=1.18.0,<2.0a0'
+    cairo: '>=1.18.2,<2.0a0'
     gdk-pixbuf: '>=2.42.12,<3.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.1-hbc281fb_0.conda
+    libglib: '>=2.82.2,<3.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
+    pango: '>=1.54.0,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.4-h266df6f_2.conda
   hash:
-    md5: e642889ae7e977769f6d0328e2ec7497
-    sha256: 01fdd2c28b24d319f46cf8072147beda48e223757a8fb6bca95fb6c93bad918b
+    md5: 82c31ce77bac095b5700b1fdaad9a628
+    sha256: c1ef2c5855166001967952d7525aa2f29707214495c74c2bbb60e691aee45ef0
   category: dev
   optional: true
 - name: librttopo
@@ -10363,13 +10554,13 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    geos: '>=3.12.2,<3.12.3.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hc670b87_16.conda
+    geos: '>=3.13.0,<3.13.1.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h97f6797_17.conda
   hash:
-    md5: 3d9f3a2e5d7213c34997e4464d2f938c
-    sha256: 65bfd9f8915b1fc2523c58bf556dc2b9ed6127b7c6877ed2841c67b717f6f924
+    md5: e16e9b1333385c502bf915195f421934
+    sha256: 1fb8a71bdbc236b8e74f0475887786735d5fa6f5d76d9a4135021279c7ff54b8
   category: main
   optional: false
 - name: librttopo
@@ -10378,12 +10569,12 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    geos: '>=3.12.2,<3.12.3.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-he2ba7a0_16.conda
+    geos: '>=3.13.0,<3.13.1.0a0'
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-hdfb80b9_17.conda
   hash:
-    md5: 80cc407788999eb3cd5a3651981e55fd
-    sha256: 907f602ad39172a98e3062c0d6616535075f5227435753fe2c843eb10891403c
+    md5: 627b89a9764485ebace5ebe42b6e6ab4
+    sha256: 683ec76fcc035f3803aedbffdc4e8ab62fbde360bfaa73f3693eeb429c48b029
   category: main
   optional: false
 - name: librttopo
@@ -10392,88 +10583,91 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    geos: '>=3.12.2,<3.12.3.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-h31fb324_16.conda
+    geos: '>=3.13.0,<3.13.1.0a0'
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-ha2cf0f4_17.conda
   hash:
-    md5: 1a8e3f8e886499916b8942628e6b6880
-    sha256: bf022fa3a85bc38c200c5f97d2e19ac5aa4e97908a6a542e8c13b7d3ff869224
+    md5: ba729f000ea379b76ed2190119d21e13
+    sha256: 9ff3162d035a1d9022f6145755a70d0c0ce6c9152792402bc42294354c871a17
   category: main
   optional: false
 - name: libsodium
-  version: 1.0.18
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
-  hash:
-    md5: c3788462a6fbddafdb413a9f9053e58d
-    sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
-  category: dev
-  optional: true
-- name: libsodium
-  version: 1.0.18
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
-  hash:
-    md5: 24632c09ed931af617fe6d5292919cab
-    sha256: 2da45f14e3d383b4b9e3a8bacc95cd2832aac2dbf9fbc70d255d384a310c5660
-  category: dev
-  optional: true
-- name: libsodium
-  version: 1.0.18
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
-  hash:
-    md5: 90859688dbca4735b74c02af14c4c793
-    sha256: 1d95fe5e5e6a0700669aab454b2a32f97289c9ed8d1f7667c2ba98327a6f05bc
-  category: dev
-  optional: true
-- name: libsolv
-  version: 0.7.29
+  version: 1.0.20
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsolv-0.7.29-ha6fb4c9_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
   hash:
-    md5: 28f3c528c01a07a592ee19f73ed730a0
-    sha256: 4e6d2c6f3a8e23a7fee6a198bda7a82ee1405dd04b3ca824805125b7ea11bde5
-  category: main
-  optional: false
-- name: libsolv
-  version: 0.7.29
+    md5: a587892d3c13b6621a6091be690dbca2
+    sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
+  category: dev
+  optional: true
+- name: libsodium
+  version: 1.0.20
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.29-h4f92f52_0.conda
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
   hash:
-    md5: f7618796195afe62f076d48737bbbbb8
-    sha256: c91c9fa1a5cfa6c1d1b125567e82c99df8b4117416076fb909acd5e7ab0fad28
+    md5: 6af4b059e26492da6013e79cbcb4d069
+    sha256: d3975cfe60e81072666da8c76b993af018cf2e73fe55acba2b5ba0928efaccf5
+  category: dev
+  optional: true
+- name: libsodium
+  version: 1.0.20
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
+  hash:
+    md5: a7ce36e284c5faaf93c220dfc39e3abd
+    sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
+  category: dev
+  optional: true
+- name: libsolv
+  version: 0.7.30
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsolv-0.7.30-h3509ff9_0.conda
+  hash:
+    md5: 02539b77d25aa4f65b20246549e256c3
+    sha256: 1dddbde791efdfc34c8fefa74dc2f910eac9cf87bf37ee6c3c9132eb96a0e7d4
   category: main
   optional: false
 - name: libsolv
-  version: 0.7.29
+  version: 0.7.30
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcxx: '>=16'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsolv-0.7.30-h69d5d9b_0.conda
+  hash:
+    md5: 8f8fd9f1740c8cb7dcfebf1a1ed7e678
+    sha256: d0c8a8a448dc8b01aecc023b8e6a26f8cdd03f04263ca0a282a057d636b47b3c
+  category: main
+  optional: false
+- name: libsolv
+  version: 0.7.30
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=16'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsolv-0.7.29-h1efcc80_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsolv-0.7.30-h6c9b7f8_0.conda
   hash:
-    md5: 16dbbca4087dd16c9d5d57b74b17af4c
-    sha256: 70d7340c263178526b041360dfa87dc327402103dfda48eec6cfabea9f385d95
+    md5: a5795a7ca73c9c99f112abce7864b500
+    sha256: e5ffda8a71a334edff7af4f194aa6c72df2f0763321250270f9f68dfc8eaf439
   category: main
   optional: false
 - name: libspatialite
@@ -10483,20 +10677,20 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     freexl: '>=2.0.0,<3.0a0'
-    geos: '>=3.12.2,<3.12.3.0a0'
-    libgcc-ng: '>=12'
+    geos: '>=3.13.0,<3.13.1.0a0'
+    libgcc: '>=13'
     librttopo: '>=1.1.0,<1.2.0a0'
-    libsqlite: '>=3.46.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.7,<3.0a0'
+    libsqlite: '>=3.47.2,<4.0a0'
+    libstdcxx: '>=13'
+    libxml2: '>=2.13.5,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    proj: '>=9.4.1,<9.5.0a0'
+    proj: '>=9.5.1,<9.6.0a0'
     sqlite: ''
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h15fa968_8.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h1b4f908_12.conda
   hash:
-    md5: 48502f34f5ba86c1ce192cb30f959dc9
-    sha256: ba7a298eb6e101ad4c3769c84f0d635c34e677a1879064f41e82598f0a0f5696
+    md5: 641f91ac6f984a91a78ba2411fe4f106
+    sha256: a9274b30ecc8967fa87959c1978de3b2bfae081b1a8fea7c5a61588041de818f
   category: main
   optional: false
 - name: libspatialite
@@ -10506,20 +10700,20 @@ package:
   dependencies:
     __osx: '>=10.13'
     freexl: '>=2.0.0,<3.0a0'
-    geos: '>=3.12.2,<3.12.3.0a0'
-    libcxx: '>=16'
+    geos: '>=3.13.0,<3.13.1.0a0'
+    libcxx: '>=18'
     libiconv: '>=1.17,<2.0a0'
     librttopo: '>=1.1.0,<1.2.0a0'
-    libsqlite: '>=3.46.0,<4.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
+    libsqlite: '>=3.47.2,<4.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    proj: '>=9.4.1,<9.5.0a0'
+    proj: '>=9.5.1,<9.6.0a0'
     sqlite: ''
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-hdc25a2c_8.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-h74337a0_12.conda
   hash:
-    md5: 51fd57e4f726cea701188184c036c341
-    sha256: 860aa6eae736e7f280fcded14541512a98def5f49e9206042b452428d9913509
+    md5: a1c412b37aefefd924b2f652a79eb17c
+    sha256: bdbd010754dc82dcd6ca9c0d4203ee81fa7b2e51e587766ef580da2f93f80d7b
   category: main
   optional: false
 - name: libspatialite
@@ -10529,215 +10723,268 @@ package:
   dependencies:
     __osx: '>=11.0'
     freexl: '>=2.0.0,<3.0a0'
-    geos: '>=3.12.2,<3.12.3.0a0'
-    libcxx: '>=16'
+    geos: '>=3.13.0,<3.13.1.0a0'
+    libcxx: '>=18'
     libiconv: '>=1.17,<2.0a0'
     librttopo: '>=1.1.0,<1.2.0a0'
-    libsqlite: '>=3.46.0,<4.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
+    libsqlite: '>=3.47.2,<4.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    proj: '>=9.4.1,<9.5.0a0'
+    proj: '>=9.5.1,<9.6.0a0'
     sqlite: ''
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-hf7a34df_8.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-hf92fc0a_12.conda
   hash:
-    md5: a7ded74ba9c89174f15aa61d0c9b4ef8
-    sha256: 95353aabfb7e632ca093fed17a9949ef736e8199a542dd0e6a55725d9e245188
+    md5: f05759528e44f74888830119ab32fc81
+    sha256: b11e6169fdbef472c307129192fd46133eec543036e41ab2f957615713b03d19
   category: main
   optional: false
 - name: libsqlite
-  version: 3.46.0
+  version: 3.48.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.48.0-hee588c1_1.conda
   hash:
-    md5: 18aa975d2094c34aef978060ae7da7d8
-    sha256: daee3f68786231dad457d0dfde3f7f1f9a7f2018adabdbb864226775101341a8
+    md5: 3fa05c528d8a1e2a67bbf1e36f22d3bc
+    sha256: 22853d289ef6ec8a5b20f1aa261895b06525439990d3b139f8bfd0b5c5e32a3a
   category: main
   optional: false
 - name: libsqlite
-  version: 3.46.0
+  version: 3.48.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libzlib: '>=1.2.13,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.48.0-hdb6dae5_1.conda
   hash:
-    md5: 5dadfbc1a567fe6e475df4ce3148be09
-    sha256: 63af1a9e3284c7e4952364bafe7267e41e2d9d8bcc0e85a4ea4b0ec02d3693f6
+    md5: 6c4d367a4916ea169d614590bdf33b7c
+    sha256: ccff3309ed7b1561d3bb00f1e4f36d9d1323af998013e3182a13bf0b5dcef4ec
   category: main
   optional: false
 - name: libsqlite
-  version: 3.46.0
+  version: 3.48.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libzlib: '>=1.2.13,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.0-hfb93653_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.48.0-h3f77e49_1.conda
   hash:
-    md5: 12300188028c9bc02da965128b91b517
-    sha256: 73048f9cb8647d3d3bfe6021c0b7d663e12cffbe9b4f31bd081e713b0a9ad8f9
+    md5: 4c55169502ecddf8077973a987d08f08
+    sha256: 17c06940cc2a13fd6a17effabd6881b1477db38b2cd3ee2571092d293d3fdd75
   category: main
   optional: false
 - name: libssh2
-  version: 1.11.0
+  version: 1.11.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
   hash:
-    md5: 1f5a58e686b13bcfde88b93f547d23fe
-    sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+    md5: be2de152d8073ef1c01b7728475f2fe7
+    sha256: 0407ac9fda2bb67e11e357066eff144c845801d00b5f664efbc48813af1e7bb9
   category: main
   optional: false
 - name: libssh2
-  version: 1.11.0
+  version: 1.11.1
   manager: conda
   platform: osx-64
   dependencies:
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+    __osx: '>=10.13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-h3dc7d44_0.conda
   hash:
-    md5: ca3a72efba692c59a90d4b9fc0dfe774
-    sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
+    md5: b1caec4561059e43a5d056684c5a2de0
+    sha256: ef2a81c9a15080b996a37f0e1712881da90a710b234e63d8539d69892353de90
   category: main
   optional: false
 - name: libssh2
-  version: 1.11.0
+  version: 1.11.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.1.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h9cc3647_0.conda
   hash:
-    md5: 029f7dc931a3b626b94823bc77830b01
-    sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
+    md5: ddc7194676c285513706e5fc64f214d7
+    sha256: f7047c6ed44bcaeb04432e8c74da87591940d091b0a3940c0d884b7faa8062e9
+  category: main
+  optional: false
+- name: libstdcxx
+  version: 14.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc: 14.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+  hash:
+    md5: 234a5554c53625688d51062645337328
+    sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
   category: main
   optional: false
 - name: libstdcxx-ng
-  version: 14.1.0
+  version: 14.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: 14.1.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-hc0a3c3a_0.conda
+    libstdcxx: 14.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
   hash:
-    md5: 1cb187a157136398ddbaae90713e2498
-    sha256: 88c42b388202ffe16adaa337e36cf5022c63cf09b0405cf06fc6aeacccbe6146
+    md5: 8371ac6457591af2cf6159439c1fd051
+    sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
+  category: main
+  optional: false
+- name: libsystemd0
+  version: '256.9'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libcap: '>=2.71,<2.72.0a0'
+    libgcc: '>=13'
+    libgcrypt-lib: '>=1.11.0,<2.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-256.9-h2774228_0.conda
+  hash:
+    md5: 7b283ff97a87409a884bc11283855c17
+    sha256: a93e45c12c2954942a994ff3ffc8b9a144261288032da834ed80a6210708ad49
   category: main
   optional: false
 - name: libthrift
-  version: 0.19.0
+  version: 0.21.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libevent: '>=2.1.12,<2.1.13.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
   hash:
-    md5: 8cdb7d41faa0260875ba92414c487e2d
-    sha256: 719add2cf20d144ef9962c57cd0f77178259bdb3aae1cded2e2b2b7c646092f5
+    md5: dcb95c0a98ba9ff737f7ae482aef7833
+    sha256: ebb395232973c18745b86c9a399a4725b2c39293c9a91b8e59251be013db42f0
   category: main
   optional: false
 - name: libthrift
-  version: 0.19.0
+  version: 0.21.0
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
+    __osx: '>=10.13'
+    libcxx: '>=17'
     libevent: '>=2.1.12,<2.1.13.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.21.0-h75589b3_0.conda
   hash:
-    md5: b152655bfad7c2374ff03be0596052b6
-    sha256: 4346c25ef6e2ff3d0fc93074238508531188ecd0dbea6414f6cb93a7775072c4
+    md5: 7a472cd20d9ae866aeb6e292b33381d6
+    sha256: 3f82eddd6de435a408538ac81a7a2c0c155877534761ec9cd7a2906c005cece2
   category: main
   optional: false
 - name: libthrift
-  version: 0.19.0
+  version: 0.21.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
+    __osx: '>=11.0'
+    libcxx: '>=17'
     libevent: '>=2.1.12,<2.1.13.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.21.0-h64651cc_0.conda
   hash:
-    md5: 4b8b21eb00d9019e9fa351141da2a6ac
-    sha256: b2c1b30d36f0412c0c0313db76a0236d736f3a9b887b8ed16182f531e4b7cb80
+    md5: 7ce2bd2f650f8c31ad7ba4c7bfea61b7
+    sha256: 7a6c7d5f58cbbc2ccd6493b4b821639fdb0701b9b04c737a949e8cb6adf1c9ad
   category: main
   optional: false
 - name: libtiff
-  version: 4.6.0
+  version: 4.7.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.20,<1.21.0a0'
-    libgcc-ng: '>=12'
+    libdeflate: '>=1.22,<1.23.0a0'
+    libgcc: '>=13'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h1dd3fc0_3.conda
+    liblzma: '>=5.6.3,<6.0a0'
+    libstdcxx: '>=13'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hc4654cb_2.conda
   hash:
-    md5: 66f03896ffbe1a110ffda05c7a856504
-    sha256: fc3b210f9584a92793c07396cb93e72265ff3f1fa7ca629128bf0a50d5cb15e4
+    md5: be54fb40ea32e8fe9dbaa94d4528b57e
+    sha256: 18653b4a5c73e19c5e86ff72dab9bf59f5cc43d7f404a6be705d152dfd5e0660
   category: main
   optional: false
 - name: libtiff
-  version: 4.6.0
+  version: 4.7.0
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     lerc: '>=4.0.0,<5.0a0'
-    libcxx: '>=16'
-    libdeflate: '>=1.20,<1.21.0a0'
+    libcxx: '>=18'
+    libdeflate: '>=1.22,<1.23.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h129831d_3.conda
+    liblzma: '>=5.6.3,<6.0a0'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-hf4bdac2_2.conda
   hash:
-    md5: 568593071d2e6cea7b5fc1f75bfa10ca
-    sha256: f9b35c5ec1aea9a2cc20e9275a0bb8f056482faa8c5a62feb243ed780755ea30
+    md5: 99a4153a4ee19d4902c0c08bfae4cdb4
+    sha256: dba23d6c9c1df6092e894b69d53fcdb78cdd10eab8e1b57f040de91a8beed908
   category: main
   optional: false
 - name: libtiff
-  version: 4.6.0
+  version: 4.7.0
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     lerc: '>=4.0.0,<5.0a0'
-    libcxx: '>=16'
-    libdeflate: '>=1.20,<1.21.0a0'
+    libcxx: '>=18'
+    libdeflate: '>=1.22,<1.23.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-h07db509_3.conda
+    liblzma: '>=5.6.3,<6.0a0'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-ha962b0a_2.conda
   hash:
-    md5: 28c9f8c6dd75666dfb296aea06c49cb8
-    sha256: 6df3e129682f6dc43826e5028e1807624b2a7634c4becbb50e56be9f77167f25
+    md5: 8e14b5225c593f099a21971568e6d7b4
+    sha256: d9e6835fd189b85eb90dbfdcc51f5375decbf5bb53130042f49bbd6bfb0b24be
+  category: main
+  optional: false
+- name: libudev1
+  version: '257.2'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libcap: '>=2.71,<2.72.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.2-h9a4d06a_0.conda
+  hash:
+    md5: f8ff68da999a4f1c57b1d523b18de1cc
+    sha256: d1558209de4908c12dd9119ce01d39d0d0052c5a20123957ed49b5ab21cb2ee8
   category: main
   optional: false
 - name: libutf8proc
@@ -10745,33 +10992,36 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-hf23e847_1.conda
   hash:
-    md5: ede4266dc02e875fe1ea77b25dd43747
-    sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
+    md5: b1aa0faa95017bca11369bd080487ec4
+    sha256: 104cf5b427fc914fec63e55f685a39480abeb4beb34bdbc77dea084c8f5a55cb
   category: main
   optional: false
 - name: libutf8proc
   version: 2.8.0
   manager: conda
   platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-he670073_1.conda
   hash:
-    md5: db98dc3e58cbc11583180609c429c17d
-    sha256: 55a7f96b2802e94def207fdfe92bc52c24d705d139bb6cdb3d936cbe85e1c505
+    md5: a7ce895b33370269f03650fa30b7c53d
+    sha256: 2b4c4c2a6051433e5c39943b8886a89fc74543f3b5d8286e5a39c7373f5f6cec
   category: main
   optional: false
 - name: libutf8proc
   version: 2.8.0
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-hc098a78_1.conda
   hash:
-    md5: f8c9c41a122ab3abdf8943b13f4957ee
-    sha256: a3faddac08efd930fa3a1cc254b5053b4ed9428c49a888d437bf084d403c931a
+    md5: ed89b8bf0d74d23ce47bcf566dd36608
+    sha256: 7807a98522477a8bf12460402845224f607ab6e1e73ac316b667169f5143cfe5
   category: main
   optional: false
 - name: libuuid
@@ -10786,132 +11036,87 @@ package:
     sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   category: main
   optional: false
-- name: libwebp
-  version: 1.4.0
+- name: libwebp-base
+  version: 1.5.0
   manager: conda
   platform: linux-64
   dependencies:
-    giflib: '>=5.2.2,<5.3.0a0'
-    libgcc-ng: '>=12'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-1.4.0-h2c329e2_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.5.0-h851e524_0.conda
   hash:
-    md5: 80030debaa84cfc31755d53742df3ca6
-    sha256: bd45805b169e3e0ff166d360c3c4842d77107d28c8f9feba020a8e8b9c80f948
-  category: dev
-  optional: true
-- name: libwebp
-  version: 1.4.0
+    md5: 63f790534398730f59e1b899c3644d4a
+    sha256: c45283fd3e90df5f0bd3dbcd31f59cdd2b001d424cf30a07223655413b158eaf
+  category: main
+  optional: false
+- name: libwebp-base
+  version: 1.5.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    giflib: '>=5.2.2,<5.3.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-1.4.0-hc207709_0.conda
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.5.0-h6cf52b4_0.conda
   hash:
-    md5: c5aa72a275c001665128245084c9ce14
-    sha256: 5c7103d5462deedf0f80a081bc895c25b05404719c11b33a846dc5f5328d791c
-  category: dev
-  optional: true
-- name: libwebp
-  version: 1.4.0
+    md5: 5e0cefc99a231ac46ba21e27ae44689f
+    sha256: 7f110eba04150f1fe5fe297f08fb5b82463eed74d1f068bc67c96637f9c63569
+  category: main
+  optional: false
+- name: libwebp-base
+  version: 1.5.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    giflib: '>=5.2.2,<5.3.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-1.4.0-h54798ee_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.5.0-h2471fea_0.conda
   hash:
-    md5: 078abbcc54996b186b9144cf795bd30f
-    sha256: e75e7a58793236fc8e92733c8bad168ce7bea40ca54c8c643e357511ba4a7b98
-  category: dev
-  optional: true
-- name: libwebp-base
-  version: 1.4.0
+    md5: 569466afeb84f90d5bb88c11cc23d746
+    sha256: f8bdb876b4bc8cb5df47c28af29188de8911c3fea4b799a33743500149de3f4a
+  category: main
+  optional: false
+- name: libxcb
+  version: 1.17.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
-  hash:
-    md5: b26e8aa824079e1be0294e7152ca4559
-    sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
-  category: main
-  optional: false
-- name: libwebp-base
-  version: 1.4.0
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
-  hash:
-    md5: b2c0047ea73819d992484faacbbe1c24
-    sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
-  category: main
-  optional: false
-- name: libwebp-base
-  version: 1.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
-  hash:
-    md5: c0af0edfebe780b19940e94871f1a765
-    sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
-  category: main
-  optional: false
-- name: libxcb
-  version: '1.16'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     pthread-stubs: ''
     xorg-libxau: '>=1.0.11,<2.0a0'
     xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.16-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
   hash:
-    md5: 151cba22b85a989c2d6ef9633ffee1e4
-    sha256: 7180375f37fd264bb50672a63da94536d4abd81ccec059e932728ae056324b3a
+    md5: 92ed62436b625154323d40d5f2f11dd7
+    sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
   category: main
   optional: false
 - name: libxcb
-  version: '1.16'
+  version: 1.17.0
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     pthread-stubs: ''
     xorg-libxau: '>=1.0.11,<2.0a0'
     xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.16-h0dc2134_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
   hash:
-    md5: 07e80289d4ba724f37b4b6f001f88fbe
-    sha256: c64277f586b716d5c34947e7f2783ef0d24f239a136bc6a024e854bede0389a9
+    md5: bbeca862892e2898bdb45792a61c4afc
+    sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
   category: main
   optional: false
 - name: libxcb
-  version: '1.16'
+  version: 1.17.0
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     pthread-stubs: ''
     xorg-libxau: '>=1.0.11,<2.0a0'
     xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.16-hf2054a2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
   hash:
-    md5: 55b5ed79062edde70459943d2d430d99
-    sha256: ebf4b797f18de4280548520c97ca1528bcb5a8bc721e3bb133a4e3c930a5320f
+    md5: af523aae2eca6dfa1c8eec693f5b9a79
+    sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
   category: main
   optional: false
 - name: libxcrypt
@@ -10926,95 +11131,71 @@ package:
     sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   category: main
   optional: false
-- name: libxml2
-  version: 2.12.7
+- name: libxkbcommon
+  version: 1.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    icu: '>=73.2,<74.0a0'
-    libgcc-ng: '>=12'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-hc051c1a_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libxcb: '>=1.17.0,<2.0a0'
+    libxml2: '>=2.13.5,<3.0a0'
+    xkeyboard-config: ''
+    xorg-libxau: '>=1.0.12,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.8.0-hc4a0caf_0.conda
   hash:
-    md5: 340278ded8b0dc3a73f3660bbb0adbc6
-    sha256: 576ea9134176636283ff052897bf7a91ffd8ac35b2c505dfde2890ec52849698
+    md5: f1656760dbf05f47f962bfdc59fc3416
+    sha256: 583203155abcfb03938d8473afbf129156b5b30301a0f796c8ecca8c5b7b2ed2
+  category: dev
+  optional: true
+- name: libxml2
+  version: 2.13.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=75.1,<76.0a0'
+    libgcc: '>=13'
+    libiconv: '>=1.17,<2.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h8d12d68_1.conda
+  hash:
+    md5: 1a21e49e190d1ffe58531a81b6e400e1
+    sha256: c3b05bdc40d27a9249f0bb60f3f71718f94104b8bcd200163a6c9d4ade7aa052
   category: main
   optional: false
 - name: libxml2
-  version: 2.12.7
+  version: 2.13.5
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    icu: '>=73.2,<74.0a0'
+    icu: '>=75.1,<76.0a0'
     libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.7-h3e169fe_1.conda
+    liblzma: '>=5.6.3,<6.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.13.5-hebb159f_1.conda
   hash:
-    md5: ddb63049aa7bd9f08f2cdc5a1c144d1a
-    sha256: 75554b5ef4c61a97c1d2ddcaff2d87c5ee120ff6925c2b714e18b20727cafb98
+    md5: 23c629eba5239465a34bca0ed9c0b5d3
+    sha256: b9332bd8d47a72b7b8fa2ae13c24387ed4f5fd4e1f7ecf0031068c6a755267ae
   category: main
   optional: false
 - name: libxml2
-  version: 2.12.7
+  version: 2.13.5
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    icu: '>=73.2,<74.0a0'
+    icu: '>=75.1,<76.0a0'
     libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.7-ha661575_1.conda
+    liblzma: '>=5.6.3,<6.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.5-h178c5d8_1.conda
   hash:
-    md5: 8ea71a74847498c793b0a8e9054a177a
-    sha256: 0ea12032b53d3767564a058ccd5208c0a1724ed2f8074dd22257ff3859ea6a4e
-  category: main
-  optional: false
-- name: libzip
-  version: 1.10.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.1.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.10.1-h2629f0a_3.conda
-  hash:
-    md5: ac79812548e7e8cf61f7b0abdef01d3b
-    sha256: 84e93f189072dcfcbe77744f19c7e4171523fbecfaba7352e5a23bbe014574c7
-  category: main
-  optional: false
-- name: libzip
-  version: 1.10.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.1.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.10.1-hc158999_3.conda
-  hash:
-    md5: 6112b3173f3aa2f12a8f40d07a77cc35
-    sha256: 0689e4a6e67e80027e43eefb8a365273405a01f5ab2ece97319155b8be5d64f6
-  category: main
-  optional: false
-- name: libzip
-  version: 1.10.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.1.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.10.1-ha0bc3c6_3.conda
-  hash:
-    md5: e37c0da207079e488709043634d6a711
-    sha256: fb42f34c2275523a06bc8464454fa57f2417203524cabb7aacca4e5de6cfeb69
+    md5: 3dc3cff0eca1640a6acbbfab2f78139e
+    sha256: d7af3f25a4cece170502acd38f2dafbea4521f373f46dcb28a37fbe6ac2da544
   category: main
   optional: false
 - name: libzlib
@@ -11022,11 +11203,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
   hash:
-    md5: 57d7dc60e9325e3de37ff8dffd18e814
-    sha256: adf6096f98b537a11ae3729eaa642b0811478f0ea0402ca67b5108fe2cb0010d
+    md5: edb0dca6bc32e4f4789199455a1dbeb8
+    sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
   category: main
   optional: false
 - name: libzlib
@@ -11035,10 +11217,10 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
   hash:
-    md5: b7575b5aa92108dcc9aaab0f05f2dbce
-    sha256: 80a62db652b1da0ccc100812a1d86e94f75028968991bfb17f9536f3aa72d91d
+    md5: 003a54a4e32b02f7355b50a837e699da
+    sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
   category: main
   optional: false
 - name: libzlib
@@ -11047,85 +11229,86 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
   hash:
-    md5: 636077128927cf79fd933276dc3aed47
-    sha256: c34365dd37b0eab27b9693af32a1f7f284955517c2cc91f1b88a7ef4738ff03e
+    md5: 369964e85dc26bfe78f41399b366c435
+    sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
   category: main
   optional: false
 - name: llvm-openmp
-  version: 18.1.8
+  version: 19.1.7
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.7-ha54dae1_0.conda
   hash:
-    md5: 2c3c6c8aaf8728f87326964a82fdc7d8
-    sha256: 0fd74128806bd839c7a9aa343faf265b94aece84f75f67f14b6246936138e61e
+    md5: 65d08c50518999e69f421838c1d5b91f
+    sha256: b5b06821b0d4143f66ba652ffe6f535696dc3a4096175d9be8b19b1a7350c86d
   category: main
   optional: false
 - name: llvm-openmp
-  version: 18.1.8
+  version: 19.1.7
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.7-hdb05f8b_0.conda
   hash:
-    md5: 82393fdbe38448d878a8848b6fcbcefb
-    sha256: 42bc913b3c91934a1ce7ff635e87ee48e2e252632f0cbf607c5a3e4409d9f9dd
+    md5: c4d54bfd3817313ce758aa76283b118d
+    sha256: b92a669f2059874ebdcb69041b6c243d68ffc3fb356ac1339cec44aeb27245d7
   category: main
   optional: false
 - name: llvmlite
-  version: 0.43.0
+  version: 0.44.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libllvm14: '>=14.0.6,<14.1.0a0'
-    libstdcxx-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libllvm15: '>=15.0.7,<15.1.0a0'
+    libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.43.0-py312h9c5d478_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.44.0-py312h374181b_0.conda
   hash:
-    md5: b7a63a49d7a0664376b27cd4f052a888
-    sha256: 02a2a1896e80ec8c17c186b120fc021d10b24682a810200f62a9aaacdc988463
+    md5: 4fec2cf2f40c75c0993964bb7a4c8424
+    sha256: c05668c8099cd398c4fca015f0189187dd24f5b6763caf85cda299fde0092e5b
   category: main
   optional: false
 - name: llvmlite
-  version: 0.43.0
+  version: 0.44.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcxx: '>=16'
-    libllvm14: '>=14.0.6,<14.1.0a0'
+    libcxx: '>=18'
+    libllvm15: '>=15.0.7,<15.1.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py312hdeb90da_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.44.0-py312hc7f3abb_0.conda
   hash:
-    md5: fbf9baa6234121382858875dd707d700
-    sha256: b5f11398b4c64afd4188ec3e99a5e43fbc54f867c208cdde83eb2a306f1576b6
+    md5: 1c6cdbcbe581a77837db527f8ff7cac2
+    sha256: efa04ef77fa34893eff45b88b7bb30458103a6b2ad21bddc10ed90f2be7ba2fd
   category: main
   optional: false
 - name: llvmlite
-  version: 0.43.0
+  version: 0.44.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
-    libllvm14: '>=14.0.6,<14.1.0a0'
+    libcxx: '>=18'
+    libllvm15: '>=15.0.7,<15.1.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.43.0-py312h30cb90f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.44.0-py312h728bc31_0.conda
   hash:
-    md5: 7a5d0e3a58a4bfb6f93cadc0d2529b4f
-    sha256: 33695ee9042e0de27d8310dad64c18d1cf7aeaf91c286738d2ab2388f4ab291a
+    md5: 4ead86be7c51a3dc8e76f2b059bacd86
+    sha256: 9eb98299e5a7c71128930dd3e152572d2aeba1935f0a638af50e00a2416000b3
   category: main
   optional: false
 - name: lz4-c
@@ -11200,7 +11383,7 @@ package:
   category: main
   optional: false
 - name: mapclassify
-  version: 2.6.1
+  version: 2.8.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -11210,44 +11393,44 @@ package:
     python: '>=3.9'
     scikit-learn: '>=1.0'
     scipy: '>=1.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 6aceae1ad4f16cf7b73ee04189947f98
-    sha256: 204ab8b242229d422b33cfec07ea61cefa8bd22375a16658afbabaafce031d64
+    md5: c48bbb2bcc3f9f46741a7915d67e6839
+    sha256: c498a016b233be5a7defee443733a82d5fe41b83016ca8a136876a64fd15564b
   category: main
   optional: false
 - name: mapclassify
-  version: 2.6.1
+  version: 2.8.1
   manager: conda
   platform: osx-64
   dependencies:
-    networkx: '>=2.7'
-    numpy: '>=1.23'
-    pandas: '>=1.4,!=1.5.0'
     python: '>=3.9'
-    scikit-learn: '>=1.0'
+    numpy: '>=1.23'
     scipy: '>=1.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
+    scikit-learn: '>=1.0'
+    networkx: '>=2.7'
+    pandas: '>=1.4,!=1.5.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 6aceae1ad4f16cf7b73ee04189947f98
-    sha256: 204ab8b242229d422b33cfec07ea61cefa8bd22375a16658afbabaafce031d64
+    md5: c48bbb2bcc3f9f46741a7915d67e6839
+    sha256: c498a016b233be5a7defee443733a82d5fe41b83016ca8a136876a64fd15564b
   category: main
   optional: false
 - name: mapclassify
-  version: 2.6.1
+  version: 2.8.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    networkx: '>=2.7'
-    numpy: '>=1.23'
-    pandas: '>=1.4,!=1.5.0'
     python: '>=3.9'
-    scikit-learn: '>=1.0'
+    numpy: '>=1.23'
     scipy: '>=1.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
+    scikit-learn: '>=1.0'
+    networkx: '>=2.7'
+    pandas: '>=1.4,!=1.5.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 6aceae1ad4f16cf7b73ee04189947f98
-    sha256: 204ab8b242229d422b33cfec07ea61cefa8bd22375a16658afbabaafce031d64
+    md5: c48bbb2bcc3f9f46741a7915d67e6839
+    sha256: c498a016b233be5a7defee443733a82d5fe41b83016ca8a136876a64fd15564b
   category: main
   optional: false
 - name: markdown-it-py
@@ -11256,11 +11439,11 @@ package:
   platform: linux-64
   dependencies:
     mdurl: '>=0.1,<1'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+    md5: fee3164ac23dfca50cfcc8b85ddefb81
+    sha256: 0fbacdfb31e55964152b24d5567e9a9996e1e7902fb08eb7d91b5fd6ce60803a
   category: main
   optional: false
 - name: markdown-it-py
@@ -11268,12 +11451,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.9'
     mdurl: '>=0.1,<1'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+    md5: fee3164ac23dfca50cfcc8b85ddefb81
+    sha256: 0fbacdfb31e55964152b24d5567e9a9996e1e7902fb08eb7d91b5fd6ce60803a
   category: main
   optional: false
 - name: markdown-it-py
@@ -11281,67 +11464,70 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.9'
     mdurl: '>=0.1,<1'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+    md5: fee3164ac23dfca50cfcc8b85ddefb81
+    sha256: 0fbacdfb31e55964152b24d5567e9a9996e1e7902fb08eb7d91b5fd6ce60803a
   category: main
   optional: false
 - name: markupsafe
-  version: 2.1.5
+  version: 3.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py312h98912ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py312h178313f_1.conda
   hash:
-    md5: 6ff0b9582da2d4a74a1f9ae1f9ce2af6
-    sha256: 273d8efd6c089c534ccbede566394c0ac1e265bfe5d89fe76e80332f3d75a636
+    md5: eb227c3e0bf58f5bd69c0532b157975b
+    sha256: 4a6bf68d2a2b669fecc9a4a009abd1cf8e72c2289522ff00d81b5a6e51ae78f5
   category: main
   optional: false
 - name: markupsafe
-  version: 2.1.5
+  version: 3.0.2
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.5-py312h41838bb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.2-py312h3520af0_1.conda
   hash:
-    md5: c4a9c25c09cef3901789ca818d9beb10
-    sha256: 8dc8f31f78d00713300da000b6ebaa1943a17c112f267de310d5c3d82950079c
+    md5: 32d6bc2407685d7e2d8db424f42018c6
+    sha256: d521e272f7789ca62e7617058a4ea3bd79efa73de1a39732df209ca5299e64e2
   category: main
   optional: false
 - name: markupsafe
-  version: 2.1.5
+  version: 3.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.5-py312he37b823_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py312h998013c_1.conda
   hash:
-    md5: ba3a8f8cf8bbdb81394275b1e1d271da
-    sha256: 61480b725490f68856dd14e646f51ffc34f77f2c985bd33e3b77c04b2856d97d
+    md5: 46e547061080fddf9cf95a0327e8aba6
+    sha256: 4aa997b244014d3707eeef54ab0ee497d12c0d0d184018960cce096169758283
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.9.1
+  version: 3.10.0
   manager: conda
   platform: linux-64
   dependencies:
-    certifi: '>=2020.06.20'
+    __glibc: '>=2.17,<3.0.a0'
     contourpy: '>=1.0.1'
     cycler: '>=0.10'
     fonttools: '>=4.22.0'
     freetype: '>=2.12.1,<3.0a0'
     kiwisolver: '>=1.3.1'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
     numpy: '>=1.23'
     packaging: '>=20.0'
     pillow: '>=8'
@@ -11351,25 +11537,24 @@ package:
     python_abi: 3.12.*
     qhull: '>=2020.2,<2020.3.0a0'
     tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.1-py312h9201f00_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.0-py312hd3ec401_0.conda
   hash:
-    md5: e1dc3a7d999666f5c58cbb391940e235
-    sha256: 6535eaf7260fc7ebd30b208197dc5eb00a1f1e4bbbbc057bb8bc52442b28fcf8
+    md5: c27a17a8c54c0d35cf83bbc0de8f7f77
+    sha256: eed67ea988883a3c05160c6d02f34f5a4b6405713cf699d9117eb68fb4743017
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.9.1
+  version: 3.10.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    certifi: '>=2020.06.20'
     contourpy: '>=1.0.1'
     cycler: '>=0.10'
     fonttools: '>=4.22.0'
     freetype: '>=2.12.1,<3.0a0'
     kiwisolver: '>=1.3.1'
-    libcxx: '>=16'
+    libcxx: '>=18'
     numpy: '>=1.23'
     packaging: '>=20.0'
     pillow: '>=8'
@@ -11378,25 +11563,24 @@ package:
     python-dateutil: '>=2.7'
     python_abi: 3.12.*
     qhull: '>=2020.2,<2020.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.1-py312h0d5aeb7_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.10.0-py312h535dea3_0.conda
   hash:
-    md5: 824194f775dbc413b1dc44d58f3249db
-    sha256: 9f4c796d6eb7841bbfd68e6272d25fe719d842134e08a17994e857f517062ba0
+    md5: 128c27d25c9398bab477b7a9a8478c90
+    sha256: 69249e9211aefc96fee9ef1b72ab7ed5c4f73c68cd1e0187eeceb6e22c46ecce
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.9.1
+  version: 3.10.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    certifi: '>=2020.06.20'
     contourpy: '>=1.0.1'
     cycler: '>=0.10'
     fonttools: '>=4.22.0'
     freetype: '>=2.12.1,<3.0a0'
     kiwisolver: '>=1.3.1'
-    libcxx: '>=16'
+    libcxx: '>=18'
     numpy: '>=1.23'
     packaging: '>=20.0'
     pillow: '>=8'
@@ -11405,10 +11589,10 @@ package:
     python-dateutil: '>=2.7'
     python_abi: 3.12.*
     qhull: '>=2020.2,<2020.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.1-py312h32d6e5a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.0-py312hdbc7e53_0.conda
   hash:
-    md5: 02eddb506a3949536cfeb267a328e3e4
-    sha256: 57630e1a274fcfc8fa016e70cef13802afe8fdfb5852b8733c14dc25d6208de8
+    md5: af50086982d6939b23d2656c21172be0
+    sha256: 8e53e3e3a7c81aed357b92e5dc0be0199a0081a2ce9cc726f5afba946ed77796
   category: main
   optional: false
 - name: matplotlib-inline
@@ -11416,12 +11600,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
+    python: '>=3.9'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
   hash:
-    md5: 779345c95648be40d22aaa89de7d4254
-    sha256: 7ea68676ea35fbb095420bbcc1c82c4767b8be7bb56abb6989b7f89d957a3bab
+    md5: af6ab708897df59bd6e7283ceab1b56b
+    sha256: 69b7dc7131703d3d60da9b0faa6dd8acbf6f6c396224cf6aef3e855b8c0c41c6
   category: dev
   optional: true
 - name: matplotlib-inline
@@ -11429,12 +11613,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
   hash:
-    md5: 779345c95648be40d22aaa89de7d4254
-    sha256: 7ea68676ea35fbb095420bbcc1c82c4767b8be7bb56abb6989b7f89d957a3bab
+    md5: af6ab708897df59bd6e7283ceab1b56b
+    sha256: 69b7dc7131703d3d60da9b0faa6dd8acbf6f6c396224cf6aef3e855b8c0c41c6
   category: dev
   optional: true
 - name: matplotlib-inline
@@ -11442,12 +11626,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_1.conda
   hash:
-    md5: 779345c95648be40d22aaa89de7d4254
-    sha256: 7ea68676ea35fbb095420bbcc1c82c4767b8be7bb56abb6989b7f89d957a3bab
+    md5: af6ab708897df59bd6e7283ceab1b56b
+    sha256: 69b7dc7131703d3d60da9b0faa6dd8acbf6f6c396224cf6aef3e855b8c0c41c6
   category: dev
   optional: true
 - name: mccabe
@@ -11455,11 +11639,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 34fc335fc50eef0b5ea708f2b5f54e0c
-    sha256: 0466ad9490b761e9a8c57fab574fc099136b45fa19a0746ce33acdeb2a84766b
+    md5: 827064ddfe0de2917fb29f1da4f8f533
+    sha256: 9b0037171dad0100f0296699a11ae7d355237b55f42f9094aebc0f41512d96a1
   category: dev
   optional: true
 - name: mccabe
@@ -11467,11 +11651,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 34fc335fc50eef0b5ea708f2b5f54e0c
-    sha256: 0466ad9490b761e9a8c57fab574fc099136b45fa19a0746ce33acdeb2a84766b
+    md5: 827064ddfe0de2917fb29f1da4f8f533
+    sha256: 9b0037171dad0100f0296699a11ae7d355237b55f42f9094aebc0f41512d96a1
   category: dev
   optional: true
 - name: mccabe
@@ -11479,11 +11663,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 34fc335fc50eef0b5ea708f2b5f54e0c
-    sha256: 0466ad9490b761e9a8c57fab574fc099136b45fa19a0746ce33acdeb2a84766b
+    md5: 827064ddfe0de2917fb29f1da4f8f533
+    sha256: 9b0037171dad0100f0296699a11ae7d355237b55f42f9094aebc0f41512d96a1
   category: dev
   optional: true
 - name: mdurl
@@ -11491,11 +11675,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 776a8dd9e824f77abac30e6ef43a8f7a
-    sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+    md5: 592132998493b3ff25fd7479396e8351
+    sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
   category: main
   optional: false
 - name: mdurl
@@ -11503,11 +11687,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 776a8dd9e824f77abac30e6ef43a8f7a
-    sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+    md5: 592132998493b3ff25fd7479396e8351
+    sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
   category: main
   optional: false
 - name: mdurl
@@ -11515,50 +11699,50 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 776a8dd9e824f77abac30e6ef43a8f7a
-    sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+    md5: 592132998493b3ff25fd7479396e8351
+    sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
   category: main
   optional: false
 - name: menuinst
-  version: 2.1.1
+  version: 2.2.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/menuinst-2.1.1-py312h7900ff3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/menuinst-2.2.0-py312h7900ff3_0.conda
   hash:
-    md5: 697641b112727643cd03ca1a1d339631
-    sha256: 7b224e817e361277f1e128ed7d604f5133e6e549f1ed1d0c33e74b60e1bc2603
+    md5: f22f8e77b36e67297feffe03eefd5375
+    sha256: a3d3f509e545913b6aee004b3e91c0147723b7d569ff256db9cbc8eb2d7b1772
   category: main
   optional: false
 - name: menuinst
-  version: 2.1.1
+  version: 2.2.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/menuinst-2.1.1-py312hb401068_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/menuinst-2.2.0-py312hb401068_0.conda
   hash:
-    md5: 826e070b70c3ae16258e72d8f8f42ed2
-    sha256: 0b569079269c7ed22043386d6d116724259c757d14e6c27418231b8679888b58
+    md5: 4b908217561a1274f48b0f9952fb5359
+    sha256: caf806b6f0d8acbfc06d87c21d89b0624b5b230fd30246860399fa01f3b0ba0f
   category: main
   optional: false
 - name: menuinst
-  version: 2.1.1
+  version: 2.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/menuinst-2.1.1-py312h81bd7bf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/menuinst-2.2.0-py312h81bd7bf_0.conda
   hash:
-    md5: 0b62c0f6e8efc0da273ff37be2c86c29
-    sha256: 624dccbf32ba5964c74596b538a6263c090b19a7bf0f41ad3f7a6c1ab2b42009
+    md5: 4ecad32f75f4ad25268e38778cac2b7f
+    sha256: b1def1d581bfd96473e854712ce77fe039835ea5c80d9a5033b0d2d2d14cdf0c
   category: main
   optional: false
 - name: mercantile
@@ -11567,12 +11751,12 @@ package:
   platform: linux-64
   dependencies:
     click: '>=3.0'
-    python: '>=3.6'
+    python: '>=3.9'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: aa20d014b5bd1924727dd86467648a27
-    sha256: 372275c3b0b0e5028cd25a87a23b23311b3412e556f8ee1768473e7634fb94ea
+    md5: 9820756deea38bd213240fd0556d44b8
+    sha256: 42ab9a82c4e4686d7c2a2d511877895bfe946ec2c2ec66e4e1593006fa32445f
   category: dev
   optional: true
 - name: mercantile
@@ -11580,13 +11764,13 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    click: '>=3.0'
-    python: '>=3.6'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+    click: '>=3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: aa20d014b5bd1924727dd86467648a27
-    sha256: 372275c3b0b0e5028cd25a87a23b23311b3412e556f8ee1768473e7634fb94ea
+    md5: 9820756deea38bd213240fd0556d44b8
+    sha256: 42ab9a82c4e4686d7c2a2d511877895bfe946ec2c2ec66e4e1593006fa32445f
   category: dev
   optional: true
 - name: mercantile
@@ -11594,13 +11778,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    click: '>=3.0'
-    python: '>=3.6'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+    click: '>=3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: aa20d014b5bd1924727dd86467648a27
-    sha256: 372275c3b0b0e5028cd25a87a23b23311b3412e556f8ee1768473e7634fb94ea
+    md5: 9820756deea38bd213240fd0556d44b8
+    sha256: 42ab9a82c4e4686d7c2a2d511877895bfe946ec2c2ec66e4e1593006fa32445f
   category: dev
   optional: true
 - name: minizip
@@ -11608,924 +11792,979 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     libiconv: '>=1.17,<2.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h05a5f5f_3.conda
+  hash:
+    md5: eec77634ccdb2ba6c231290c399b1dae
+    sha256: 9a9459024e9cdc68c799b057de021b8c652de542e24e9e48f2726578e822659c
+  category: main
+  optional: false
+- name: minizip
+  version: 4.0.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    bzip2: '>=1.0.8,<2.0a0'
+    libcxx: '>=18'
+    libiconv: '>=1.17,<2.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.7-hfb7a1ec_3.conda
+  hash:
+    md5: cb826e74fb8eb56f407493aa18e6a9e9
+    sha256: 69e9874ac02b298ab075cd4f1242b9678fd38cfe4470e935a44cf09d7e02bfc6
+  category: main
+  optional: false
+- name: minizip
+  version: 4.0.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libcxx: '>=18'
+    libiconv: '>=1.17,<2.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.7-hff1a8ea_3.conda
+  hash:
+    md5: 666bd61287ad7ee417884eacd9aef2ea
+    sha256: 6d904a6fc5e875e687b9fab244d5b286961222d72f546f9939d8f80ebe873c1c
+  category: main
+  optional: false
+- name: more-itertools
+  version: 10.6.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.6.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9b1225d67235df5411dbd2c94a5876b7
+    sha256: e017ede184823b12a194d058924ca26e1129975cee1cae47f69d6115c0478b55
+  category: main
+  optional: false
+- name: more-itertools
+  version: 10.6.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.6.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9b1225d67235df5411dbd2c94a5876b7
+    sha256: e017ede184823b12a194d058924ca26e1129975cee1cae47f69d6115c0478b55
+  category: main
+  optional: false
+- name: more-itertools
+  version: 10.6.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.6.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9b1225d67235df5411dbd2c94a5876b7
+    sha256: e017ede184823b12a194d058924ca26e1129975cee1cae47f69d6115c0478b55
+  category: main
+  optional: false
+- name: moto
+  version: 4.2.14
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-xray-sdk: '!=0.96,>=0.93'
+    boto3: '>=1.9.201'
+    botocore: '>=1.12.201'
+    cfn-lint: '>=0.40.0'
+    cryptography: '>=3.3.1'
+    docker-py: '>=2.5.1'
+    flask: '!=2.2.0,!=2.2.1'
+    flask_cors: ''
+    graphql-core: ''
+    idna: '>=2.5,<4'
+    importlib_metadata: ''
+    jinja2: '>=2.10.1'
+    jsondiff: '>=1.1.2'
+    openapi-spec-validator: '>=0.2.8'
+    pyparsing: '>=3.0.7'
+    python: '>=3.3'
+    python-dateutil: '>=2.1,<3.0.0'
+    python-jose: '>=3.1.0,<4.0.0'
+    pytz: ''
+    pyyaml: '>=5.1'
+    requests: '>=2.5'
+    responses: '>=0.9.0'
+    setuptools: ''
+    sshpubkeys: '>=3.1.0'
+    werkzeug: '>=0.5,!=2.2.0,!=2.2.1'
+    xmltodict: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/moto-4.2.14-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6e68c67781a43d8400b7a10f6f532725
+    sha256: 51380f1bcf262799a3ea19c17efdaa9821dd956032627dd585bf439c837bea59
+  category: dev
+  optional: true
+- name: moto
+  version: 4.2.14
+  manager: conda
+  platform: osx-64
+  dependencies:
+    setuptools: ''
+    pytz: ''
+    importlib_metadata: ''
+    xmltodict: ''
+    graphql-core: ''
+    flask_cors: ''
+    python-dateutil: '>=2.1,<3.0.0'
+    pyyaml: '>=5.1'
+    python: '>=3.3'
+    jinja2: '>=2.10.1'
+    requests: '>=2.5'
+    cryptography: '>=3.3.1'
+    idna: '>=2.5,<4'
+    boto3: '>=1.9.201'
+    aws-xray-sdk: '!=0.96,>=0.93'
+    jsondiff: '>=1.1.2'
+    responses: '>=0.9.0'
+    docker-py: '>=2.5.1'
+    botocore: '>=1.12.201'
+    python-jose: '>=3.1.0,<4.0.0'
+    sshpubkeys: '>=3.1.0'
+    flask: '!=2.2.0,!=2.2.1'
+    pyparsing: '>=3.0.7'
+    werkzeug: '>=0.5,!=2.2.0,!=2.2.1'
+    openapi-spec-validator: '>=0.2.8'
+    cfn-lint: '>=0.40.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/moto-4.2.14-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6e68c67781a43d8400b7a10f6f532725
+    sha256: 51380f1bcf262799a3ea19c17efdaa9821dd956032627dd585bf439c837bea59
+  category: dev
+  optional: true
+- name: moto
+  version: 4.2.14
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    setuptools: ''
+    pytz: ''
+    importlib_metadata: ''
+    xmltodict: ''
+    graphql-core: ''
+    flask_cors: ''
+    python-dateutil: '>=2.1,<3.0.0'
+    pyyaml: '>=5.1'
+    python: '>=3.3'
+    jinja2: '>=2.10.1'
+    requests: '>=2.5'
+    cryptography: '>=3.3.1'
+    idna: '>=2.5,<4'
+    boto3: '>=1.9.201'
+    aws-xray-sdk: '!=0.96,>=0.93'
+    jsondiff: '>=1.1.2'
+    responses: '>=0.9.0'
+    docker-py: '>=2.5.1'
+    botocore: '>=1.12.201'
+    python-jose: '>=3.1.0,<4.0.0'
+    sshpubkeys: '>=3.1.0'
+    flask: '!=2.2.0,!=2.2.1'
+    pyparsing: '>=3.0.7'
+    werkzeug: '>=0.5,!=2.2.0,!=2.2.1'
+    openapi-spec-validator: '>=0.2.8'
+    cfn-lint: '>=0.40.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/moto-4.2.14-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6e68c67781a43d8400b7a10f6f532725
+    sha256: 51380f1bcf262799a3ea19c17efdaa9821dd956032627dd585bf439c837bea59
+  category: dev
+  optional: true
+- name: mpc
+  version: 1.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    gmp: '>=6.3.0,<7.0a0'
+    libgcc: '>=13'
+    mpfr: '>=4.2.1,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.3.1-h24ddda3_1.conda
+  hash:
+    md5: aa14b9a5196a6d8dd364164b7ce56acf
+    sha256: 1bf794ddf2c8b3a3e14ae182577c624fa92dea975537accff4bc7e5fea085212
+  category: dev
+  optional: true
+- name: mpc
+  version: 1.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    gmp: '>=6.3.0,<7.0a0'
+    mpfr: '>=4.2.1,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h9d8efa1_1.conda
+  hash:
+    md5: 0520855aaae268ea413d6bc913f1384c
+    sha256: dcf91571da6c2f0db96d43a1b639047def05a0e1b6436d42c9129ab14af47b10
+  category: dev
+  optional: true
+- name: mpc
+  version: 1.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    gmp: '>=6.3.0,<7.0a0'
+    mpfr: '>=4.2.1,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h8f1351a_1.conda
+  hash:
+    md5: a5635df796b71f6ca400fc7026f50701
+    sha256: 2700899ad03302a1751dbf2bca135407e470dd83ac897ab91dd8675d4300f158
+  category: dev
+  optional: true
+- name: mpfr
+  version: 4.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    gmp: '>=6.3.0,<7.0a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.1-h90cbb55_3.conda
+  hash:
+    md5: 2eeb50cab6652538eee8fc0bc3340c81
+    sha256: f25d2474dd557ca66c6231c8f5ace5af312efde1ba8290a6ea5e1732a4e669c0
+  category: dev
+  optional: true
+- name: mpfr
+  version: 4.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/mpfr-4.2.1-haed47dc_3.conda
+  hash:
+    md5: d511e58aaaabfc23136880d9956fa7a6
+    sha256: dddb6721dff05b8dfb654c532725330231fcb81ff1e27d885ee0cdcc9fccf1c4
+  category: dev
+  optional: true
+- name: mpfr
+  version: 4.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-hb693164_3.conda
+  hash:
+    md5: 4e4ea852d54cc2b869842de5044662fb
+    sha256: 4463e4e2aba7668e37a1b8532859191b4477a6f3602a5d6b4d64ad4c4baaeac5
+  category: dev
+  optional: true
+- name: mpmath
+  version: 1.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3585aa87c43ab15b167b574cd73b057b
+    sha256: 7d7aa3fcd6f42b76bd711182f3776a02bef09a68c5f117d66b712a6d81368692
+  category: dev
+  optional: true
+- name: mpmath
+  version: 1.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3585aa87c43ab15b167b574cd73b057b
+    sha256: 7d7aa3fcd6f42b76bd711182f3776a02bef09a68c5f117d66b712a6d81368692
+  category: dev
+  optional: true
+- name: mpmath
+  version: 1.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 3585aa87c43ab15b167b574cd73b057b
+    sha256: 7d7aa3fcd6f42b76bd711182f3776a02bef09a68c5f117d66b712a6d81368692
+  category: dev
+  optional: true
+- name: msgpack-python
+  version: 1.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py312h68727a3_0.conda
+  hash:
+    md5: 5c9b020a3f86799cdc6115e55df06146
+    sha256: 4bc53333774dea1330643b7e23aa34fd6880275737fc2e07491795872d3af8dd
+  category: main
+  optional: false
+- name: msgpack-python
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcxx: '>=17'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.1.0-py312hc5c4d5f_0.conda
+  hash:
+    md5: 3448a4ca65790764c2f8d44d5f917f84
+    sha256: d12f400fb57eef8aae8a8b2a3c4d4917130b9bd8f08a631646e3bf4a6551bb54
+  category: main
+  optional: false
+- name: msgpack-python
+  version: 1.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=17'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py312h6142ec9_0.conda
+  hash:
+    md5: 0dfc3750cc6bbc463d72c0b727e60d8a
+    sha256: 2b8c22f8a4e0031c2d6fa81d32814c8afdaf7e7fe2e681bf2369a35ff3eab1fd
+  category: main
+  optional: false
+- name: multidict
+  version: 6.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.1.0-py312h178313f_2.conda
+  hash:
+    md5: 5b5e3267d915a107eca793d52e1b780a
+    sha256: b05bc8252a6e957bf4a776ed5e0e61d1ba88cdc46ccb55890c72cc58b10371f4
+  category: main
+  optional: false
+- name: multidict
+  version: 6.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.1.0-py312h6f3313d_1.conda
+  hash:
+    md5: 47e51ecdee53dfc456f02ad633aa43bf
+    sha256: 326c92cd8e4bc85294f2f0b5cdf97d90e96158c2881915256e99f8bc07559960
+  category: main
+  optional: false
+- name: multidict
+  version: 6.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.1.0-py312hdb8e49c_1.conda
+  hash:
+    md5: 0048335516fed938e4dd2c457b4c5b9b
+    sha256: 482fd09fb798090dc8cce2285fa69f43b1459099122eac2fb112d9b922b9f916
+  category: main
+  optional: false
+- name: munkres
+  version: 1.1.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 2ba8498c1018c1e9c61eb99b973dfe19
+    sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  category: main
+  optional: false
+- name: munkres
+  version: 1.1.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 2ba8498c1018c1e9c61eb99b973dfe19
+    sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  category: main
+  optional: false
+- name: munkres
+  version: 1.1.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 2ba8498c1018c1e9c61eb99b973dfe19
+    sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+  category: main
+  optional: false
+- name: mypy
+  version: 1.15.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    mypy_extensions: '>=1.0.0'
+    psutil: '>=4.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    typing_extensions: '>=4.1.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.15.0-py312h66e93f0_0.conda
+  hash:
+    md5: a84061bc7e166712deb33bf7b32f756d
+    sha256: b57c8bd233087479c70cb3ee3420861e0625b8a5a697f5abe41f5103fb2c2e69
+  category: dev
+  optional: true
+- name: mypy
+  version: 1.15.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    mypy_extensions: '>=1.0.0'
+    psutil: '>=4.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    typing_extensions: '>=4.1.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.15.0-py312h01d7ebd_0.conda
+  hash:
+    md5: 0251bb4d6702b729b06fd5c7918e9242
+    sha256: 38132c4b5de6686965f21b51a1656438e83b2a53d6f50e9589e73fb57a43dd49
+  category: dev
+  optional: true
+- name: mypy
+  version: 1.15.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    mypy_extensions: '>=1.0.0'
+    psutil: '>=4.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    typing_extensions: '>=4.1.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.15.0-py312hea69d52_0.conda
+  hash:
+    md5: 909034322685579577b1bbb9b47e39e1
+    sha256: 7284d77173d385f5c7456c13d825dbae170920a31ca7a0996d2608ad17f17e2f
+  category: dev
+  optional: true
+- name: mypy-boto3-s3
+  version: 1.36.9
+  manager: conda
+  platform: linux-64
+  dependencies:
+    boto3: ''
+    python: '>=3.9'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.36.9-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7c2ae5ac33152d95ffa4650fc32d2e66
+    sha256: c8cdb36240ab01860d1105002d82fbd5ed562ad2cd67a542a3ad229da4f35312
+  category: dev
+  optional: true
+- name: mypy-boto3-s3
+  version: 1.36.9
+  manager: conda
+  platform: osx-64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.36.9-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7c2ae5ac33152d95ffa4650fc32d2e66
+    sha256: c8cdb36240ab01860d1105002d82fbd5ed562ad2cd67a542a3ad229da4f35312
+  category: dev
+  optional: true
+- name: mypy-boto3-s3
+  version: 1.36.9
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.36.9-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7c2ae5ac33152d95ffa4650fc32d2e66
+    sha256: c8cdb36240ab01860d1105002d82fbd5ed562ad2cd67a542a3ad229da4f35312
+  category: dev
+  optional: true
+- name: mypy_boto3_cloudformation
+  version: 1.36.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    boto3: ''
+    python: '>=3.9'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_cloudformation-1.36.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 488d39d13164142267903d8a3db3bdbf
+    sha256: 4f8a6b1ec3652749691e0394fb1ca118a1d98a44e5c0701ae41301c378fe742a
+  category: dev
+  optional: true
+- name: mypy_boto3_cloudformation
+  version: 1.36.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_cloudformation-1.36.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 488d39d13164142267903d8a3db3bdbf
+    sha256: 4f8a6b1ec3652749691e0394fb1ca118a1d98a44e5c0701ae41301c378fe742a
+  category: dev
+  optional: true
+- name: mypy_boto3_cloudformation
+  version: 1.36.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_cloudformation-1.36.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 488d39d13164142267903d8a3db3bdbf
+    sha256: 4f8a6b1ec3652749691e0394fb1ca118a1d98a44e5c0701ae41301c378fe742a
+  category: dev
+  optional: true
+- name: mypy_boto3_dynamodb
+  version: 1.36.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    boto3: ''
+    python: '>=3.9'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_dynamodb-1.36.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: e2edd16f8ca14a7312cb6dd017dfb7bc
+    sha256: 29db2c80816ad22060259c71f8cb30f102b067398a6412152cdfc9918c4e1e1b
+  category: dev
+  optional: true
+- name: mypy_boto3_dynamodb
+  version: 1.36.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_dynamodb-1.36.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: e2edd16f8ca14a7312cb6dd017dfb7bc
+    sha256: 29db2c80816ad22060259c71f8cb30f102b067398a6412152cdfc9918c4e1e1b
+  category: dev
+  optional: true
+- name: mypy_boto3_dynamodb
+  version: 1.36.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_dynamodb-1.36.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: e2edd16f8ca14a7312cb6dd017dfb7bc
+    sha256: 29db2c80816ad22060259c71f8cb30f102b067398a6412152cdfc9918c4e1e1b
+  category: dev
+  optional: true
+- name: mypy_boto3_ec2
+  version: 1.36.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    boto3: ''
+    python: '>=3.9'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_ec2-1.36.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9552eef7855e48161b8ff2cfa21aeed0
+    sha256: b2de20084dae428630e1a6fd7eb80eb9ee10e0c16563656b5c13b1aa0a8af02e
+  category: dev
+  optional: true
+- name: mypy_boto3_ec2
+  version: 1.36.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_ec2-1.36.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9552eef7855e48161b8ff2cfa21aeed0
+    sha256: b2de20084dae428630e1a6fd7eb80eb9ee10e0c16563656b5c13b1aa0a8af02e
+  category: dev
+  optional: true
+- name: mypy_boto3_ec2
+  version: 1.36.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_ec2-1.36.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9552eef7855e48161b8ff2cfa21aeed0
+    sha256: b2de20084dae428630e1a6fd7eb80eb9ee10e0c16563656b5c13b1aa0a8af02e
+  category: dev
+  optional: true
+- name: mypy_boto3_lambda
+  version: 1.36.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    boto3: ''
+    python: '>=3.9'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_lambda-1.36.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 58cf24312ec79aebf76571980e633afc
+    sha256: c09a24971b0751db2c81cd578191a9f9ae4dd211a293a2e905edb7367a00c18d
+  category: dev
+  optional: true
+- name: mypy_boto3_lambda
+  version: 1.36.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_lambda-1.36.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 58cf24312ec79aebf76571980e633afc
+    sha256: c09a24971b0751db2c81cd578191a9f9ae4dd211a293a2e905edb7367a00c18d
+  category: dev
+  optional: true
+- name: mypy_boto3_lambda
+  version: 1.36.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_lambda-1.36.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 58cf24312ec79aebf76571980e633afc
+    sha256: c09a24971b0751db2c81cd578191a9f9ae4dd211a293a2e905edb7367a00c18d
+  category: dev
+  optional: true
+- name: mypy_boto3_rds
+  version: 1.36.14
+  manager: conda
+  platform: linux-64
+  dependencies:
+    boto3: ''
+    python: '>=3.9'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_rds-1.36.14-pyhd8ed1ab_0.conda
+  hash:
+    md5: f25ad79cceba418be8dd6e3af732e1a6
+    sha256: f6a438b41528794861f007f1a7ae56770bf470c9c0fb1d150fa3a72e2505706b
+  category: dev
+  optional: true
+- name: mypy_boto3_rds
+  version: 1.36.14
+  manager: conda
+  platform: osx-64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_rds-1.36.14-pyhd8ed1ab_0.conda
+  hash:
+    md5: f25ad79cceba418be8dd6e3af732e1a6
+    sha256: f6a438b41528794861f007f1a7ae56770bf470c9c0fb1d150fa3a72e2505706b
+  category: dev
+  optional: true
+- name: mypy_boto3_rds
+  version: 1.36.14
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_rds-1.36.14-pyhd8ed1ab_0.conda
+  hash:
+    md5: f25ad79cceba418be8dd6e3af732e1a6
+    sha256: f6a438b41528794861f007f1a7ae56770bf470c9c0fb1d150fa3a72e2505706b
+  category: dev
+  optional: true
+- name: mypy_boto3_sqs
+  version: 1.36.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    boto3: ''
+    python: '>=3.9'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_sqs-1.36.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 42f7f59f426692b70e1ae07be674a5d1
+    sha256: ccbe63318691c064fd5bcc30c401d7154298fe7cafd37287d8071c14be61d7a2
+  category: dev
+  optional: true
+- name: mypy_boto3_sqs
+  version: 1.36.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_sqs-1.36.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 42f7f59f426692b70e1ae07be674a5d1
+    sha256: ccbe63318691c064fd5bcc30c401d7154298fe7cafd37287d8071c14be61d7a2
+  category: dev
+  optional: true
+- name: mypy_boto3_sqs
+  version: 1.36.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    boto3: ''
+    typing-extensions: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_sqs-1.36.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 42f7f59f426692b70e1ae07be674a5d1
+    sha256: ccbe63318691c064fd5bcc30c401d7154298fe7cafd37287d8071c14be61d7a2
+  category: dev
+  optional: true
+- name: mypy_extensions
+  version: 1.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
+  hash:
+    md5: 29097e7ea634a45cc5386b95cac6568f
+    sha256: 1895f47b7d68581a6facde5cb13ab8c2764c2e53a76bd746f8f98910dc4e08fe
+  category: dev
+  optional: true
+- name: mypy_extensions
+  version: 1.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
+  hash:
+    md5: 29097e7ea634a45cc5386b95cac6568f
+    sha256: 1895f47b7d68581a6facde5cb13ab8c2764c2e53a76bd746f8f98910dc4e08fe
+  category: dev
+  optional: true
+- name: mypy_extensions
+  version: 1.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
+  hash:
+    md5: 29097e7ea634a45cc5386b95cac6568f
+    sha256: 1895f47b7d68581a6facde5cb13ab8c2764c2e53a76bd746f8f98910dc4e08fe
+  category: dev
+  optional: true
+- name: ncurses
+  version: '6.5'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+  hash:
+    md5: 47e340acb35de30501a76c7c799c41d7
+    sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.5'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
+  hash:
+    md5: ced34dd9929f491ca6dab6a2927aff25
+    sha256: ea4a5d27ded18443749aefa49dc79f6356da8506d508b5296f60b8d51e0c4bd9
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.5'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+  hash:
+    md5: 068d497125e4bf8a66bf707254fff5ae
+    sha256: 2827ada40e8d9ca69a153a45f7fd14f32b2ead7045d3bbb5d10964898fe65733
+  category: main
+  optional: false
+- name: nest-asyncio
+  version: 1.6.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 598fd7d4d0de2455fb74f56063969a97
+    sha256: bb7b21d7fd0445ddc0631f64e66d91a179de4ba920b8381f29b9d006a42788c0
+  category: dev
+  optional: true
+- name: nest-asyncio
+  version: 1.6.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 598fd7d4d0de2455fb74f56063969a97
+    sha256: bb7b21d7fd0445ddc0631f64e66d91a179de4ba920b8381f29b9d006a42788c0
+  category: dev
+  optional: true
+- name: nest-asyncio
+  version: 1.6.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 598fd7d4d0de2455fb74f56063969a97
+    sha256: bb7b21d7fd0445ddc0631f64e66d91a179de4ba920b8381f29b9d006a42788c0
+  category: dev
+  optional: true
+- name: networkx
+  version: 3.4.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.4.2-pyh267e887_2.conda
+  hash:
+    md5: fd40bf7f7f4bc4b647dc8512053d9873
+    sha256: 39625cd0c9747fa5c46a9a90683b8997d8b9649881b3dc88336b13b7bdd60117
+  category: main
+  optional: false
+- name: networkx
+  version: 3.4.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.4.2-pyh267e887_2.conda
+  hash:
+    md5: fd40bf7f7f4bc4b647dc8512053d9873
+    sha256: 39625cd0c9747fa5c46a9a90683b8997d8b9649881b3dc88336b13b7bdd60117
+  category: main
+  optional: false
+- name: networkx
+  version: 3.4.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.4.2-pyh267e887_2.conda
+  hash:
+    md5: fd40bf7f7f4bc4b647dc8512053d9873
+    sha256: 39625cd0c9747fa5c46a9a90683b8997d8b9649881b3dc88336b13b7bdd60117
+  category: main
+  optional: false
+- name: nlohmann_json
+  version: 3.11.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.11.3-he02047a_1.conda
   hash:
-    md5: 4474532a312b2245c5c77f1176989b46
-    sha256: 6315ea87d094418e744deb79a22331718b36a0e6e107cd7fc3c52c7922bc8133
+    md5: e46f7ac4917215b49df2ea09a694a3fa
+    sha256: ce4bcced4f8eea71b7cac8bc3daac097abf7a5792f278cd811dedada199500c1
   category: main
   optional: false
-- name: minizip
-  version: 4.0.7
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    bzip2: '>=1.0.8,<2.0a0'
-    libcxx: '>=16'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.7-h62b0c8d_0.conda
-  hash:
-    md5: 9cb19284d7d835918241acf8180099db
-    sha256: e02a6e1a43b0ff44bb9460d46d3f7687a1876d435fb3c2c6cf9e19bab60901f6
-  category: main
-  optional: false
-- name: minizip
-  version: 4.0.7
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libcxx: '>=16'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.7-h27ee973_0.conda
-  hash:
-    md5: 73dcdab1f21da49048a4f26d648c87a9
-    sha256: 8216190bed8462758d1fea34964f4f46e6314e92696d8b6607bde588895663ad
-  category: main
-  optional: false
-- name: more-itertools
-  version: 10.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a57fb23d0260a962a67c7d990ec1c812
-    sha256: 9c485cc52dfd646ea584e9055c1bbaac8f27687d806c1ef00f299ec2e642ce04
-  category: main
-  optional: false
-- name: more-itertools
-  version: 10.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a57fb23d0260a962a67c7d990ec1c812
-    sha256: 9c485cc52dfd646ea584e9055c1bbaac8f27687d806c1ef00f299ec2e642ce04
-  category: main
-  optional: false
-- name: more-itertools
-  version: 10.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a57fb23d0260a962a67c7d990ec1c812
-    sha256: 9c485cc52dfd646ea584e9055c1bbaac8f27687d806c1ef00f299ec2e642ce04
-  category: main
-  optional: false
-- name: moto
-  version: 4.2.14
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-xray-sdk: '!=0.96,>=0.93'
-    boto3: '>=1.9.201'
-    botocore: '>=1.12.201'
-    cfn-lint: '>=0.40.0'
-    cryptography: '>=3.3.1'
-    docker-py: '>=2.5.1'
-    flask: '!=2.2.0,!=2.2.1'
-    flask_cors: ''
-    graphql-core: ''
-    idna: '>=2.5,<4'
-    importlib_metadata: ''
-    jinja2: '>=2.10.1'
-    jsondiff: '>=1.1.2'
-    openapi-spec-validator: '>=0.2.8'
-    pyparsing: '>=3.0.7'
-    python: '>=3.3'
-    python-dateutil: '>=2.1,<3.0.0'
-    python-jose: '>=3.1.0,<4.0.0'
-    pytz: ''
-    pyyaml: '>=5.1'
-    requests: '>=2.5'
-    responses: '>=0.9.0'
-    setuptools: ''
-    sshpubkeys: '>=3.1.0'
-    werkzeug: '>=0.5,!=2.2.0,!=2.2.1'
-    xmltodict: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/moto-4.2.14-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6e68c67781a43d8400b7a10f6f532725
-    sha256: 51380f1bcf262799a3ea19c17efdaa9821dd956032627dd585bf439c837bea59
-  category: dev
-  optional: true
-- name: moto
-  version: 4.2.14
-  manager: conda
-  platform: osx-64
-  dependencies:
-    aws-xray-sdk: '!=0.96,>=0.93'
-    boto3: '>=1.9.201'
-    botocore: '>=1.12.201'
-    cfn-lint: '>=0.40.0'
-    cryptography: '>=3.3.1'
-    docker-py: '>=2.5.1'
-    flask: '!=2.2.0,!=2.2.1'
-    flask_cors: ''
-    graphql-core: ''
-    idna: '>=2.5,<4'
-    importlib_metadata: ''
-    jinja2: '>=2.10.1'
-    jsondiff: '>=1.1.2'
-    openapi-spec-validator: '>=0.2.8'
-    pyparsing: '>=3.0.7'
-    python: '>=3.3'
-    python-dateutil: '>=2.1,<3.0.0'
-    python-jose: '>=3.1.0,<4.0.0'
-    pytz: ''
-    pyyaml: '>=5.1'
-    requests: '>=2.5'
-    responses: '>=0.9.0'
-    setuptools: ''
-    sshpubkeys: '>=3.1.0'
-    werkzeug: '>=0.5,!=2.2.0,!=2.2.1'
-    xmltodict: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/moto-4.2.14-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6e68c67781a43d8400b7a10f6f532725
-    sha256: 51380f1bcf262799a3ea19c17efdaa9821dd956032627dd585bf439c837bea59
-  category: dev
-  optional: true
-- name: moto
-  version: 4.2.14
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    aws-xray-sdk: '!=0.96,>=0.93'
-    boto3: '>=1.9.201'
-    botocore: '>=1.12.201'
-    cfn-lint: '>=0.40.0'
-    cryptography: '>=3.3.1'
-    docker-py: '>=2.5.1'
-    flask: '!=2.2.0,!=2.2.1'
-    flask_cors: ''
-    graphql-core: ''
-    idna: '>=2.5,<4'
-    importlib_metadata: ''
-    jinja2: '>=2.10.1'
-    jsondiff: '>=1.1.2'
-    openapi-spec-validator: '>=0.2.8'
-    pyparsing: '>=3.0.7'
-    python: '>=3.3'
-    python-dateutil: '>=2.1,<3.0.0'
-    python-jose: '>=3.1.0,<4.0.0'
-    pytz: ''
-    pyyaml: '>=5.1'
-    requests: '>=2.5'
-    responses: '>=0.9.0'
-    setuptools: ''
-    sshpubkeys: '>=3.1.0'
-    werkzeug: '>=0.5,!=2.2.0,!=2.2.1'
-    xmltodict: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/moto-4.2.14-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6e68c67781a43d8400b7a10f6f532725
-    sha256: 51380f1bcf262799a3ea19c17efdaa9821dd956032627dd585bf439c837bea59
-  category: dev
-  optional: true
-- name: mpc
-  version: 1.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gmp: '>=6.2.1,<7.0a0'
-    libgcc-ng: '>=12'
-    mpfr: '>=4.1.0,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.3.1-hfe3b2da_0.conda
-  hash:
-    md5: 289c71e83dc0daa7d4c81f04180778ca
-    sha256: 2f88965949ba7b4b21e7e5facd62285f7c6efdb17359d1b365c3bb4ecc968d29
-  category: dev
-  optional: true
-- name: mpc
-  version: 1.3.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    gmp: '>=6.2.1,<7.0a0'
-    mpfr: '>=4.1.0,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h81bd1dd_0.conda
-  hash:
-    md5: c752c0eb6c250919559172c011e5f65b
-    sha256: 2ae945a15c8a984d581dcfb974ad3b5d877a6527de2c95a3363e6b4490b2f312
-  category: dev
-  optional: true
-- name: mpc
-  version: 1.3.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    gmp: '>=6.2.1,<7.0a0'
-    mpfr: '>=4.1.0,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h91ba8db_0.conda
-  hash:
-    md5: 362af269d860ae49580f8f032a68b0df
-    sha256: 6d8d4f8befca279f022c1c212241ad6672cb347181452555414e277484ad534c
-  category: dev
-  optional: true
-- name: mpfr
-  version: 4.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.1-h9458935_1.conda
-  hash:
-    md5: 8083b20f566639c22f78bcd6ca35b276
-    sha256: 38c501f6b8dff124e57711c01da23e204703a3c14276f4cf6abd28850b2b9893
-  category: dev
-  optional: true
-- name: mpfr
-  version: 4.2.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/mpfr-4.2.1-h4f6b447_1.conda
-  hash:
-    md5: b90df08f0deb2f58631447c1462c92a7
-    sha256: 002209e7d1f21cdd04de17050ab2050de4347e5bf04210ce6a636cbabf43e1d0
-  category: dev
-  optional: true
-- name: mpfr
-  version: 4.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-h41d338b_1.conda
-  hash:
-    md5: 616d9bb6983991de582589b9a06e4cea
-    sha256: a0b183cdf8bd1f2462d965f7a065cbfc32669d95bb6c8f970f7c7f63d2938436
-  category: dev
-  optional: true
-- name: mpmath
-  version: 1.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: dbf6e2d89137da32fa6670f3bffc024e
-    sha256: a4f025c712ec1502a55c471b56a640eaeebfce38dd497d5a1a33729014cac47a
-  category: dev
-  optional: true
-- name: mpmath
-  version: 1.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: dbf6e2d89137da32fa6670f3bffc024e
-    sha256: a4f025c712ec1502a55c471b56a640eaeebfce38dd497d5a1a33729014cac47a
-  category: dev
-  optional: true
-- name: mpmath
-  version: 1.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: dbf6e2d89137da32fa6670f3bffc024e
-    sha256: a4f025c712ec1502a55c471b56a640eaeebfce38dd497d5a1a33729014cac47a
-  category: dev
-  optional: true
-- name: msgpack-python
-  version: 1.0.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.8-py312h2492b07_0.conda
-  hash:
-    md5: 0df463266eaaa1b8a35f8fd26368c1a1
-    sha256: 3761f57834ae20e49b4665b341057cf8ac2641d6f87e76d3d5cc615bc0dae8cc
-  category: main
-  optional: false
-- name: msgpack-python
-  version: 1.0.8
+- name: nlohmann_json
+  version: 3.11.3
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libcxx: '>=16'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.0.8-py312hc3c9ca0_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/nlohmann_json-3.11.3-hf036a51_1.conda
   hash:
-    md5: 87927f3f0037c19ac74ac3f820c26bd1
-    sha256: d48287594d4c4a9323deb2f505c52f53f757981d4d16b22231f8831bd22349bf
+    md5: 00c3efa95b3a010ee85bc36aac6ab2f6
+    sha256: 41b1aa2a67654917c9c32a5f0111970b11cfce49ed57cf44bba4aefdcd59e54b
   category: main
   optional: false
-- name: msgpack-python
-  version: 1.0.8
+- name: nlohmann_json
+  version: 3.11.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=16'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.0.8-py312h157fec4_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.11.3-h00cdb27_1.conda
   hash:
-    md5: b815836e3b798dff1d7a28095761658b
-    sha256: 88abda8e86379e085540cbe54897792b62e61b7f0b77882a7361dba01a4687f4
-  category: main
-  optional: false
-- name: multidict
-  version: 6.0.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.0.5-py312h98912ed_0.conda
-  hash:
-    md5: d0d2cab29d6c33c47f719d7a1879e08b
-    sha256: 27f085bde8e70f20196934ceeb0e1b9d3f2c67a5a24c688c3050d50ac0125eb4
-  category: main
-  optional: false
-- name: multidict
-  version: 6.0.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.0.5-py312h97956c7_0.conda
-  hash:
-    md5: 4b6f7537d79a75053c8fd79cb5bc5f13
-    sha256: fe408d289a8e39d0a2a2e590d03421e1f7dd83e2936297bd3f5c43a6ee86f458
-  category: main
-  optional: false
-- name: multidict
-  version: 6.0.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.0.5-py312h670c8ac_0.conda
-  hash:
-    md5: 5f132dbfff9d4ac73f5d4786459b22ba
-    sha256: d7a15bf4dda045aa0808c2f90eb53759d7d1c7a88b9a98713b182ff231bfaba0
-  category: main
-  optional: false
-- name: munkres
-  version: 1.1.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 2ba8498c1018c1e9c61eb99b973dfe19
-    sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
-  category: main
-  optional: false
-- name: munkres
-  version: 1.1.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 2ba8498c1018c1e9c61eb99b973dfe19
-    sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
-  category: main
-  optional: false
-- name: munkres
-  version: 1.1.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 2ba8498c1018c1e9c61eb99b973dfe19
-    sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
-  category: main
-  optional: false
-- name: mypy
-  version: 1.10.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    mypy_extensions: '>=1.0.0'
-    psutil: '>=4.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    typing_extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.10.1-py312h9a8786e_0.conda
-  hash:
-    md5: 35504aad41d76808fa379bee8cd6882e
-    sha256: d65af401f7368680f164990f110d084ee5139cd01a62189c76a88ab87ea50285
-  category: dev
-  optional: true
-- name: mypy
-  version: 1.10.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    mypy_extensions: '>=1.0.0'
-    psutil: '>=4.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    typing_extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.10.1-py312hbd25219_0.conda
-  hash:
-    md5: 38d751fa3fd6e793f11903f816ee1cfe
-    sha256: 353e75ea35e3c44294787f318e710379f7f0618962a918af90e91597a2710dea
-  category: dev
-  optional: true
-- name: mypy
-  version: 1.10.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    mypy_extensions: '>=1.0.0'
-    psutil: '>=4.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    typing_extensions: '>=4.1.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.10.1-py312h7e5086c_0.conda
-  hash:
-    md5: 0aea347a79c70d8134ebd2efc897dda0
-    sha256: d07f260bde42e963558bedbb5d8607c18a16f71a0dff45fb7cecc85bfcd97c6f
-  category: dev
-  optional: true
-- name: mypy-boto3-s3
-  version: 1.34.138
-  manager: conda
-  platform: linux-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.34.138-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1bdf3cabd34c365de48c68d95bec59b4
-    sha256: 4216554db1cfd65ec854e666ffd29e59859ce117f065454baf0c894423240ed2
-  category: dev
-  optional: true
-- name: mypy-boto3-s3
-  version: 1.34.138
-  manager: conda
-  platform: osx-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.34.138-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1bdf3cabd34c365de48c68d95bec59b4
-    sha256: 4216554db1cfd65ec854e666ffd29e59859ce117f065454baf0c894423240ed2
-  category: dev
-  optional: true
-- name: mypy-boto3-s3
-  version: 1.34.138
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.34.138-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1bdf3cabd34c365de48c68d95bec59b4
-    sha256: 4216554db1cfd65ec854e666ffd29e59859ce117f065454baf0c894423240ed2
-  category: dev
-  optional: true
-- name: mypy_boto3_cloudformation
-  version: 1.34.111
-  manager: conda
-  platform: linux-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_cloudformation-1.34.111-pyhd8ed1ab_0.conda
-  hash:
-    md5: c2e9a69cf5af0488570e6e61c43d1660
-    sha256: a00e9c8c4171f72ed058cbd3f93bbe9f6da88a3c00c42375212042feaa53b961
-  category: dev
-  optional: true
-- name: mypy_boto3_cloudformation
-  version: 1.34.111
-  manager: conda
-  platform: osx-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_cloudformation-1.34.111-pyhd8ed1ab_0.conda
-  hash:
-    md5: c2e9a69cf5af0488570e6e61c43d1660
-    sha256: a00e9c8c4171f72ed058cbd3f93bbe9f6da88a3c00c42375212042feaa53b961
-  category: dev
-  optional: true
-- name: mypy_boto3_cloudformation
-  version: 1.34.111
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_cloudformation-1.34.111-pyhd8ed1ab_0.conda
-  hash:
-    md5: c2e9a69cf5af0488570e6e61c43d1660
-    sha256: a00e9c8c4171f72ed058cbd3f93bbe9f6da88a3c00c42375212042feaa53b961
-  category: dev
-  optional: true
-- name: mypy_boto3_dynamodb
-  version: 1.34.131
-  manager: conda
-  platform: linux-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_dynamodb-1.34.131-pyhd8ed1ab_0.conda
-  hash:
-    md5: 566f4dd49524fe04905968ebff421edd
-    sha256: fd269c3acf6cb621ec10a1776c2cfea1c1bd6a9377322e5e6ee4acc973242d77
-  category: dev
-  optional: true
-- name: mypy_boto3_dynamodb
-  version: 1.34.131
-  manager: conda
-  platform: osx-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_dynamodb-1.34.131-pyhd8ed1ab_0.conda
-  hash:
-    md5: 566f4dd49524fe04905968ebff421edd
-    sha256: fd269c3acf6cb621ec10a1776c2cfea1c1bd6a9377322e5e6ee4acc973242d77
-  category: dev
-  optional: true
-- name: mypy_boto3_dynamodb
-  version: 1.34.131
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_dynamodb-1.34.131-pyhd8ed1ab_0.conda
-  hash:
-    md5: 566f4dd49524fe04905968ebff421edd
-    sha256: fd269c3acf6cb621ec10a1776c2cfea1c1bd6a9377322e5e6ee4acc973242d77
-  category: dev
-  optional: true
-- name: mypy_boto3_ec2
-  version: 1.34.138
-  manager: conda
-  platform: linux-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_ec2-1.34.138-pyhd8ed1ab_0.conda
-  hash:
-    md5: 35d0b7c5e08f70db9a3669955072ade1
-    sha256: c5a09de8f3798bfe739280054ad5bb2222ffd820e841b8b66dc56e54db7a5a2f
-  category: dev
-  optional: true
-- name: mypy_boto3_ec2
-  version: 1.34.138
-  manager: conda
-  platform: osx-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_ec2-1.34.138-pyhd8ed1ab_0.conda
-  hash:
-    md5: 35d0b7c5e08f70db9a3669955072ade1
-    sha256: c5a09de8f3798bfe739280054ad5bb2222ffd820e841b8b66dc56e54db7a5a2f
-  category: dev
-  optional: true
-- name: mypy_boto3_ec2
-  version: 1.34.138
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_ec2-1.34.138-pyhd8ed1ab_0.conda
-  hash:
-    md5: 35d0b7c5e08f70db9a3669955072ade1
-    sha256: c5a09de8f3798bfe739280054ad5bb2222ffd820e841b8b66dc56e54db7a5a2f
-  category: dev
-  optional: true
-- name: mypy_boto3_lambda
-  version: 1.34.58
-  manager: conda
-  platform: linux-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_lambda-1.34.58-pyhd8ed1ab_0.conda
-  hash:
-    md5: f9f6596dffa1b488c32e0e8c29e9d544
-    sha256: f9d4eef0fff32fb12fa478d2075145635995d5b28dfbf95928fc9ac498fa043b
-  category: dev
-  optional: true
-- name: mypy_boto3_lambda
-  version: 1.34.58
-  manager: conda
-  platform: osx-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_lambda-1.34.58-pyhd8ed1ab_0.conda
-  hash:
-    md5: f9f6596dffa1b488c32e0e8c29e9d544
-    sha256: f9d4eef0fff32fb12fa478d2075145635995d5b28dfbf95928fc9ac498fa043b
-  category: dev
-  optional: true
-- name: mypy_boto3_lambda
-  version: 1.34.58
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_lambda-1.34.58-pyhd8ed1ab_0.conda
-  hash:
-    md5: f9f6596dffa1b488c32e0e8c29e9d544
-    sha256: f9d4eef0fff32fb12fa478d2075145635995d5b28dfbf95928fc9ac498fa043b
-  category: dev
-  optional: true
-- name: mypy_boto3_rds
-  version: 1.34.135
-  manager: conda
-  platform: linux-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_rds-1.34.135-pyhd8ed1ab_0.conda
-  hash:
-    md5: c99cb9d6180037e5350a8021c7d9d5c7
-    sha256: 458d0fa98f1f85522d10fd073f3445f661419ededcdb7eb6489ba8a28ed37a1d
-  category: dev
-  optional: true
-- name: mypy_boto3_rds
-  version: 1.34.135
-  manager: conda
-  platform: osx-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_rds-1.34.135-pyhd8ed1ab_0.conda
-  hash:
-    md5: c99cb9d6180037e5350a8021c7d9d5c7
-    sha256: 458d0fa98f1f85522d10fd073f3445f661419ededcdb7eb6489ba8a28ed37a1d
-  category: dev
-  optional: true
-- name: mypy_boto3_rds
-  version: 1.34.135
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_rds-1.34.135-pyhd8ed1ab_0.conda
-  hash:
-    md5: c99cb9d6180037e5350a8021c7d9d5c7
-    sha256: 458d0fa98f1f85522d10fd073f3445f661419ededcdb7eb6489ba8a28ed37a1d
-  category: dev
-  optional: true
-- name: mypy_boto3_sqs
-  version: 1.34.121
-  manager: conda
-  platform: linux-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_sqs-1.34.121-pyhd8ed1ab_0.conda
-  hash:
-    md5: 00710840131b36739e942763477b7e8b
-    sha256: ae39855bd6b7f80beee28c872ba59f60c8542ec2b074e514219afe970721d626
-  category: dev
-  optional: true
-- name: mypy_boto3_sqs
-  version: 1.34.121
-  manager: conda
-  platform: osx-64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_sqs-1.34.121-pyhd8ed1ab_0.conda
-  hash:
-    md5: 00710840131b36739e942763477b7e8b
-    sha256: ae39855bd6b7f80beee28c872ba59f60c8542ec2b074e514219afe970721d626
-  category: dev
-  optional: true
-- name: mypy_boto3_sqs
-  version: 1.34.121
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    boto3: ''
-    python: '>=3.6'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_sqs-1.34.121-pyhd8ed1ab_0.conda
-  hash:
-    md5: 00710840131b36739e942763477b7e8b
-    sha256: ae39855bd6b7f80beee28c872ba59f60c8542ec2b074e514219afe970721d626
-  category: dev
-  optional: true
-- name: mypy_extensions
-  version: 1.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-  hash:
-    md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-    sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-  category: dev
-  optional: true
-- name: mypy_extensions
-  version: 1.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-  hash:
-    md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-    sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-  category: dev
-  optional: true
-- name: mypy_extensions
-  version: 1.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-  hash:
-    md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-    sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-  category: dev
-  optional: true
-- name: ncurses
-  version: '6.5'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
-  hash:
-    md5: fcea371545eda051b6deafb24889fc69
-    sha256: 4fc3b384f4072b68853a0013ea83bdfd3d66b0126e2238e1d6e1560747aa7586
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.5'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
-  hash:
-    md5: 02a888433d165c99bf09784a7b14d900
-    sha256: 6ecc73db0e49143092c0934355ac41583a5d5a48c6914c5f6ca48e562d3a4b79
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.5'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
-  hash:
-    md5: b13ad5724ac9ae98b6b4fd87e4500ba4
-    sha256: 87d7cf716d9d930dab682cb57b3b8d3a61940b47d6703f3529a155c938a6990a
-  category: main
-  optional: false
-- name: nest-asyncio
-  version: 1.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6598c056f64dc8800d40add25e4e2c34
-    sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
-  category: dev
-  optional: true
-- name: nest-asyncio
-  version: 1.6.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6598c056f64dc8800d40add25e4e2c34
-    sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
-  category: dev
-  optional: true
-- name: nest-asyncio
-  version: 1.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6598c056f64dc8800d40add25e4e2c34
-    sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
-  category: dev
-  optional: true
-- name: networkx
-  version: '3.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.3-pyhd8ed1ab_1.conda
-  hash:
-    md5: d335fd5704b46f4efb89a6774e81aef0
-    sha256: cbd8a6de87ad842e7665df38dcec719873fe74698bc761de5431047b8fada41a
-  category: main
-  optional: false
-- name: networkx
-  version: '3.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.3-pyhd8ed1ab_1.conda
-  hash:
-    md5: d335fd5704b46f4efb89a6774e81aef0
-    sha256: cbd8a6de87ad842e7665df38dcec719873fe74698bc761de5431047b8fada41a
-  category: main
-  optional: false
-- name: networkx
-  version: '3.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.3-pyhd8ed1ab_1.conda
-  hash:
-    md5: d335fd5704b46f4efb89a6774e81aef0
-    sha256: cbd8a6de87ad842e7665df38dcec719873fe74698bc761de5431047b8fada41a
+    md5: d2dee849c806430eee64d3acc98ce090
+    sha256: 3f4e6a4fa074bb297855f8111ab974dab6d9f98b7d4317d4dd46f8687ee2363b
   category: main
   optional: false
 - name: nodeenv
@@ -12533,12 +12772,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: 2.7|>=3.7
+    python: '>=3.9'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
   hash:
-    md5: dfe0528d0f1c16c1f7c528ea5536ab30
-    sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
+    md5: 7ba3f09fceae6a120d664217e58fe686
+    sha256: 3636eec0e60466a00069b47ce94b6d88b01419b6577d8e393da44bb5bc8d3468
   category: dev
   optional: true
 - name: nodeenv
@@ -12546,12 +12785,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: 2.7|>=3.7
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
   hash:
-    md5: dfe0528d0f1c16c1f7c528ea5536ab30
-    sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
+    md5: 7ba3f09fceae6a120d664217e58fe686
+    sha256: 3636eec0e60466a00069b47ce94b6d88b01419b6577d8e393da44bb5bc8d3468
   category: dev
   optional: true
 - name: nodeenv
@@ -12559,12 +12798,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: 2.7|>=3.7
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
   hash:
-    md5: dfe0528d0f1c16c1f7c528ea5536ab30
-    sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
+    md5: 7ba3f09fceae6a120d664217e58fe686
+    sha256: 3636eec0e60466a00069b47ce94b6d88b01419b6577d8e393da44bb5bc8d3468
   category: dev
   optional: true
 - name: nomkl
@@ -12578,193 +12817,109 @@ package:
     sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
   category: main
   optional: false
-- name: nspr
-  version: '4.35'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
-  hash:
-    md5: da0ec11a6454ae19bff5b02ed881a2b1
-    sha256: 8fadeebb2b7369a4f3b2c039a980d419f65c7b18267ba0c62588f9f894396d0c
-  category: main
-  optional: false
-- name: nspr
-  version: '4.35'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libcxx: '>=14.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
-  hash:
-    md5: a9e56c98d13d8b7ce72bf4357317c29b
-    sha256: da6e19bd0ff31e219760e647cfe1cc499a8cdfaff305f06c56d495ca062b86de
-  category: main
-  optional: false
-- name: nspr
-  version: '4.35'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=14.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
-  hash:
-    md5: f81b5ec944dbbcff3dd08375eb036efa
-    sha256: 35959d36ea9e8a2c422db9f113ee0ac91a9b0c19c51b05f75d0793c3827cfa3a
-  category: main
-  optional: false
-- name: nss
-  version: '3.102'
+- name: numba
+  version: 0.61.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libsqlite: '>=3.46.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.3.1,<2.0a0'
-    nspr: '>=4.35,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.102-h593d115_0.conda
-  hash:
-    md5: 40e5e48c55a45621c4399ca9236406b7
-    sha256: 5e5dbae2f5bc55646a9d70601432ea71b867ce06bccd174e479ac36abf5d0807
-  category: main
-  optional: false
-- name: nss
-  version: '3.102'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=16'
-    libsqlite: '>=3.46.0,<4.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    nspr: '>=4.35,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.102-he7eb89d_0.conda
-  hash:
-    md5: 95e32708bfbae8cd9936c0ad006439a1
-    sha256: 205386081d59f541784594628d542996b0bcfac1fe32d42010221706bcaf88a4
-  category: main
-  optional: false
-- name: nss
-  version: '3.102'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=16'
-    libsqlite: '>=3.46.0,<4.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    nspr: '>=4.35,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.102-hc42bcbf_0.conda
-  hash:
-    md5: 8e6786925188583c0c18920545bb0d72
-    sha256: 15f521cae90a27ff42b5de3f40cf76f574e0e703c51aa4c882a3590eef284edf
-  category: main
-  optional: false
-- name: numba
-  version: 0.60.0
-  manager: conda
-  platform: linux-64
-  dependencies:
     _openmp_mutex: '>=4.5'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    llvmlite: '>=0.43.0,<0.44.0a0'
-    numpy: '>=1.22.3,<2.1'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    llvmlite: '>=0.44.0,<0.45.0a0'
+    numpy: '>=1.24,<2.2'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py312h83e6fd3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numba-0.61.0-py312h2e6246c_0.conda
   hash:
-    md5: e064ca33edf91ac117236c4b5dee207a
-    sha256: af31c1989ddf1cd46f073f32a8150274c606fdc9fced0e4f5aaf0571b97bd09f
+    md5: 619c3dcab3dd5d52ab5df63410896049
+    sha256: 3ed553a41a309d1378dbb57997077428aa494164b72f85b898a9af69b173e7ad
   category: main
   optional: false
 - name: numba
-  version: 0.60.0
+  version: 0.61.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcxx: '>=16'
-    llvm-openmp: '>=18.1.8'
-    llvmlite: '>=0.43.0,<0.44.0a0'
-    numpy: '>=1.22.3,<2.1'
+    libcxx: '>=18'
+    llvm-openmp: '>=19.1.7'
+    llvmlite: '>=0.44.0,<0.45.0a0'
+    numpy: '>=1.24,<2.2'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py312hc3b515d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/numba-0.61.0-py312hfa89a5f_0.conda
   hash:
-    md5: 4138842cc16a0a1994d1a80214c25d7e
-    sha256: 46c21bdad81e0c48edbaeae9b68a4418b566e323f5417922f1a949ac34f17eb4
+    md5: fd05ff7256c53bccfa7b3464342517b2
+    sha256: 82724934e2e68ded589366934dc44008ccbf97daab03d267758f70bdb5797248
   category: main
   optional: false
 - name: numba
-  version: 0.60.0
+  version: 0.61.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
-    llvm-openmp: '>=18.1.7'
-    llvmlite: '>=0.43.0,<0.44.0a0'
-    numpy: '>=1.22.3,<2.1'
+    libcxx: '>=18'
+    llvm-openmp: '>=19.1.7'
+    llvmlite: '>=0.44.0,<0.45.0a0'
+    numpy: '>=1.24,<2.2'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py312h41cea2d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.61.0-py312hdf12f13_0.conda
   hash:
-    md5: deed63e07bfe8494e806baccc9d7fd1b
-    sha256: 2a7597cf215e47f973923ee0403d2b1b37aed4eb611e03628ce31ec08f105037
+    md5: 2facd75eba8ddcda8575d4bd6730ebb4
+    sha256: 251f7902785030804f1aef65abbc92e74a96bbc5c8bffe24ada519756bc7492c
   category: main
   optional: false
 - name: numexpr
-  version: 2.10.0
+  version: 2.10.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
     nomkl: ''
-    numpy: '>=1.19,<3'
+    numpy: '>=1.23.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.0-py312hf412c99_100.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.10.2-py312h6a710ac_100.conda
   hash:
-    md5: 302f3d106749fc6e101a189fbdadd2d5
-    sha256: a138e5e0fc63cd557d3d0f0a8cdcc2d065878f28c49d09fddfcabdef4395cc31
+    md5: 67bf1e95cdc344f82b990ee422792426
+    sha256: c91a397de5acceb1fcdf6c871ee7da953baf7b826e6d9c0dc2324466f0d7bd01
   category: main
   optional: false
 - name: numexpr
-  version: 2.10.0
+  version: 2.10.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcxx: '>=16'
-    numpy: '>=1.19,<3'
+    libcxx: '>=18'
+    numpy: '>=1.23.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/numexpr-2.10.0-py312h1171441_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/numexpr-2.10.2-py312ha51eba0_0.conda
   hash:
-    md5: ee46d8648076ecb1c9b9d758b6981231
-    sha256: 3f054c7f9d19e335aad29e434b7c5dca1ff4fdcbcb3238887bda2789c1b484f2
+    md5: ffe2e5fb72043ed4aeb2877f3e0e61fd
+    sha256: 1c49ffc6477568bd650849a850a8ad739427d0297a1de7f33cf06c58f35ce007
   category: main
   optional: false
 - name: numexpr
-  version: 2.10.0
+  version: 2.10.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
-    numpy: '>=1.19,<3'
+    libcxx: '>=18'
+    numpy: '>=1.23.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.0-py312h8ae5369_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numexpr-2.10.2-py312hbbbb429_0.conda
   hash:
-    md5: 52a038a2c531adb72b8b3056952b5d87
-    sha256: 61901b678d7142bfe5ef66beca70312a1e8e743b7323177e73e41040f4e53eea
+    md5: b02d84bc1dfb80c9651f1625d443737f
+    sha256: f82ad4de3ea4dcd01c1ccd59dd7278710d00f20348be2651ce4efc475dcaac2b
   category: main
   optional: false
 - name: numpy
@@ -12820,48 +12975,48 @@ package:
   category: main
   optional: false
 - name: openapi-schema-validator
-  version: 0.6.2
+  version: 0.6.3
   manager: conda
   platform: linux-64
   dependencies:
     jsonschema: '>=4.19.1,<5.0.0a0'
-    jsonschema-specifications: '>=2023.5.2,<2024.0.0'
-    python: '>=3.8'
+    jsonschema-specifications: '>=2023.5.2'
+    python: '>=3.9'
     rfc3339-validator: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/openapi-schema-validator-0.6.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/openapi-schema-validator-0.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 86794cb397bb1b311da59f9ac232b0c8
-    sha256: 184ab5d662741d549e5bdc3ea75846ed9a5d0ae2072d9b970d92ab0e4fbe6145
+    md5: d99b3bb08a0d8c7116e15469ee0bed86
+    sha256: 586d9cbb78825a5b1bbff76358dddead8595ddb10362397d64c0b9f04fd25356
   category: dev
   optional: true
 - name: openapi-schema-validator
-  version: 0.6.2
+  version: 0.6.3
   manager: conda
   platform: osx-64
   dependencies:
-    jsonschema: '>=4.19.1,<5.0.0a0'
-    jsonschema-specifications: '>=2023.5.2,<2024.0.0'
-    python: '>=3.8'
     rfc3339-validator: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/openapi-schema-validator-0.6.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    jsonschema: '>=4.19.1,<5.0.0a0'
+    jsonschema-specifications: '>=2023.5.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/openapi-schema-validator-0.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 86794cb397bb1b311da59f9ac232b0c8
-    sha256: 184ab5d662741d549e5bdc3ea75846ed9a5d0ae2072d9b970d92ab0e4fbe6145
+    md5: d99b3bb08a0d8c7116e15469ee0bed86
+    sha256: 586d9cbb78825a5b1bbff76358dddead8595ddb10362397d64c0b9f04fd25356
   category: dev
   optional: true
 - name: openapi-schema-validator
-  version: 0.6.2
+  version: 0.6.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    jsonschema: '>=4.19.1,<5.0.0a0'
-    jsonschema-specifications: '>=2023.5.2,<2024.0.0'
-    python: '>=3.8'
     rfc3339-validator: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/openapi-schema-validator-0.6.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    jsonschema: '>=4.19.1,<5.0.0a0'
+    jsonschema-specifications: '>=2023.5.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/openapi-schema-validator-0.6.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 86794cb397bb1b311da59f9ac232b0c8
-    sha256: 184ab5d662741d549e5bdc3ea75846ed9a5d0ae2072d9b970d92ab0e4fbe6145
+    md5: d99b3bb08a0d8c7116e15469ee0bed86
+    sha256: 586d9cbb78825a5b1bbff76358dddead8595ddb10362397d64c0b9f04fd25356
   category: dev
   optional: true
 - name: openapi-spec-validator
@@ -12874,11 +13029,11 @@ package:
     jsonschema-path: '>=0.3.1,<0.4.0'
     lazy-object-proxy: '>=1.7.1,<2.0.0'
     openapi-schema-validator: '>=0.6.0,<0.7.0'
-    python: '>=3.8.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/openapi-spec-validator-0.7.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/openapi-spec-validator-0.7.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 01d3b50ae6ec011c99b043388fc3148d
-    sha256: b3aff38febb575647f1b5ad246dc4a9f221e3f712027a71be6e2554c3fe44220
+    md5: 2028f191c3d68895ae570e1faa0a9c82
+    sha256: f7608a72c4bbfb55e6e4169f922044454581c63506344bcda8f0bac8290e4ffa
   category: dev
   optional: true
 - name: openapi-spec-validator
@@ -12886,16 +13041,16 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    importlib_resources: '>=5.8,<7.0'
+    python: '>=3.9'
     jsonschema: '>=4.18.0,<5.0.0'
-    jsonschema-path: '>=0.3.1,<0.4.0'
     lazy-object-proxy: '>=1.7.1,<2.0.0'
     openapi-schema-validator: '>=0.6.0,<0.7.0'
-    python: '>=3.8.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/openapi-spec-validator-0.7.1-pyhd8ed1ab_0.conda
+    jsonschema-path: '>=0.3.1,<0.4.0'
+    importlib_resources: '>=5.8,<7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/openapi-spec-validator-0.7.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 01d3b50ae6ec011c99b043388fc3148d
-    sha256: b3aff38febb575647f1b5ad246dc4a9f221e3f712027a71be6e2554c3fe44220
+    md5: 2028f191c3d68895ae570e1faa0a9c82
+    sha256: f7608a72c4bbfb55e6e4169f922044454581c63506344bcda8f0bac8290e4ffa
   category: dev
   optional: true
 - name: openapi-spec-validator
@@ -12903,398 +13058,411 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib_resources: '>=5.8,<7.0'
+    python: '>=3.9'
     jsonschema: '>=4.18.0,<5.0.0'
-    jsonschema-path: '>=0.3.1,<0.4.0'
     lazy-object-proxy: '>=1.7.1,<2.0.0'
     openapi-schema-validator: '>=0.6.0,<0.7.0'
-    python: '>=3.8.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/openapi-spec-validator-0.7.1-pyhd8ed1ab_0.conda
+    jsonschema-path: '>=0.3.1,<0.4.0'
+    importlib_resources: '>=5.8,<7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/openapi-spec-validator-0.7.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 01d3b50ae6ec011c99b043388fc3148d
-    sha256: b3aff38febb575647f1b5ad246dc4a9f221e3f712027a71be6e2554c3fe44220
+    md5: 2028f191c3d68895ae570e1faa0a9c82
+    sha256: f7608a72c4bbfb55e6e4169f922044454581c63506344bcda8f0bac8290e4ffa
   category: dev
   optional: true
 - name: openjpeg
-  version: 2.5.2
+  version: 2.5.3
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libpng: '>=1.6.44,<1.7.0a0'
+    libstdcxx: '>=13'
+    libtiff: '>=4.7.0,<4.8.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
   hash:
-    md5: 7f2e286780f072ed750df46dc2631138
-    sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
+    md5: 9e5816bc95d285c115a3ebc2f8563564
+    sha256: 5bee706ea5ba453ed7fd9da7da8380dd88b865c8d30b5aaec14d2b6dd32dbc39
   category: main
   optional: false
 - name: openjpeg
-  version: 2.5.2
+  version: 2.5.3
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=16'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+    __osx: '>=10.13'
+    libcxx: '>=18'
+    libpng: '>=1.6.44,<1.7.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.3-h7fd6d84_0.conda
   hash:
-    md5: 05a14cc9d725dd74995927968d6547e3
-    sha256: dc9c405119b9b54f8ca5984da27ba498bd848ab4f0f580da6f293009ca5adc13
+    md5: 025c711177fc3309228ca1a32374458d
+    sha256: faea03f36c9aa3524c911213b116da41695ff64b952d880551edee2843fe115b
   category: main
   optional: false
 - name: openjpeg
-  version: 2.5.2
+  version: 2.5.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=16'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+    __osx: '>=11.0'
+    libcxx: '>=18'
+    libpng: '>=1.6.44,<1.7.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.3-h8a3d83b_0.conda
   hash:
-    md5: 5029846003f0bc14414b9128a1f7c84b
-    sha256: 472d6eaffc1996e6af35ec8e91c967f472a536a470079bfa56383cc0dbf4d463
+    md5: 4b71d78648dbcf68ce8bf22bb07ff838
+    sha256: 1d59bc72ca7faac06d349c1a280f5cfb8a57ee5896f1e24225a997189d7418c7
   category: main
   optional: false
 - name: openssl
-  version: 3.3.1
+  version: 3.4.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     ca-certificates: ''
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4ab18f5_1.conda
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-h7b32b05_1.conda
   hash:
-    md5: b1e9d076f14e8d776213fd5047b4c3d9
-    sha256: ff3faf8d4c1c9aa4bd3263b596a68fcc6ac910297f354b2ce28718a3509db6d9
+    md5: 4ce6875f75469b2757a65e10a5d05e31
+    sha256: f62f6bca4a33ca5109b6d571b052a394d836956d21b25b7ffd03376abf7a481f
   category: main
   optional: false
 - name: openssl
-  version: 3.3.1
+  version: 3.4.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.4.0-hc426f3f_1.conda
   hash:
-    md5: d838ffe9ec3c6d971f110e04487466ff
-    sha256: 60eed5d771207bcef05e0547c8f93a61d0ad1dcf75e19f8f8d9ded8094d78477
+    md5: eaae23dbfc9ec84775097898526c72ea
+    sha256: 879a960d586cf8a64131ac0c060ef575cfb8aa9f6813093cba92042a86ee867c
   category: main
   optional: false
 - name: openssl
-  version: 3.3.1
+  version: 3.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.1-hfb2fe0b_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
   hash:
-    md5: c665dec48e08311096823956642a501c
-    sha256: 3ab411856c3bef88595473f0dd86e82de4f913f88319548acf262d5b1175b050
+    md5: 22f971393637480bda8c679f374d8861
+    sha256: 97772762abc70b3a537683ca9fc3ff3d6099eb64e4aba3b9c99e6fce48422d21
   category: main
   optional: false
 - name: orc
-  version: 2.0.1
+  version: 2.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.2.0,<1.3.0a0'
+    snappy: '>=1.2.1,<1.3.0a0'
     tzdata: ''
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.1-h17fec99_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.2-he039a57_2.conda
   hash:
-    md5: 3bf65f0d8e7322a1cfe8b670fa35ec81
-    sha256: d340c67b23fb0e1ef7e13574dd4a428f360bfce93b2a588b3b63625926b038d6
+    md5: 5e7bb9779cc5c200e63475eb2538d382
+    sha256: cfc92e5b6be25e5ebee117cd54336ce71a0115c251974c379f4765b35d7466fe
   category: main
   optional: false
 - name: orc
-  version: 2.0.1
+  version: 2.0.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcxx: '>=16'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libcxx: '>=17'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.2.0,<1.3.0a0'
+    snappy: '>=1.2.1,<1.3.0a0'
     tzdata: ''
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.1-hf43e91b_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.2-hb8ce1e1_2.conda
   hash:
-    md5: 15d11d156ad646e69176df6af6ef0826
-    sha256: 718010a056ef084a12bfd6b4d7908c8817a0093ecc395c270857134e002d5857
+    md5: 4943ece8238f5b0385cad55b50544f8a
+    sha256: 3a068269489e5ab1447148be4d63f64a479450cdb107feb69ba21e1542a2afbe
   category: main
   optional: false
 - name: orc
-  version: 2.0.1
+  version: 2.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libcxx: '>=17'
+    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.2.0,<1.3.0a0'
+    snappy: '>=1.2.1,<1.3.0a0'
     tzdata: ''
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.1-h47ade37_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.2-hcb3c8b3_2.conda
   hash:
-    md5: cd1013678ccef9b552335004f20a2d26
-    sha256: 567a9677258cdd03484e3045255bf10a9d8f1031c5030ef83f1fdc1a1ad6f401
+    md5: 3d2c62c12889872216f673c452d23186
+    sha256: 70d5045cbccfb472578b5b9e9e200b7dd122486e5e9a93e9424967f53d838352
   category: main
   optional: false
 - name: packaging
-  version: '24.1'
+  version: '24.2'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
   hash:
-    md5: cbe1bb1f21567018ce595d9c2be0f0db
-    sha256: 36aca948219e2c9fdd6d80728bcc657519e02f06c2703d8db3446aec67f51d81
+    md5: 3bfed7e6228ebf2f7b9eaa47f1b4e2aa
+    sha256: da157b19bcd398b9804c5c52fc000fcb8ab0525bdb9c70f95beaa0bb42f85af1
   category: main
   optional: false
 - name: packaging
-  version: '24.1'
+  version: '24.2'
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
   hash:
-    md5: cbe1bb1f21567018ce595d9c2be0f0db
-    sha256: 36aca948219e2c9fdd6d80728bcc657519e02f06c2703d8db3446aec67f51d81
+    md5: 3bfed7e6228ebf2f7b9eaa47f1b4e2aa
+    sha256: da157b19bcd398b9804c5c52fc000fcb8ab0525bdb9c70f95beaa0bb42f85af1
   category: main
   optional: false
 - name: packaging
-  version: '24.1'
+  version: '24.2'
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
   hash:
-    md5: cbe1bb1f21567018ce595d9c2be0f0db
-    sha256: 36aca948219e2c9fdd6d80728bcc657519e02f06c2703d8db3446aec67f51d81
+    md5: 3bfed7e6228ebf2f7b9eaa47f1b4e2aa
+    sha256: da157b19bcd398b9804c5c52fc000fcb8ab0525bdb9c70f95beaa0bb42f85af1
   category: main
   optional: false
 - name: pandas
-  version: 2.2.2
+  version: 2.2.3
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.19,<3'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    numpy: '>=1.22.4'
     python: '>=3.12,<3.13.0a0'
     python-dateutil: '>=2.8.1'
     python-tzdata: '>=2022a'
     python_abi: 3.12.*
-    pytz: '>=2020.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.2-py312h1d6d2e6_1.conda
+    pytz: '>=2020.1,<2024.2'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py312hf9745cd_1.conda
   hash:
-    md5: ae00b61f3000d2284d1f2584d4dfafa8
-    sha256: 80fd53b68aa89b929d03874b99621ec8cc6a12629bd8bfbdca87a95f8852af96
+    md5: 8bce4f6caaf8c5448c7ac86d87e26b4b
+    sha256: ad275a83bfebfa8a8fee9b0569aaf6f513ada6a246b2f5d5b85903d8ca61887e
   category: main
   optional: false
 - name: pandas
-  version: 2.2.2
+  version: 2.2.3
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcxx: '>=16'
-    numpy: '>=1.19,<3'
+    libcxx: '>=17'
+    numpy: '>=1.22.4'
     python: '>=3.12,<3.13.0a0'
     python-dateutil: '>=2.8.1'
     python-tzdata: '>=2022a'
     python_abi: 3.12.*
-    pytz: '>=2020.1'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.2-py312h1171441_1.conda
+    pytz: '>=2020.1,<2024.2'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py312h98e817e_1.conda
   hash:
-    md5: 240737937f1f046b0e03ecc11ac4ec98
-    sha256: 99ef3986a0c6a5fe31a94b298f3ef60eb7ec7aa683a9aee6682f97d003aeb423
+    md5: a7f7c58bbbfcdf820edb6e544555fe8f
+    sha256: 86c252ce5718b55129303f7d5c9a8664d8f0b23e303579142d09fcfd701e4fbe
   category: main
   optional: false
 - name: pandas
-  version: 2.2.2
+  version: 2.2.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
-    numpy: '>=1.19,<3'
+    libcxx: '>=17'
+    numpy: '>=1.22.4'
     python: '>=3.12,<3.13.0a0'
     python-dateutil: '>=2.8.1'
     python-tzdata: '>=2022a'
     python_abi: 3.12.*
-    pytz: '>=2020.1'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.2-py312h8ae5369_1.conda
+    pytz: '>=2020.1,<2024.2'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py312hcd31e36_1.conda
   hash:
-    md5: b38af0cd7ae3616c90a2511272385941
-    sha256: 664bf370d1e254f29fab3b9834ae5f692a59f7e35c64c61d9a9b9989831fd721
+    md5: c68bfa69e6086c381c74e16fd72613a8
+    sha256: ff0cb54b5d058c7987b4a0984066e893642d1865a7bb695294b6172e2fcdc457
   category: main
   optional: false
 - name: pandas-stubs
-  version: 2.2.2.240603
+  version: 2.2.3.241126
   manager: conda
   platform: linux-64
   dependencies:
     numpy: '>=1.26.0'
-    python: '>=3.9'
+    python: '>=3.10'
     types-pytz: '>=2022.1.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.2.240603-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.3.241126-pyhd8ed1ab_1.conda
   hash:
-    md5: 2ffa854e866926e8e6a76274b9aca854
-    sha256: f22e5bb371fac515c4a53d49fe4d7fcddc71136e5ed3094fde0f37dfc249d244
+    md5: 5566bee0d9903c795cc6d6f5cb6bf4ad
+    sha256: 4061dd7c87a3b28d612d14be51f369cfbf7cf6341c104034f641962c39e76374
   category: dev
   optional: true
 - name: pandas-stubs
-  version: 2.2.2.240603
+  version: 2.2.3.241126
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.10'
     numpy: '>=1.26.0'
-    python: '>=3.9'
     types-pytz: '>=2022.1.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.2.240603-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.3.241126-pyhd8ed1ab_1.conda
   hash:
-    md5: 2ffa854e866926e8e6a76274b9aca854
-    sha256: f22e5bb371fac515c4a53d49fe4d7fcddc71136e5ed3094fde0f37dfc249d244
+    md5: 5566bee0d9903c795cc6d6f5cb6bf4ad
+    sha256: 4061dd7c87a3b28d612d14be51f369cfbf7cf6341c104034f641962c39e76374
   category: dev
   optional: true
 - name: pandas-stubs
-  version: 2.2.2.240603
+  version: 2.2.3.241126
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.10'
     numpy: '>=1.26.0'
-    python: '>=3.9'
     types-pytz: '>=2022.1.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.2.240603-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.3.241126-pyhd8ed1ab_1.conda
   hash:
-    md5: 2ffa854e866926e8e6a76274b9aca854
-    sha256: f22e5bb371fac515c4a53d49fe4d7fcddc71136e5ed3094fde0f37dfc249d244
+    md5: 5566bee0d9903c795cc6d6f5cb6bf4ad
+    sha256: 4061dd7c87a3b28d612d14be51f369cfbf7cf6341c104034f641962c39e76374
   category: dev
   optional: true
 - name: pango
-  version: 1.54.0
+  version: 1.56.1
   manager: conda
   platform: linux-64
   dependencies:
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.2,<2.0a0'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
     fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=8.5.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.2,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h84a9a3c_0.conda
+    harfbuzz: '>=10.2.0,<11.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libgcc: '>=13'
+    libglib: '>=2.82.2,<3.0a0'
+    libpng: '>=1.6.45,<1.7.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.1-h861ebed_0.conda
   hash:
-    md5: 7c51e110b2f059c0843269d3324e4b22
-    sha256: 3d0ef5a908f0429d7821d8a03a6f19ea7801245802c47f7c8c57163ea60e45c7
+    md5: 59e660508a4de9401543303d5f576aeb
+    sha256: 20e5e280859a7803e8b5a09f18a7e43b56d1b8e61e4888c1a24cbb0d5b9cabd3
   category: dev
   optional: true
 - name: pango
-  version: 1.54.0
+  version: 1.56.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
+    cairo: '>=1.18.2,<2.0a0'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
     fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=9.0.0,<10.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pango-1.54.0-h115fe74_1.conda
+    harfbuzz: '>=10.2.0,<11.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libglib: '>=2.82.2,<3.0a0'
+    libpng: '>=1.6.45,<1.7.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pango-1.56.1-hf94f63b_0.conda
   hash:
-    md5: 02bbb71305225106985ec1f28ff9f50b
-    sha256: 7449699b7cb10f89bcfb05b1a65681bd3f73974ccddb3084cbbddb659a027718
+    md5: 3888a31896ccefaa6aa608ff13fd527c
+    sha256: 2f8ec6dff342ef4417b9ab608a33cd1aac9167e778096c3ef0db997087c0e726
   category: dev
   optional: true
 - name: pango
-  version: 1.54.0
+  version: 1.56.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
+    cairo: '>=1.18.2,<2.0a0'
+    fontconfig: '>=2.15.0,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
     fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=9.0.0,<10.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.54.0-h9ee27a3_1.conda
+    harfbuzz: '>=10.2.0,<11.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
+    libglib: '>=2.82.2,<3.0a0'
+    libpng: '>=1.6.45,<1.7.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.56.1-h73f1e88_0.conda
   hash:
-    md5: 362011ec7d84f31f77ba13398c33cf6b
-    sha256: 49b70f3d230381e3b1e6c036569455972130230462e0c53870b5c7135f5de467
+    md5: d90e7fdeb40d3e1739f3d2da0c15edf0
+    sha256: 1f032cd6e70a07071f2839e79a07976b3d66c1c742e5bc5276ac91a4f738babb
   category: dev
   optional: true
 - name: paramiko
-  version: 3.4.0
+  version: 3.5.1
   manager: conda
   platform: linux-64
   dependencies:
     bcrypt: '>=3.2'
     cryptography: '>=3.3'
     pynacl: '>=1.5'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.4.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.5.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a5e792523b028b06d7ce6e65a6cd4a33
-    sha256: 2e66359261954a79b66858c30e69ea6dd4380bf8bd733940527386b25e31dd13
+    md5: 4e6bea7eee94bb9d8a599385215719f9
+    sha256: 1499e558d31536707fdd7d0b569dbe29ae6e3aa8f2fdce9ea6f3df3ce4c1aaf1
   category: dev
   optional: true
 - name: paramiko
-  version: 3.4.0
+  version: 3.5.1
   manager: conda
   platform: osx-64
   dependencies:
-    bcrypt: '>=3.2'
+    python: '>=3.9'
     cryptography: '>=3.3'
+    bcrypt: '>=3.2'
     pynacl: '>=1.5'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.5.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a5e792523b028b06d7ce6e65a6cd4a33
-    sha256: 2e66359261954a79b66858c30e69ea6dd4380bf8bd733940527386b25e31dd13
+    md5: 4e6bea7eee94bb9d8a599385215719f9
+    sha256: 1499e558d31536707fdd7d0b569dbe29ae6e3aa8f2fdce9ea6f3df3ce4c1aaf1
   category: dev
   optional: true
 - name: paramiko
-  version: 3.4.0
+  version: 3.5.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    bcrypt: '>=3.2'
+    python: '>=3.9'
     cryptography: '>=3.3'
+    bcrypt: '>=3.2'
     pynacl: '>=1.5'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.5.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a5e792523b028b06d7ce6e65a6cd4a33
-    sha256: 2e66359261954a79b66858c30e69ea6dd4380bf8bd733940527386b25e31dd13
+    md5: 4e6bea7eee94bb9d8a599385215719f9
+    sha256: 1499e558d31536707fdd7d0b569dbe29ae6e3aa8f2fdce9ea6f3df3ce4c1aaf1
   category: dev
   optional: true
 - name: parso
@@ -13302,11 +13470,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 81534b420deb77da8833f2289b8d47ac
-    sha256: bfe404eebb930cc41782d34f8fc04c0388ea692eeebe2c5fc28df8ec8d4d61ae
+    md5: 5c092057b6badd30f75b06244ecd01c9
+    sha256: 17131120c10401a99205fc6fe436e7903c0fa092f1b3e80452927ab377239bcc
   category: dev
   optional: true
 - name: parso
@@ -13314,11 +13482,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 81534b420deb77da8833f2289b8d47ac
-    sha256: bfe404eebb930cc41782d34f8fc04c0388ea692eeebe2c5fc28df8ec8d4d61ae
+    md5: 5c092057b6badd30f75b06244ecd01c9
+    sha256: 17131120c10401a99205fc6fe436e7903c0fa092f1b3e80452927ab377239bcc
   category: dev
   optional: true
 - name: parso
@@ -13326,11 +13494,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 81534b420deb77da8833f2289b8d47ac
-    sha256: bfe404eebb930cc41782d34f8fc04c0388ea692eeebe2c5fc28df8ec8d4d61ae
+    md5: 5c092057b6badd30f75b06244ecd01c9
+    sha256: 17131120c10401a99205fc6fe436e7903c0fa092f1b3e80452927ab377239bcc
   category: dev
   optional: true
 - name: pastel
@@ -13370,39 +13538,39 @@ package:
   category: main
   optional: false
 - name: pathable
-  version: 0.4.3
+  version: 0.4.4
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathable-0.4.3-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pathable-0.4.4-pyhd8ed1ab_0.conda
   hash:
-    md5: f3e7301de38fd621c902faf8087bc564
-    sha256: 7258b7f6a8e5fcd5e5a22e0a85b89e03e9cf5049d1591bc98420fd080007f25d
+    md5: 7177a7cde05e5b0b3635e13f07b13733
+    sha256: d1ab9496d20fd68e1a853f6a8e0f63c79626e00badf75af8a9a8dcd379302e23
   category: dev
   optional: true
 - name: pathable
-  version: 0.4.3
+  version: 0.4.4
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathable-0.4.3-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pathable-0.4.4-pyhd8ed1ab_0.conda
   hash:
-    md5: f3e7301de38fd621c902faf8087bc564
-    sha256: 7258b7f6a8e5fcd5e5a22e0a85b89e03e9cf5049d1591bc98420fd080007f25d
+    md5: 7177a7cde05e5b0b3635e13f07b13733
+    sha256: d1ab9496d20fd68e1a853f6a8e0f63c79626e00badf75af8a9a8dcd379302e23
   category: dev
   optional: true
 - name: pathable
-  version: 0.4.3
+  version: 0.4.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathable-0.4.3-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pathable-0.4.4-pyhd8ed1ab_0.conda
   hash:
-    md5: f3e7301de38fd621c902faf8087bc564
-    sha256: 7258b7f6a8e5fcd5e5a22e0a85b89e03e9cf5049d1591bc98420fd080007f25d
+    md5: 7177a7cde05e5b0b3635e13f07b13733
+    sha256: d1ab9496d20fd68e1a853f6a8e0f63c79626e00badf75af8a9a8dcd379302e23
   category: dev
   optional: true
 - name: pathspec
@@ -13410,11 +13578,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 17064acba08d3686f1135b5ec1b32b12
-    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
+    md5: 617f15191456cc6a13db418a275435e5
+    sha256: 9f64009cdf5b8e529995f18e03665b03f5d07c0b17445b8badef45bde76249ee
   category: dev
   optional: true
 - name: pathspec
@@ -13422,11 +13590,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 17064acba08d3686f1135b5ec1b32b12
-    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
+    md5: 617f15191456cc6a13db418a275435e5
+    sha256: 9f64009cdf5b8e529995f18e03665b03f5d07c0b17445b8badef45bde76249ee
   category: dev
   optional: true
 - name: pathspec
@@ -13434,646 +13602,468 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 17064acba08d3686f1135b5ec1b32b12
-    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
+    md5: 617f15191456cc6a13db418a275435e5
+    sha256: 9f64009cdf5b8e529995f18e03665b03f5d07c0b17445b8badef45bde76249ee
   category: dev
   optional: true
 - name: pbr
-  version: 6.0.0
+  version: 6.1.1
   manager: conda
   platform: linux-64
   dependencies:
     pip: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pbr-6.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pbr-6.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8dbab5ba746ed14aa32cb232dc437f8f
-    sha256: 4c83853fc6349de163c2871613e064e5fdab91723db9b50bcda681adc05e4b87
+    md5: 80ef57db70bcc25593f8de5fc4fd8b14
+    sha256: 2b8ef8612692a02b9ff556c749c8c0d3958ee364c678422d9f232293a208e6a3
   category: dev
   optional: true
 - name: pbr
-  version: 6.0.0
+  version: 6.1.1
   manager: conda
   platform: osx-64
   dependencies:
     pip: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pbr-6.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pbr-6.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8dbab5ba746ed14aa32cb232dc437f8f
-    sha256: 4c83853fc6349de163c2871613e064e5fdab91723db9b50bcda681adc05e4b87
+    md5: 80ef57db70bcc25593f8de5fc4fd8b14
+    sha256: 2b8ef8612692a02b9ff556c749c8c0d3958ee364c678422d9f232293a208e6a3
   category: dev
   optional: true
 - name: pbr
-  version: 6.0.0
+  version: 6.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
     pip: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pbr-6.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pbr-6.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 8dbab5ba746ed14aa32cb232dc437f8f
-    sha256: 4c83853fc6349de163c2871613e064e5fdab91723db9b50bcda681adc05e4b87
+    md5: 80ef57db70bcc25593f8de5fc4fd8b14
+    sha256: 2b8ef8612692a02b9ff556c749c8c0d3958ee364c678422d9f232293a208e6a3
   category: dev
   optional: true
 - name: pcre2
   version: '10.44'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libgcc-ng: '>=12'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-h0f59acf_0.conda
-  hash:
-    md5: 3914f7ac1761dce57102c72ca7c35d01
-    sha256: 90646ad0d8f9d0fd896170c4f3d754e88c4ba0eaf856c24d00842016f644baab
-  category: main
-  optional: false
-- name: pcre2
-  version: '10.44'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    bzip2: '>=1.0.8,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_0.conda
-  hash:
-    md5: b8f63aec37f31ffddac6dfdc0b31a73e
-    sha256: b397f92ef7d561f817c5336295d6696c72d2576328baceb9dc51bfc772bcb48e
-  category: main
-  optional: false
-- name: pcre2
-  version: '10.44'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_0.conda
-  hash:
-    md5: 62f8d7e2ef03b0aae64185b0f38316eb
-    sha256: 23ddc5022a1025027ac1957dc1947c70d93a78414fbb183026457a537e8b3770
-  category: main
-  optional: false
-- name: pexpect
-  version: 4.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    ptyprocess: '>=0.5'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 629f3203c99b32e0988910c93e77f3b6
-    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
-  category: dev
-  optional: true
-- name: pexpect
-  version: 4.9.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    ptyprocess: '>=0.5'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 629f3203c99b32e0988910c93e77f3b6
-    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
-  category: dev
-  optional: true
-- name: pexpect
-  version: 4.9.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    ptyprocess: '>=0.5'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 629f3203c99b32e0988910c93e77f3b6
-    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
-  category: dev
-  optional: true
-- name: pickleshare
-  version: 0.7.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-  hash:
-    md5: 415f0ebb6198cc2801c73438a9fb5761
-    sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
-  category: dev
-  optional: true
-- name: pickleshare
-  version: 0.7.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-  hash:
-    md5: 415f0ebb6198cc2801c73438a9fb5761
-    sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
-  category: dev
-  optional: true
-- name: pickleshare
-  version: 0.7.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-  hash:
-    md5: 415f0ebb6198cc2801c73438a9fb5761
-    sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
-  category: dev
-  optional: true
-- name: pillow
-  version: 10.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    freetype: '>=2.12.1,<3.0a0'
-    lcms2: '>=2.16,<3.0a0'
-    libgcc-ng: '>=12'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libxcb: '>=1.16,<1.17.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.4.0-py312h287a98d_0.conda
-  hash:
-    md5: 59ea71eed98aee0bebbbdd3b118167c7
-    sha256: f3bca9472702f32bf85196efbf013e9dabe130776e76c7f81062f18682f33a05
-  category: main
-  optional: false
-- name: pillow
-  version: 10.4.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    freetype: '>=2.12.1,<3.0a0'
-    lcms2: '>=2.16,<3.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libxcb: '>=1.16,<1.17.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.4.0-py312hbd70edc_0.conda
-  hash:
-    md5: 8d55e92fa6380ac8c245f253b096fefd
-    sha256: 38b6e8c63c8ebfd9c8552312cecd385ec7bfad6e5733f5c6b6df0db801ea5f43
-  category: main
-  optional: false
-- name: pillow
-  version: 10.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    freetype: '>=2.12.1,<3.0a0'
-    lcms2: '>=2.16,<3.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libxcb: '>=1.16,<1.17.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.4.0-py312h39b1d8d_0.conda
-  hash:
-    md5: 461c9897622e08c614087f9c9b9a22ce
-    sha256: 7c4244fa62cf630375531723631764a276eb06eeb5cc345a8e55a091aec1e52d
-  category: main
-  optional: false
-- name: pip
-  version: '24.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    setuptools: ''
-    wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f586ac1e56c8638b64f9c8122a7b8a67
-    sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
-  category: main
-  optional: false
-- name: pip
-  version: '24.0'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-    setuptools: ''
-    wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f586ac1e56c8638b64f9c8122a7b8a67
-    sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
-  category: main
-  optional: false
-- name: pip
-  version: '24.0'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    setuptools: ''
-    wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f586ac1e56c8638b64f9c8122a7b8a67
-    sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
-  category: main
-  optional: false
-- name: pixman
-  version: 0.43.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
-  hash:
-    md5: 71004cbf7924e19c02746ccde9fd7123
-    sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
-  category: main
-  optional: false
-- name: pixman
-  version: 0.43.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
-  hash:
-    md5: cb134c1e03fd32f4e6bea3f6de2614fd
-    sha256: 3ab44e12e566c67a6e9fd831f557ab195456aa996b8dd9af19787ca80caa5cd1
-  category: main
-  optional: false
-- name: pixman
-  version: 0.43.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
-  hash:
-    md5: 0308c68e711cd295aaa026a4f8c4b1e5
-    sha256: df0ba2710ccdea5c909b63635529797f6eb3635b6fb77ae9cb2f183d08818409
-  category: main
-  optional: false
-- name: pkginfo
-  version: 1.11.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.11.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6a3e4fb1396215d0d88b3cc2f09de412
-    sha256: 8eb347932cd42fffe9370e82a31cfbabc40b2149c2b049cf087d4a78f5b3b53c
-  category: main
-  optional: false
-- name: pkginfo
-  version: 1.11.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.11.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6a3e4fb1396215d0d88b3cc2f09de412
-    sha256: 8eb347932cd42fffe9370e82a31cfbabc40b2149c2b049cf087d4a78f5b3b53c
-  category: main
-  optional: false
-- name: pkginfo
-  version: 1.11.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.11.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6a3e4fb1396215d0d88b3cc2f09de412
-    sha256: 8eb347932cd42fffe9370e82a31cfbabc40b2149c2b049cf087d4a78f5b3b53c
-  category: main
-  optional: false
-- name: pkgutil-resolve-name
-  version: 1.3.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
-  hash:
-    md5: 405678b942f2481cecdb3e010f4925d9
-    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
-  category: dev
-  optional: true
-- name: pkgutil-resolve-name
-  version: 1.3.10
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
-  hash:
-    md5: 405678b942f2481cecdb3e010f4925d9
-    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
-  category: dev
-  optional: true
-- name: pkgutil-resolve-name
-  version: 1.3.10
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
-  hash:
-    md5: 405678b942f2481cecdb3e010f4925d9
-    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
-  category: dev
-  optional: true
-- name: platformdirs
-  version: 4.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6f6cf28bf8e021933869bae3f84b8fc9
-    sha256: adc59384cf0b2fc6dc7362840151e8cb076349197a38f7230278252698a88442
-  category: main
-  optional: false
-- name: platformdirs
-  version: 4.2.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6f6cf28bf8e021933869bae3f84b8fc9
-    sha256: adc59384cf0b2fc6dc7362840151e8cb076349197a38f7230278252698a88442
-  category: main
-  optional: false
-- name: platformdirs
-  version: 4.2.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6f6cf28bf8e021933869bae3f84b8fc9
-    sha256: adc59384cf0b2fc6dc7362840151e8cb076349197a38f7230278252698a88442
-  category: main
-  optional: false
-- name: pluggy
-  version: 1.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
-    sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
-  category: main
-  optional: false
-- name: pluggy
-  version: 1.5.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
-    sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
-  category: main
-  optional: false
-- name: pluggy
-  version: 1.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
-    sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
-  category: main
-  optional: false
-- name: poppler
-  version: 24.07.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    lcms2: '>=2.16,<3.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
     libgcc-ng: '>=12'
-    libglib: '>=2.80.3,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    nspr: '>=4.35,<5.0a0'
-    nss: '>=3.102,<4.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    poppler-data: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.07.0-hb0d391f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
   hash:
-    md5: 561842bc59112340fa1f5f1ed06ae4a2
-    sha256: 20ddd62419f3ddf779dfaae7d12001b0e63e365f781b1137f6db0b428193a3cb
+    md5: df359c09c41cd186fffb93a2d87aa6f5
+    sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
   category: main
   optional: false
-- name: poppler
-  version: 24.07.0
+- name: pcre2
+  version: '10.44'
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    lcms2: '>=2.16,<3.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
-    libglib: '>=2.80.3,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    nspr: '>=4.35,<5.0a0'
-    nss: '>=3.102,<4.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    poppler-data: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.07.0-h744cbf2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_2.conda
   hash:
-    md5: 1603ef5fcf8bffffc3451ca182b6df0a
-    sha256: 012c492087fdcc10a97fab28f3e105ca995bc796f72f0744b1cd050ca35828e5
+    md5: 58cde0663f487778bcd7a0c8daf50293
+    sha256: 336057fce69d45e1059f138beb38d60eb87ba858c3ad729ed49d9ecafd23669f
   category: main
   optional: false
-- name: poppler
-  version: 24.07.0
+- name: pcre2
+  version: '10.44'
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    lcms2: '>=2.16,<3.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
-    libglib: '>=2.80.3,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    nspr: '>=4.35,<5.0a0'
-    nss: '>=3.102,<4.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    poppler-data: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/poppler-24.07.0-h9787579_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
   hash:
-    md5: be71ad375a07cf6e2266c1f388c093a9
-    sha256: 52aaad25569bc5e3ba867ae01be90d01e0701683d16820888cb6a6c45402f6d6
+    md5: 147c83e5e44780c7492998acbacddf52
+    sha256: 83153c7d8fd99cab33c92ce820aa7bfed0f1c94fc57010cf227b6e3c50cb7796
   category: main
   optional: false
-- name: poppler-data
-  version: 0.4.12
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
-  hash:
-    md5: d8d7293c5b37f39b2ac32940621c6592
-    sha256: 2f227e17b3c0346112815faa605502b66c1c4511a856127f2899abf15a98a2cf
-  category: main
-  optional: false
-- name: poppler-data
-  version: 0.4.12
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
-  hash:
-    md5: d8d7293c5b37f39b2ac32940621c6592
-    sha256: 2f227e17b3c0346112815faa605502b66c1c4511a856127f2899abf15a98a2cf
-  category: main
-  optional: false
-- name: poppler-data
-  version: 0.4.12
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
-  hash:
-    md5: d8d7293c5b37f39b2ac32940621c6592
-    sha256: 2f227e17b3c0346112815faa605502b66c1c4511a856127f2899abf15a98a2cf
-  category: main
-  optional: false
-- name: postgresql
-  version: '16.3'
+- name: pexpect
+  version: 4.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libgcc-ng: '>=12'
-    libpq: '16.3'
-    libxml2: '>=2.12.6,<3.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.3.0,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    tzcode: ''
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.3-h8e811e2_0.conda
+    ptyprocess: '>=0.5'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
   hash:
-    md5: e4d52462da124ed3792472f95a36fc2a
-    sha256: 4cd39edd84011657978e35abdc880cf3e49785e8a86f1c99a34029a3e4998abe
+    md5: d0d408b1f18883a944376da5cf8101ea
+    sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
+  category: dev
+  optional: true
+- name: pexpect
+  version: 4.9.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    ptyprocess: '>=0.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: d0d408b1f18883a944376da5cf8101ea
+    sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
+  category: dev
+  optional: true
+- name: pexpect
+  version: 4.9.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    ptyprocess: '>=0.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: d0d408b1f18883a944376da5cf8101ea
+    sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
+  category: dev
+  optional: true
+- name: pickleshare
+  version: 0.7.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+  hash:
+    md5: 11a9d1d09a3615fc07c3faf79bc0b943
+    sha256: e2ac3d66c367dada209fc6da43e645672364b9fd5f9d28b9f016e24b81af475b
+  category: dev
+  optional: true
+- name: pickleshare
+  version: 0.7.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+  hash:
+    md5: 11a9d1d09a3615fc07c3faf79bc0b943
+    sha256: e2ac3d66c367dada209fc6da43e645672364b9fd5f9d28b9f016e24b81af475b
+  category: dev
+  optional: true
+- name: pickleshare
+  version: 0.7.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+  hash:
+    md5: 11a9d1d09a3615fc07c3faf79bc0b943
+    sha256: e2ac3d66c367dada209fc6da43e645672364b9fd5f9d28b9f016e24b81af475b
+  category: dev
+  optional: true
+- name: pillow
+  version: 11.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    freetype: '>=2.12.1,<3.0a0'
+    lcms2: '>=2.16,<3.0a0'
+    libgcc: '>=13'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
+    libxcb: '>=1.17.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openjpeg: '>=2.5.3,<3.0a0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    tk: '>=8.6.13,<8.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.1.0-py312h80c1187_0.conda
+  hash:
+    md5: d3894405f05b2c0f351d5de3ae26fa9c
+    sha256: 5c347962202b55ae4d8a463e0555c5c6ca33396266a08284bf1384399894e541
   category: main
   optional: false
-- name: postgresql
-  version: '16.3'
+- name: pillow
+  version: 11.1.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    krb5: '>=1.21.2,<1.22.0a0'
-    libpq: '16.3'
-    libxml2: '>=2.12.6,<3.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.3.0,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    tzcode: ''
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.3-h1d90168_0.conda
+    freetype: '>=2.12.1,<3.0a0'
+    lcms2: '>=2.16,<3.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
+    libxcb: '>=1.17.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openjpeg: '>=2.5.3,<3.0a0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    tk: '>=8.6.13,<8.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.1.0-py312hd9f36e3_0.conda
   hash:
-    md5: a7ccb9b98d8e3ef61c0ca6d470e8e66d
-    sha256: 69a0887d23f51bc7e35097bf03f88d2ff14e88cc578c3f8296a178c8378950ec
+    md5: 3b4657a78aaca3af9b392b0657eb3e94
+    sha256: 3f6794fae455f2a1854cef4a3f3bb0bc9bfb68412dc64caf22cb797a455ef73b
   category: main
   optional: false
-- name: postgresql
-  version: '16.3'
+- name: pillow
+  version: 11.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    krb5: '>=1.21.2,<1.22.0a0'
-    libpq: '16.3'
-    libxml2: '>=2.12.6,<3.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.3.0,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    tzcode: ''
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/postgresql-16.3-hdfa2ec6_0.conda
+    freetype: '>=2.12.1,<3.0a0'
+    lcms2: '>=2.16,<3.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
+    libxcb: '>=1.17.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openjpeg: '>=2.5.3,<3.0a0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    tk: '>=8.6.13,<8.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.1.0-py312h50aef2c_0.conda
   hash:
-    md5: caaf4b5ea6b6abebcbf6ac18522b5875
-    sha256: 50bb32b3c8f827a07b29cec09df578fa4f4f7b41770ca6686cccdb5e3bf91431
+    md5: 94d6ba8cd468668a9fb04193b0f4b36e
+    sha256: b29b7c915053e06a7a5b4118760202c572c9c35d23bd6ce8e73270b6a50e50ee
+  category: main
+  optional: false
+- name: pip
+  version: '25.0'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9,<3.13.0a0'
+    setuptools: ''
+    wheel: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-25.0-pyh8b19718_0.conda
+  hash:
+    md5: c2548760a02ed818f92dd0d8c81b55b4
+    sha256: 094fa4c825f8b9e8403e0c0b569c3d50892325acdac1010ff43cc3ac65bf62cd
+  category: main
+  optional: false
+- name: pip
+  version: '25.0'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    setuptools: ''
+    wheel: ''
+    python: '>=3.9,<3.13.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-25.0-pyh8b19718_0.conda
+  hash:
+    md5: c2548760a02ed818f92dd0d8c81b55b4
+    sha256: 094fa4c825f8b9e8403e0c0b569c3d50892325acdac1010ff43cc3ac65bf62cd
+  category: main
+  optional: false
+- name: pip
+  version: '25.0'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    setuptools: ''
+    wheel: ''
+    python: '>=3.9,<3.13.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-25.0-pyh8b19718_0.conda
+  hash:
+    md5: c2548760a02ed818f92dd0d8c81b55b4
+    sha256: 094fa4c825f8b9e8403e0c0b569c3d50892325acdac1010ff43cc3ac65bf62cd
+  category: main
+  optional: false
+- name: pixman
+  version: 0.44.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.44.2-h29eaf8c_0.conda
+  hash:
+    md5: 5e2a7acfa2c24188af39e7944e1b3604
+    sha256: 747c58db800d5583fee78e76240bf89cbaeedf7ab1ef339c2990602332b9c4be
+  category: dev
+  optional: true
+- name: pixman
+  version: 0.44.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.44.2-h1fd1274_0.conda
+  hash:
+    md5: 9d3ed4c1a6e21051bf4ce53851acdc96
+    sha256: 7e5a9823e7e759355b954037f97d4aa53c26db1d73408571e749f8375b363743
+  category: dev
+  optional: true
+- name: pixman
+  version: 0.44.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.44.2-h2f9eb0b_0.conda
+  hash:
+    md5: fa8e429fdb9e5b757281f69b8cc4330b
+    sha256: 28855d4cb2d9fc9a6bd9196dadbaecd6868ec706394cec2f88824a61ba4b1bc0
+  category: dev
+  optional: true
+- name: pkginfo
+  version: 1.12.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: b52da1d59d874c97dcca251757a368b3
+    sha256: 588999bbbfd7f68dbfd1836866be888a18fedd348b679b4c410ffe7634378bee
+  category: main
+  optional: false
+- name: pkginfo
+  version: 1.12.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: b52da1d59d874c97dcca251757a368b3
+    sha256: 588999bbbfd7f68dbfd1836866be888a18fedd348b679b4c410ffe7634378bee
+  category: main
+  optional: false
+- name: pkginfo
+  version: 1.12.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: b52da1d59d874c97dcca251757a368b3
+    sha256: 588999bbbfd7f68dbfd1836866be888a18fedd348b679b4c410ffe7634378bee
+  category: main
+  optional: false
+- name: pkgutil-resolve-name
+  version: 1.3.10
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+  hash:
+    md5: 5a5870a74432aa332f7d32180633ad05
+    sha256: adb2dde5b4f7da70ae81309cce6188ed3286ff280355cf1931b45d91164d2ad8
+  category: dev
+  optional: true
+- name: pkgutil-resolve-name
+  version: 1.3.10
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+  hash:
+    md5: 5a5870a74432aa332f7d32180633ad05
+    sha256: adb2dde5b4f7da70ae81309cce6188ed3286ff280355cf1931b45d91164d2ad8
+  category: dev
+  optional: true
+- name: pkgutil-resolve-name
+  version: 1.3.10
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
+  hash:
+    md5: 5a5870a74432aa332f7d32180633ad05
+    sha256: adb2dde5b4f7da70ae81309cce6188ed3286ff280355cf1931b45d91164d2ad8
+  category: dev
+  optional: true
+- name: platformdirs
+  version: 4.3.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+  hash:
+    md5: 577852c7e53901ddccc7e6a9959ddebe
+    sha256: bb50f6499e8bc1d1a26f17716c97984671121608dc0c3ecd34858112bce59a27
+  category: main
+  optional: false
+- name: platformdirs
+  version: 4.3.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+  hash:
+    md5: 577852c7e53901ddccc7e6a9959ddebe
+    sha256: bb50f6499e8bc1d1a26f17716c97984671121608dc0c3ecd34858112bce59a27
+  category: main
+  optional: false
+- name: platformdirs
+  version: 4.3.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+  hash:
+    md5: 577852c7e53901ddccc7e6a9959ddebe
+    sha256: bb50f6499e8bc1d1a26f17716c97984671121608dc0c3ecd34858112bce59a27
+  category: main
+  optional: false
+- name: pluggy
+  version: 1.5.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: e9dcbce5f45f9ee500e728ae58b605b6
+    sha256: 122433fc5318816b8c69283aaf267c73d87aa2d09ce39f64c9805c9a3b264819
+  category: main
+  optional: false
+- name: pluggy
+  version: 1.5.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: e9dcbce5f45f9ee500e728ae58b605b6
+    sha256: 122433fc5318816b8c69283aaf267c73d87aa2d09ce39f64c9805c9a3b264819
+  category: main
+  optional: false
+- name: pluggy
+  version: 1.5.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: e9dcbce5f45f9ee500e728ae58b605b6
+    sha256: 122433fc5318816b8c69283aaf267c73d87aa2d09ce39f64c9805c9a3b264819
   category: main
   optional: false
 - name: pre-commit
-  version: 3.7.1
+  version: 3.8.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -14083,176 +14073,221 @@ package:
     python: '>=3.9'
     pyyaml: '>=5.1'
     virtualenv: '>=20.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_1.conda
   hash:
-    md5: 724bc4489c1174fc8e3233b0624fa51f
-    sha256: 689c169ce6ed5d516d8524cc1e6ef2687dff19747c1ed1ee9b347a71f47ff12d
+    md5: 004cff3a7f6fafb0a041fb575de85185
+    sha256: c2b964c86b2cd00e494093d751b1f8697b3c4bf924ff70648387af161444cc82
   category: dev
   optional: true
 - name: pre-commit
-  version: 3.7.1
+  version: 3.8.0
   manager: conda
   platform: osx-64
   dependencies:
-    cfgv: '>=2.0.0'
-    identify: '>=1.0.0'
-    nodeenv: '>=0.11.1'
     python: '>=3.9'
     pyyaml: '>=5.1'
+    identify: '>=1.0.0'
+    nodeenv: '>=0.11.1'
+    cfgv: '>=2.0.0'
     virtualenv: '>=20.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_1.conda
   hash:
-    md5: 724bc4489c1174fc8e3233b0624fa51f
-    sha256: 689c169ce6ed5d516d8524cc1e6ef2687dff19747c1ed1ee9b347a71f47ff12d
+    md5: 004cff3a7f6fafb0a041fb575de85185
+    sha256: c2b964c86b2cd00e494093d751b1f8697b3c4bf924ff70648387af161444cc82
   category: dev
   optional: true
 - name: pre-commit
-  version: 3.7.1
+  version: 3.8.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    cfgv: '>=2.0.0'
-    identify: '>=1.0.0'
-    nodeenv: '>=0.11.1'
     python: '>=3.9'
     pyyaml: '>=5.1'
+    identify: '>=1.0.0'
+    nodeenv: '>=0.11.1'
+    cfgv: '>=2.0.0'
     virtualenv: '>=20.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_1.conda
   hash:
-    md5: 724bc4489c1174fc8e3233b0624fa51f
-    sha256: 689c169ce6ed5d516d8524cc1e6ef2687dff19747c1ed1ee9b347a71f47ff12d
+    md5: 004cff3a7f6fafb0a041fb575de85185
+    sha256: c2b964c86b2cd00e494093d751b1f8697b3c4bf924ff70648387af161444cc82
   category: dev
   optional: true
 - name: proj
-  version: 9.4.1
+  version: 9.5.1
   manager: conda
   platform: linux-64
   dependencies:
-    libcurl: '>=8.8.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libsqlite: '>=3.46.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    __glibc: '>=2.17,<3.0.a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libgcc: '>=13'
+    libsqlite: '>=3.47.0,<4.0a0'
+    libstdcxx: '>=13'
+    libtiff: '>=4.7.0,<4.8.0a0'
     sqlite: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/proj-9.4.1-hb784bbd_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.1-h0054346_0.conda
   hash:
-    md5: c38c5246d064ef16eba065d93c46f1c6
-    sha256: ec9d16725925c62a7974faa396ca61878cb4cc7398c6c0e76d3ae28cffafc7db
+    md5: 398cabfd9bd75e90d0901db95224f25f
+    sha256: 835afb9c8198895ec1ce2916320503d47bb0c25b75c228d744c44e505f1f4e3b
   category: main
   optional: false
 - name: proj
-  version: 9.4.1
+  version: 9.5.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
-    libsqlite: '>=3.46.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=18'
+    libsqlite: '>=3.47.0,<4.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
     sqlite: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/proj-9.4.1-hf92c781_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/proj-9.5.1-h5273da6_0.conda
   hash:
-    md5: b128ccdae180135720ab963c68bc2f1a
-    sha256: c047c55cb2e239d35d7f28fc50225d5798be37af1e84d9036966447c82b373f5
+    md5: 523c87f13b2f99a96295993ede863b87
+    sha256: 5d35d13994abdc6a7dd1801f37db98e9efca5983f0479e380844264343ec8096
   category: main
   optional: false
 - name: proj
-  version: 9.4.1
+  version: 9.5.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
-    libsqlite: '>=3.46.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=18'
+    libsqlite: '>=3.47.0,<4.0a0'
+    libtiff: '>=4.7.0,<4.8.0a0'
     sqlite: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.4.1-hfb94cee_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.5.1-h1318a7e_0.conda
   hash:
-    md5: 090b6e9b16cf8d539c689c04e237a252
-    sha256: b50cf5ce599ec37b64b5508df1ccd9ad291656d432aa4b6aea887217e9b55690
+    md5: 5eb42e77ae79b46fabcb0f6f6d130763
+    sha256: c6289d6f1a13f28ff3754ac0cb2553f7e7bc4a3102291115f62a04995d0421eb
   category: main
   optional: false
 - name: prompt-toolkit
-  version: 3.0.47
+  version: 3.0.50
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.50-pyha770c72_0.conda
   hash:
-    md5: 1247c861065d227781231950e14fe817
-    sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
+    md5: 7d823138f550b14ecae927a5ff3286de
+    sha256: 0749c49a349bf55b8539ce5addce559b77592165da622944a51c630e94d97889
   category: dev
   optional: true
 - name: prompt-toolkit
-  version: 3.0.47
+  version: 3.0.50
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.50-pyha770c72_0.conda
   hash:
-    md5: 1247c861065d227781231950e14fe817
-    sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
+    md5: 7d823138f550b14ecae927a5ff3286de
+    sha256: 0749c49a349bf55b8539ce5addce559b77592165da622944a51c630e94d97889
   category: dev
   optional: true
 - name: prompt-toolkit
-  version: 3.0.47
+  version: 3.0.50
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.50-pyha770c72_0.conda
   hash:
-    md5: 1247c861065d227781231950e14fe817
-    sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
+    md5: 7d823138f550b14ecae927a5ff3286de
+    sha256: 0749c49a349bf55b8539ce5addce559b77592165da622944a51c630e94d97889
   category: dev
   optional: true
-- name: psutil
-  version: 6.0.0
+- name: propcache
+  version: 0.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.0.0-py312h9a8786e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.2.1-py312h178313f_1.conda
   hash:
-    md5: 1aeffa86c55972ca4e88ac843eccedf2
-    sha256: d629363515df957507411fd24db2a0635ac893e5d60b2ee2f656b53be9c70b1d
+    md5: 349635694b4df27336bc15a49e9220e9
+    sha256: 6d5ff6490c53e14591b70924711fe7bd70eb7fbeeeb1cbd9ed2f6d794ec8c4eb
   category: main
   optional: false
-- name: psutil
-  version: 6.0.0
+- name: propcache
+  version: 0.2.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.0.0-py312hbd25219_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/propcache-0.2.1-py312h3520af0_1.conda
   hash:
-    md5: db086d71e9be086313110a670b6d549f
-    sha256: 06e949079497cf8e1c9e253b77be709ec0c11816656814e1ad857ac5cbbea65b
+    md5: e712bcabf1db361f1350b638be66caca
+    sha256: 04cd2c807af8ae2921e54c372620bb6d3391a7ad59c0aa566e4d21be0e558ae1
   category: main
   optional: false
-- name: psutil
-  version: 6.0.0
+- name: propcache
+  version: 0.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.0.0-py312h7e5086c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.2.1-py312h998013c_1.conda
   hash:
-    md5: e45a140733a4805d80e282c1ede40d0b
-    sha256: d677457b2ce2e6ef6c2845c653e5bc39be9a59a900d95a5a7771b490f754cb5f
+    md5: 83678928c58c9ae76778a435b6c7a94a
+    sha256: 96145760baad111d7ae4213ea8f8cc035cf33b001f5ff37d92268e4d28b0941d
+  category: main
+  optional: false
+- name: psutil
+  version: 6.1.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.1.1-py312h66e93f0_0.conda
+  hash:
+    md5: add2c79595fa8a9b6d653d7e4e2cf05f
+    sha256: 55d4fd0b294aeada0d7810fcc25503b59ec34c4390630789bd61c085b9ce649f
+  category: main
+  optional: false
+- name: psutil
+  version: 6.1.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.1.1-py312h01d7ebd_0.conda
+  hash:
+    md5: 554ee1932283c80030e022fbae81b4e8
+    sha256: f49736cb5d36d7c21911d76114faab1afafe265702a016455014d8b74a788ec1
+  category: main
+  optional: false
+- name: psutil
+  version: 6.1.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.1.1-py312hea69d52_0.conda
+  hash:
+    md5: 90724dac996a4e9d629a88a4b1ffe694
+    sha256: 90332053dad4056fe752217fa311ffa61cb37dc693b1721e37580e71a2a6fe04
   category: main
   optional: false
 - name: pthread-stubs
@@ -14260,33 +14295,36 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   hash:
-    md5: 22dad4df6e8630e8dff2428f6f6a7036
-    sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+    md5: b3c17d95b5a10c6e64a21fa17573e70e
+    sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   category: main
   optional: false
 - name: pthread-stubs
   version: '0.4'
   manager: conda
   platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
   hash:
-    md5: addd19059de62181cd11ae8f4ef26084
-    sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
+    md5: 8bcf980d2c6b17094961198284b8e862
+    sha256: 05944ca3445f31614f8c674c560bca02ff05cb51637a96f665cb2bbe496099e5
   category: main
   optional: false
 - name: pthread-stubs
   version: '0.4'
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
   hash:
-    md5: d3f26c6494d4105d4ecb85203d687102
-    sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
+    md5: 415816daf82e0b23a736a069a75e9da7
+    sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
   category: main
   optional: false
 - name: ptyprocess
@@ -14294,11 +14332,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 359eeb6536da0e687af562ed265ec263
-    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+    md5: 7d9daffbb8d8e0af0f769dbbcd173a54
+    sha256: a7713dfe30faf17508ec359e0bc7e0983f5d94682492469bd462cdaae9c64d83
   category: dev
   optional: true
 - name: ptyprocess
@@ -14306,11 +14344,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 359eeb6536da0e687af562ed265ec263
-    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+    md5: 7d9daffbb8d8e0af0f769dbbcd173a54
+    sha256: a7713dfe30faf17508ec359e0bc7e0983f5d94682492469bd462cdaae9c64d83
   category: dev
   optional: true
 - name: ptyprocess
@@ -14318,47 +14356,47 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 359eeb6536da0e687af562ed265ec263
-    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+    md5: 7d9daffbb8d8e0af0f769dbbcd173a54
+    sha256: a7713dfe30faf17508ec359e0bc7e0983f5d94682492469bd462cdaae9c64d83
   category: dev
   optional: true
 - name: pure_eval
-  version: 0.2.2
+  version: 0.2.3
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 6784285c7e55cb7212efabc79e4c2883
-    sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+    md5: 3bfdfb8dbcdc4af1ae3f9a8eb3948f04
+    sha256: 71bd24600d14bb171a6321d523486f6a06f855e75e547fa0cb2a0953b02047f0
   category: dev
   optional: true
 - name: pure_eval
-  version: 0.2.2
+  version: 0.2.3
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 6784285c7e55cb7212efabc79e4c2883
-    sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+    md5: 3bfdfb8dbcdc4af1ae3f9a8eb3948f04
+    sha256: 71bd24600d14bb171a6321d523486f6a06f855e75e547fa0cb2a0953b02047f0
   category: dev
   optional: true
 - name: pure_eval
-  version: 0.2.2
+  version: 0.2.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 6784285c7e55cb7212efabc79e4c2883
-    sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+    md5: 3bfdfb8dbcdc4af1ae3f9a8eb3948f04
+    sha256: 71bd24600d14bb171a6321d523486f6a06f855e75e547fa0cb2a0953b02047f0
   category: dev
   optional: true
 - name: pyarrow
@@ -14374,18 +14412,18 @@ package:
     libarrow-flight-sql: 14.0.2
     libarrow-gandiva: 14.0.2
     libarrow-substrait: 14.0.2
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     libparquet: 14.0.2
-    libstdcxx-ng: '>=12'
+    libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
     numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.2-py312h4bdc4f7_30_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.2-py312h259ed4e_52_cpu.conda
   hash:
-    md5: 43a2a5822ab76f62b4d22e7e207b9972
-    sha256: c23e3f08e2f83898c93eaf284357ff6c25ab98aeefc8272bc51ab04b43e876d5
+    md5: b12befeffdaa069676e2fd94d10105a2
+    sha256: e769886476363ee9533e0b9fe49e77b933058bf08006131a3bb59d12e87a80c7
   category: main
   optional: false
 - name: pyarrow
@@ -14401,17 +14439,17 @@ package:
     libarrow-flight-sql: 14.0.2
     libarrow-gandiva: 14.0.2
     libarrow-substrait: 14.0.2
-    libcxx: '>=14'
+    libcxx: '>=17'
     libparquet: 14.0.2
     libzlib: '>=1.3.1,<2.0a0'
     numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.2-py312h2822cde_30_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.2-py312h91a4995_52_cpu.conda
   hash:
-    md5: de07ad780338d1fcb5aa53b19590b2ce
-    sha256: 2db63120bfaf5c93853f3c7b4d724e6ef74fe431583948a1977133d340ec2182
+    md5: afb29320cd7556b6302e6050b356ee1e
+    sha256: 7b4c46f797568a707ec8ea1b9f61f3ae32a878103d9db445f6448c9283e3a32f
   category: main
   optional: false
 - name: pyarrow
@@ -14427,53 +14465,53 @@ package:
     libarrow-flight-sql: 14.0.2
     libarrow-gandiva: 14.0.2
     libarrow-substrait: 14.0.2
-    libcxx: '>=14'
+    libcxx: '>=17'
     libparquet: 14.0.2
     libzlib: '>=1.3.1,<2.0a0'
     numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.2-py312hd940a8a_30_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.2-py312h6acbf39_52_cpu.conda
   hash:
-    md5: f55eac1d3f0f6cbdb6ee7796691c735d
-    sha256: cacb48980d5cc165f4a9c0906e33299daa55e44d39c0f9b31443c2506e5b7da4
+    md5: fe61482d72c9bbe0785236d51a60d4b9
+    sha256: e421fd42755a1168e55c341996d8f700d79c43db2f360f622a0564d9bd6f236b
   category: main
   optional: false
 - name: pyasn1
-  version: 0.6.0
+  version: 0.6.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda
   hash:
-    md5: d528d00a110a974e75aa6db6a4f04dc7
-    sha256: 9b54bf52c76bb7365ceb36315258011b8c603fe00f568d4bbff8bc77c7ffcfdb
+    md5: 09bb17ed307ad6ab2fd78d32372fdd4e
+    sha256: d06051df66e9ab753683d7423fcef873d78bb0c33bd112c3d5be66d529eddf06
   category: dev
   optional: true
 - name: pyasn1
-  version: 0.6.0
+  version: 0.6.1
   manager: conda
   platform: osx-64
   dependencies:
-    python: '!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda
   hash:
-    md5: d528d00a110a974e75aa6db6a4f04dc7
-    sha256: 9b54bf52c76bb7365ceb36315258011b8c603fe00f568d4bbff8bc77c7ffcfdb
+    md5: 09bb17ed307ad6ab2fd78d32372fdd4e
+    sha256: d06051df66e9ab753683d7423fcef873d78bb0c33bd112c3d5be66d529eddf06
   category: dev
   optional: true
 - name: pyasn1
-  version: 0.6.0
+  version: 0.6.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda
   hash:
-    md5: d528d00a110a974e75aa6db6a4f04dc7
-    sha256: 9b54bf52c76bb7365ceb36315258011b8c603fe00f568d4bbff8bc77c7ffcfdb
+    md5: 09bb17ed307ad6ab2fd78d32372fdd4e
+    sha256: d06051df66e9ab753683d7423fcef873d78bb0c33bd112c3d5be66d529eddf06
   category: dev
   optional: true
 - name: pybind11-abi
@@ -14510,180 +14548,186 @@ package:
   category: main
   optional: false
 - name: pycodestyle
-  version: 2.12.0
+  version: 2.12.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.12.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.12.1-pyhd8ed1ab_1.conda
   hash:
-    md5: b9cc97b824a995fb231c377f61881bf8
-    sha256: 72dab6a6e9e59d0cfb24f540c2095e844a621d397832f9f38599704a74b65ae9
+    md5: e895db5e6cee923018cbb1656c8ca7fa
+    sha256: 8671d9dcbf458adb6435616ded0fd71925f0fa1b074528604db2f64fac54bf52
   category: dev
   optional: true
 - name: pycodestyle
-  version: 2.12.0
+  version: 2.12.1
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.12.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.12.1-pyhd8ed1ab_1.conda
   hash:
-    md5: b9cc97b824a995fb231c377f61881bf8
-    sha256: 72dab6a6e9e59d0cfb24f540c2095e844a621d397832f9f38599704a74b65ae9
+    md5: e895db5e6cee923018cbb1656c8ca7fa
+    sha256: 8671d9dcbf458adb6435616ded0fd71925f0fa1b074528604db2f64fac54bf52
   category: dev
   optional: true
 - name: pycodestyle
-  version: 2.12.0
+  version: 2.12.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.12.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.12.1-pyhd8ed1ab_1.conda
   hash:
-    md5: b9cc97b824a995fb231c377f61881bf8
-    sha256: 72dab6a6e9e59d0cfb24f540c2095e844a621d397832f9f38599704a74b65ae9
+    md5: e895db5e6cee923018cbb1656c8ca7fa
+    sha256: 8671d9dcbf458adb6435616ded0fd71925f0fa1b074528604db2f64fac54bf52
   category: dev
   optional: true
 - name: pycosat
   version: 0.6.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pycosat-0.6.6-py312h98912ed_0.conda
-  hash:
-    md5: 8f1c372e7b843167be885dc8229931c1
-    sha256: b973d39eb9fd9625fe97e2fbb4b6f758ea47aa288f5f8c7769e3f36a3acbb5da
-  category: main
-  optional: false
-- name: pycosat
-  version: 0.6.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py312h104f124_0.conda
-  hash:
-    md5: 106c2d37708757f4c23ff1f487bf5a3f
-    sha256: b37afbc13d4216dde3a613ded3a1688adae3d74ab98ea55cc6914b39d2417d55
-  category: main
-  optional: false
-- name: pycosat
-  version: 0.6.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pycosat-0.6.6-py312h02f2b3b_0.conda
-  hash:
-    md5: 4d07092345b6e66e580ce3cd9141c6da
-    sha256: 79622e905c3185fe96c57bf6c57b20c545e86b3a6e7da88f24dc50d03ddbe3a6
-  category: main
-  optional: false
-- name: pycparser
-  version: '2.22'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
-  hash:
-    md5: 844d9eb3b43095b031874477f7d70088
-    sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
-  category: main
-  optional: false
-- name: pycparser
-  version: '2.22'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
-  hash:
-    md5: 844d9eb3b43095b031874477f7d70088
-    sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
-  category: main
-  optional: false
-- name: pycparser
-  version: '2.22'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
-  hash:
-    md5: 844d9eb3b43095b031874477f7d70088
-    sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
-  category: main
-  optional: false
-- name: pydantic
-  version: 2.8.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    annotated-types: '>=0.4.0'
-    pydantic-core: 2.20.1
-    python: '>=3.7'
-    typing-extensions: '>=4.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.8.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 539a038a24a959662df1fcaa2cfc5c3e
-    sha256: 5a877153f7eaaab9724db5b64366a35e346007c9c104c1d6a6042f83b2f4f0df
-  category: main
-  optional: false
-- name: pydantic
-  version: 2.8.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    annotated-types: '>=0.4.0'
-    pydantic-core: 2.20.1
-    python: '>=3.7'
-    typing-extensions: '>=4.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.8.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 539a038a24a959662df1fcaa2cfc5c3e
-    sha256: 5a877153f7eaaab9724db5b64366a35e346007c9c104c1d6a6042f83b2f4f0df
-  category: main
-  optional: false
-- name: pydantic
-  version: 2.8.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    annotated-types: '>=0.4.0'
-    pydantic-core: 2.20.1
-    python: '>=3.7'
-    typing-extensions: '>=4.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.8.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 539a038a24a959662df1fcaa2cfc5c3e
-    sha256: 5a877153f7eaaab9724db5b64366a35e346007c9c104c1d6a6042f83b2f4f0df
-  category: main
-  optional: false
-- name: pydantic-core
-  version: 2.20.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-    typing-extensions: '>=4.6.0,!=4.7.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.20.1-py312hf008fa9_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pycosat-0.6.6-py312h66e93f0_2.conda
   hash:
-    md5: 8cc8f335b7e355558854236d86b2bea4
-    sha256: adf117d3289c8dd97ffdb3076bc488217fedd02f3d96d35cc971f4de33460602
+    md5: 08223e6a73e0bca5ade16ec4cebebf23
+    sha256: dad83b55d1511a853ecf1d5bff3027055337262aa63084986ee2e329ee26d71b
+  category: main
+  optional: false
+- name: pycosat
+  version: 0.6.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/pycosat-0.6.6-py312h01d7ebd_2.conda
+  hash:
+    md5: 9addc104aa4afd0b21a086cfdca253d5
+    sha256: fabcf7191cd808ddc7ae78c7379eb7557c913e460227ae498121d022ea55e553
+  category: main
+  optional: false
+- name: pycosat
+  version: 0.6.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pycosat-0.6.6-py312hea69d52_2.conda
+  hash:
+    md5: b62d16d1aabb9349c8e81d842dfb2268
+    sha256: ad64eadac6b0a9534cbba1088df9de84c95f7f69c700a5a9cb8b20dfc175e6aa
+  category: main
+  optional: false
+- name: pycparser
+  version: '2.22'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+  hash:
+    md5: 12c566707c80111f9799308d9e265aef
+    sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
+  category: main
+  optional: false
+- name: pycparser
+  version: '2.22'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+  hash:
+    md5: 12c566707c80111f9799308d9e265aef
+    sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
+  category: main
+  optional: false
+- name: pycparser
+  version: '2.22'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+  hash:
+    md5: 12c566707c80111f9799308d9e265aef
+    sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
+  category: main
+  optional: false
+- name: pydantic
+  version: 2.10.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    annotated-types: '>=0.6.0'
+    pydantic-core: 2.27.2
+    python: '>=3.9'
+    typing-extensions: '>=4.6.1'
+    typing_extensions: '>=4.12.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.10.6-pyh3cfb1c2_0.conda
+  hash:
+    md5: c69f87041cf24dfc8cb6bf64ca7133c7
+    sha256: 9a78801a28959edeb945e8270a4e666577b52fac0cf4e35f88cf122f73d83e75
+  category: main
+  optional: false
+- name: pydantic
+  version: 2.10.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    typing_extensions: '>=4.12.2'
+    typing-extensions: '>=4.6.1'
+    annotated-types: '>=0.6.0'
+    pydantic-core: 2.27.2
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.10.6-pyh3cfb1c2_0.conda
+  hash:
+    md5: c69f87041cf24dfc8cb6bf64ca7133c7
+    sha256: 9a78801a28959edeb945e8270a4e666577b52fac0cf4e35f88cf122f73d83e75
+  category: main
+  optional: false
+- name: pydantic
+  version: 2.10.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    typing_extensions: '>=4.12.2'
+    typing-extensions: '>=4.6.1'
+    annotated-types: '>=0.6.0'
+    pydantic-core: 2.27.2
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.10.6-pyh3cfb1c2_0.conda
+  hash:
+    md5: c69f87041cf24dfc8cb6bf64ca7133c7
+    sha256: 9a78801a28959edeb945e8270a4e666577b52fac0cf4e35f88cf122f73d83e75
   category: main
   optional: false
 - name: pydantic-core
-  version: 2.20.1
+  version: 2.27.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    typing-extensions: '>=4.6.0,!=4.7.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.27.2-py312h12e396e_0.conda
+  hash:
+    md5: bae01b2563030c085f5158c518b84e86
+    sha256: 81602a4592ad2ac1a1cb57372fd25214e63b1c477d5818b0c21cde0f1f85c001
+  category: main
+  optional: false
+- name: pydantic-core
+  version: 2.27.2
   manager: conda
   platform: osx-64
   dependencies:
@@ -14691,14 +14735,14 @@ package:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     typing-extensions: '>=4.6.0,!=4.7.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.20.1-py312ha47ea1c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.27.2-py312h0d0de52_0.conda
   hash:
-    md5: 8e095b6acd6405ea0da845d191302faf
-    sha256: d82efcb45a6958af050851f76544fd35a6968fc50f613a2b24dd3467fab7a8d7
+    md5: e66079d3a6df307a882cedfe113eb5a1
+    sha256: fce4e1be48137ec2ae8a576671420665c5a3d11b2f79f2f771f0bd96a28418aa
   category: main
   optional: false
 - name: pydantic-core
-  version: 2.20.1
+  version: 2.27.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -14706,55 +14750,55 @@ package:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     typing-extensions: '>=4.6.0,!=4.7.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.20.1-py312h552d48e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.27.2-py312hcd83bfe_0.conda
   hash:
-    md5: b0b8cd2d2e6aa1620dfea907706f94b4
-    sha256: 5a6381ce4a5ecaeffe92f6c05fc4a70290140364e56c715a9de9c939c2bf46de
+    md5: dcb307e02f17d38c6e1cbfbf8c602852
+    sha256: cfa7201f890d5d08ce29ff70e65a96787d5793a1718776733666b44bbd4a1205
   category: main
   optional: false
 - name: pydot
-  version: 2.0.0
+  version: 3.0.4
   manager: conda
   platform: linux-64
   dependencies:
     graphviz: '>=2.38.0'
-    pyparsing: '>=3'
+    pyparsing: '>=3.0.9'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydot-2.0.0-py312h7900ff3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydot-3.0.4-py312h7900ff3_0.conda
   hash:
-    md5: a3628f9a0ca8573314dc6f94f40a0419
-    sha256: 18b1779b1f4de2fa0856fad018b52966de2f60a5ddf86dab89bcc404dbaa80cb
+    md5: 331fc9a56a16f02592f193c8109e4543
+    sha256: 59227fbb547dc4c5405514fd550ea51f3ea0efc0317108bcab5b7e82973e7aa9
   category: dev
   optional: true
 - name: pydot
-  version: 2.0.0
+  version: 3.0.4
   manager: conda
   platform: osx-64
   dependencies:
     graphviz: '>=2.38.0'
-    pyparsing: '>=3'
+    pyparsing: '>=3.0.9'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pydot-2.0.0-py312hb401068_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pydot-3.0.4-py312hb401068_0.conda
   hash:
-    md5: 45b0f862538bfd4319c59037da189b0b
-    sha256: 07c8305c804a7c6b62bd1a156285d99b9a275033316458db5031464c127b7148
+    md5: 9132b851f4d0a88e932fdc1b5c5784e9
+    sha256: 8c48772d194c4c33d935511e3506a170c99ef00b8fbdbbb9e6fb83c420f31ad3
   category: dev
   optional: true
 - name: pydot
-  version: 2.0.0
+  version: 3.0.4
   manager: conda
   platform: osx-arm64
   dependencies:
     graphviz: '>=2.38.0'
-    pyparsing: '>=3'
+    pyparsing: '>=3.0.9'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydot-2.0.0-py312h81bd7bf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydot-3.0.4-py312h81bd7bf_0.conda
   hash:
-    md5: c620ff4adbcae3350661ffc62212e240
-    sha256: a3faf4bf38cdd990c3c8fb6d4c7affaae7070f8539173a2c547e3ee06536d763
+    md5: 0ac88e19c9d768bfd792188b2b277a91
+    sha256: d8175dcd1cd1645eac285324daa0ceb04485181f25fc8b05e5a4f1f0c77dbbca
   category: dev
   optional: true
 - name: pyflakes
@@ -14762,11 +14806,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: 2.7.*|>=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.2.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 0cf7fef6aa123df28adb21a590065e3d
-    sha256: b1582410fcfa30b3597629e39b688ead87833c4a64f7c4637068f80aa1411d49
+    md5: 4731450b2c059fc567696242bcb7fc05
+    sha256: 22aa7a4d67c3907da5bbf2b97dbe34061c390ea7ba99e9d75ee581956270e129
   category: dev
   optional: true
 - name: pyflakes
@@ -14774,11 +14818,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: 2.7.*|>=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.2.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 0cf7fef6aa123df28adb21a590065e3d
-    sha256: b1582410fcfa30b3597629e39b688ead87833c4a64f7c4637068f80aa1411d49
+    md5: 4731450b2c059fc567696242bcb7fc05
+    sha256: 22aa7a4d67c3907da5bbf2b97dbe34061c390ea7ba99e9d75ee581956270e129
   category: dev
   optional: true
 - name: pyflakes
@@ -14786,47 +14830,47 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: 2.7.*|>=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.2.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.2.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 0cf7fef6aa123df28adb21a590065e3d
-    sha256: b1582410fcfa30b3597629e39b688ead87833c4a64f7c4637068f80aa1411d49
+    md5: 4731450b2c059fc567696242bcb7fc05
+    sha256: 22aa7a4d67c3907da5bbf2b97dbe34061c390ea7ba99e9d75ee581956270e129
   category: dev
   optional: true
 - name: pygments
-  version: 2.18.0
+  version: 2.19.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
   hash:
-    md5: b7f5c092b8f9800150d998a71b76d5a1
-    sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
+    md5: 232fb4577b6687b2d503ef8e254270c9
+    sha256: 28a3e3161390a9d23bc02b4419448f8d27679d9e2c250e29849e37749c8de86b
   category: main
   optional: false
 - name: pygments
-  version: 2.18.0
+  version: 2.19.1
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
   hash:
-    md5: b7f5c092b8f9800150d998a71b76d5a1
-    sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
+    md5: 232fb4577b6687b2d503ef8e254270c9
+    sha256: 28a3e3161390a9d23bc02b4419448f8d27679d9e2c250e29849e37749c8de86b
   category: main
   optional: false
 - name: pygments
-  version: 2.18.0
+  version: 2.19.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
   hash:
-    md5: b7f5c092b8f9800150d998a71b76d5a1
-    sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
+    md5: 232fb4577b6687b2d503ef8e254270c9
+    sha256: 28a3e3161390a9d23bc02b4419448f8d27679d9e2c250e29849e37749c8de86b
   category: main
   optional: false
 - name: pylev
@@ -14870,16 +14914,17 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cffi: '>=1.4.1'
-    libgcc-ng: '>=12'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    python: '>=3.12.0rc3,<3.13.0a0'
+    libgcc: '>=13'
+    libsodium: '>=1.0.20,<1.0.21.0a0'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     six: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.5.0-py312h98912ed_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.5.0-py312h66e93f0_4.conda
   hash:
-    md5: 66244781991f08a163ff80a91359dbf5
-    sha256: f9077093cbd75165abd2f538ad2924ec4cf3a5928604e9ff6ffcf2b224de2163
+    md5: c47ede9450b5347c1933ccb552fca707
+    sha256: 9b3849d530055c1dff2a068628a4570f55d02156d78ec00b8efbc37af396aee9
   category: dev
   optional: true
 - name: pynacl
@@ -14887,15 +14932,16 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     cffi: '>=1.4.1'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    python: '>=3.12.0rc3,<3.13.0a0'
+    libsodium: '>=1.0.20,<1.0.21.0a0'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     six: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/pynacl-1.5.0-py312h104f124_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pynacl-1.5.0-py312hb553811_4.conda
   hash:
-    md5: eee6d82c708669043c7d581afd45a6db
-    sha256: 9e7f8189c8cb3e0e4318b59ca42ff97f7803a732c69b1fb192e7c2af3f4234c3
+    md5: 88be5bbe28b39b591eb61520d12658d0
+    sha256: 32d959bd5b7e403fd38abc1137000d1106502cb90e6ef58c71e0301ac15b6803
   category: dev
   optional: true
 - name: pynacl
@@ -14903,15 +14949,16 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     cffi: '>=1.4.1'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    python: '>=3.12.0rc3,<3.13.0a0'
+    libsodium: '>=1.0.20,<1.0.21.0a0'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     six: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pynacl-1.5.0-py312h02f2b3b_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pynacl-1.5.0-py312h024a12e_4.conda
   hash:
-    md5: 5648ef2d224601e852af9b4e8eb30d3a
-    sha256: 733bba1d4b25f17a5e30f99dc4355b6cd9345cf0c9a1241c205323d8e0ec42af
+    md5: 7febc246a29d77449bdb3e7a18382788
+    sha256: 1cadc99e88105400acb41c4297d43026bf3aaaa386c72a4e2a7512c2ea70f4be
   category: dev
   optional: true
 - name: pynvml
@@ -14951,144 +14998,143 @@ package:
   category: main
   optional: false
 - name: pyogrio
-  version: 0.9.0
+  version: 0.10.0
   manager: conda
   platform: linux-64
   dependencies:
-    gdal: ''
-    libgcc-ng: '>=12'
-    libgdal: '>=3.9.0,<3.10.0a0'
-    libstdcxx-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.10.0,<3.11.0a0'
+    libstdcxx: '>=13'
     numpy: ''
     packaging: ''
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.9.0-py312h8ad7a51_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.10.0-py312h02b19dd_1.conda
   hash:
-    md5: f4d2803818632b2175fa58de7f653901
-    sha256: 4f2cc106c738be0076c11b487546bd448aa8fca7f19d2b0f54afd8fa2ee0b7d1
+    md5: 6ebb12bd1833a52e08e63297b8621903
+    sha256: b1a2754f1ddda7f098dc1f6712153c8a184bf31e11e71ee8b6ca95d9791c2147
   category: main
   optional: false
 - name: pyogrio
-  version: 0.9.0
+  version: 0.10.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    gdal: ''
-    libcxx: '>=16'
-    libgdal: '>=3.9.0,<3.10.0a0'
+    libcxx: '>=18'
+    libgdal-core: '>=3.10.0,<3.11.0a0'
     numpy: ''
     packaging: ''
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.9.0-py312h43b3a95_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.10.0-py312h4bcfd6b_1.conda
   hash:
-    md5: 1a22b21b82d6d134a06440dbaf46d1d7
-    sha256: 9dc89062437d698a1060644c96c9800bacb12370ddf416f75d2fda87afde5dea
+    md5: 35fcc42314c5aa54a8674523ae5add1a
+    sha256: a4c3fb17ca37fdf26640dd74a62483117a88ad4cdb1105954ddca1167ce4ea90
   category: main
   optional: false
 - name: pyogrio
-  version: 0.9.0
+  version: 0.10.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    gdal: ''
-    libcxx: '>=16'
-    libgdal: '>=3.9.0,<3.10.0a0'
+    libcxx: '>=18'
+    libgdal-core: '>=3.10.0,<3.11.0a0'
     numpy: ''
     packaging: ''
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.9.0-py312h15038b3_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.10.0-py312hfd5e53c_1.conda
   hash:
-    md5: a940c064a3443f423dae2b50f86ef847
-    sha256: 61d12bb940cde2a28c265b2102abeb70e0a51ae45bb159712e425b4bd226ecdb
+    md5: 19550465d36f2f513be5c62def9edfd9
+    sha256: af738bd24e6f2fcf763a0dbc22fb088222e7f52b99b7b5f49333d9da1320c8ea
   category: main
   optional: false
 - name: pyparsing
-  version: 3.1.2
+  version: 3.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: b9a4dacf97241704529131a0dfc0494f
-    sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
+    md5: 285e237b8f351e85e7574a2c7bfa6d46
+    sha256: f513fed4001fd228d3bf386269237b4ca6bff732c99ffc11fcbad8529b35407c
   category: main
   optional: false
 - name: pyparsing
-  version: 3.1.2
+  version: 3.2.1
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: b9a4dacf97241704529131a0dfc0494f
-    sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
+    md5: 285e237b8f351e85e7574a2c7bfa6d46
+    sha256: f513fed4001fd228d3bf386269237b4ca6bff732c99ffc11fcbad8529b35407c
   category: main
   optional: false
 - name: pyparsing
-  version: 3.1.2
+  version: 3.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: b9a4dacf97241704529131a0dfc0494f
-    sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
+    md5: 285e237b8f351e85e7574a2c7bfa6d46
+    sha256: f513fed4001fd228d3bf386269237b4ca6bff732c99ffc11fcbad8529b35407c
   category: main
   optional: false
 - name: pyproj
-  version: 3.6.1
+  version: 3.7.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     certifi: ''
-    libgcc-ng: '>=12'
-    proj: '>=9.4.0,<9.5.0a0'
+    libgcc: '>=13'
+    proj: '>=9.5.0,<9.6.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py312h5d05ceb_7.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.0-py312he630544_0.conda
   hash:
-    md5: b53ddc25da04839cc62b0b158a7ecb38
-    sha256: 76a8d7c8ff3f0f9ea265622517c194a05084dca584e8eb1b38fe9ef74bde1b39
+    md5: 427799f15b36751761941f4cbd7d780f
+    sha256: 713d38f8f4fce141eec5c282e333b145a1359c1c6cc34f506d03b164497e6a74
   category: main
   optional: false
 - name: pyproj
-  version: 3.6.1
+  version: 3.7.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     certifi: ''
-    proj: '>=9.4.0,<9.5.0a0'
+    proj: '>=9.5.0,<9.6.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py312ha320102_7.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.0-py312h9673cc4_0.conda
   hash:
-    md5: 42173e3a4efa0af22a562c59a12781f1
-    sha256: 4c70d5ec5bed9a4eec1160f64de93d70a44bd3c7c0a2533756148dec5ce12197
+    md5: c44fa471064d7ca1c3f335dfeafa5651
+    sha256: 7d3da4af08caf0491779b51ea055ecb74bd99ef37981ad19f9404349dbfa53ed
   category: main
   optional: false
 - name: pyproj
-  version: 3.6.1
+  version: 3.7.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     certifi: ''
-    proj: '>=9.4.0,<9.5.0a0'
+    proj: '>=9.5.0,<9.6.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.6.1-py312h64656f7_7.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.0-py312h1ab748d_0.conda
   hash:
-    md5: c8b38bd60f269e40f308ba82a2585977
-    sha256: 00598ea92c31ab46e5b1c70daa9625279d68e1c166944fc12cc91b3596ecc743
+    md5: 62be0440197cfa89eb76846895198bab
+    sha256: a6e5eda9365adcb3900338ddc809ecb9df2520871de14113675e50fddfebabbe
   category: main
   optional: false
 - name: pysocks
@@ -15097,11 +15143,11 @@ package:
   platform: linux-64
   dependencies:
     __unix: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   hash:
-    md5: 2a7de29fb590ca14b5243c4c812c8025
-    sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+    md5: 461219d1a5bd61342293efa2c0c90eac
+    sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   category: main
   optional: false
 - name: pysocks
@@ -15110,11 +15156,11 @@ package:
   platform: osx-64
   dependencies:
     __unix: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   hash:
-    md5: 2a7de29fb590ca14b5243c4c812c8025
-    sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+    md5: 461219d1a5bd61342293efa2c0c90eac
+    sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   category: main
   optional: false
 - name: pysocks
@@ -15123,11 +15169,11 @@ package:
   platform: osx-arm64
   dependencies:
     __unix: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   hash:
-    md5: 2a7de29fb590ca14b5243c4c812c8025
-    sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+    md5: 461219d1a5bd61342293efa2c0c90eac
+    sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   category: main
   optional: false
 - name: pytest
@@ -15153,13 +15199,13 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    colorama: ''
-    exceptiongroup: '>=1.0.0rc8'
-    iniconfig: ''
     packaging: ''
-    pluggy: '>=0.12,<2.0'
+    colorama: ''
+    iniconfig: ''
     python: '>=3.7'
+    exceptiongroup: '>=1.0.0rc8'
     tomli: '>=1.0.0'
+    pluggy: '>=0.12,<2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.4-pyhd8ed1ab_0.conda
   hash:
     md5: a9d145de8c5f064b5fa68fb34725d9f4
@@ -15171,13 +15217,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    colorama: ''
-    exceptiongroup: '>=1.0.0rc8'
-    iniconfig: ''
     packaging: ''
-    pluggy: '>=0.12,<2.0'
+    colorama: ''
+    iniconfig: ''
     python: '>=3.7'
+    exceptiongroup: '>=1.0.0rc8'
     tomli: '>=1.0.0'
+    pluggy: '>=0.12,<2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.4-pyhd8ed1ab_0.conda
   hash:
     md5: a9d145de8c5f064b5fa68fb34725d9f4
@@ -15185,7 +15231,7 @@ package:
   category: dev
   optional: true
 - name: pytest-recording
-  version: 0.13.1
+  version: 0.13.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -15193,152 +15239,153 @@ package:
     pytest: '>=3.5.0'
     python: '>=3.7'
     vcrpy: '>=2.0.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-recording-0.13.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-recording-0.13.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 0b1e7656def24d3dc190653940a4e6bb
-    sha256: d4e12ad38582eb51727cd562e074ba5485f26df9d8d1abefd4c7b193b495d2bf
+    md5: fca2494a433e2643eca0842f71cd3914
+    sha256: 0b6e8c97c4e851e258744a390a540b67c6be23b0435c21fc58c6dd35663ab508
   category: dev
   optional: true
 - name: pytest-recording
-  version: 0.13.1
+  version: 0.13.2
   manager: conda
   platform: osx-64
   dependencies:
     attrs: ''
-    pytest: '>=3.5.0'
     python: '>=3.7'
+    pytest: '>=3.5.0'
     vcrpy: '>=2.0.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-recording-0.13.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-recording-0.13.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 0b1e7656def24d3dc190653940a4e6bb
-    sha256: d4e12ad38582eb51727cd562e074ba5485f26df9d8d1abefd4c7b193b495d2bf
+    md5: fca2494a433e2643eca0842f71cd3914
+    sha256: 0b6e8c97c4e851e258744a390a540b67c6be23b0435c21fc58c6dd35663ab508
   category: dev
   optional: true
 - name: pytest-recording
-  version: 0.13.1
+  version: 0.13.2
   manager: conda
   platform: osx-arm64
   dependencies:
     attrs: ''
-    pytest: '>=3.5.0'
     python: '>=3.7'
+    pytest: '>=3.5.0'
     vcrpy: '>=2.0.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-recording-0.13.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-recording-0.13.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 0b1e7656def24d3dc190653940a4e6bb
-    sha256: d4e12ad38582eb51727cd562e074ba5485f26df9d8d1abefd4c7b193b495d2bf
+    md5: fca2494a433e2643eca0842f71cd3914
+    sha256: 0b6e8c97c4e851e258744a390a540b67c6be23b0435c21fc58c6dd35663ab508
   category: dev
   optional: true
 - name: python
-  version: 3.12.4
+  version: 3.12.8
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
     ld_impl_linux-64: '>=2.36.1'
-    libexpat: '>=2.6.2,<3.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
     libffi: '>=3.4,<4.0a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
+    liblzma: '>=5.6.3,<6.0a0'
     libnsl: '>=2.0.1,<2.1.0a0'
-    libsqlite: '>=3.46.0,<4.0a0'
+    libsqlite: '>=3.47.0,<4.0a0'
     libuuid: '>=2.38.1,<3.0a0'
     libxcrypt: '>=4.4.36'
     libzlib: '>=1.3.1,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
-    openssl: '>=3.3.1,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.4-h194c7f8_0_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.8-h9e4cc4f_1_cpython.conda
   hash:
-    md5: d73490214f536cccb5819e9873048c92
-    sha256: 97a78631e6c928bf7ad78d52f7f070fcf3bd37619fa48dc4394c21cf3058cdee
+    md5: 7fd2fd79436d9b473812f14e86746844
+    sha256: 3f0e0518c992d8ccfe62b189125721309836fe48a010dc424240583e157f9ff0
   category: main
   optional: false
 - name: python
-  version: 3.12.4
+  version: 3.12.8
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.6.2,<3.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
     libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.46.0,<4.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
+    libsqlite: '>=3.47.0,<4.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
-    openssl: '>=3.3.1,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.4-h37a9e06_0_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.8-h9ccd52b_1_cpython.conda
   hash:
-    md5: 94e2b77992f580ac6b7a4fc9b53018b3
-    sha256: 677958ee90eff229755d4e0ed40af6d835c9131e863b1539b34bbf07d7a775f3
+    md5: 68a31f9cfbdcab2a4baec79095374780
+    sha256: bee7b5288337cde8cbb21f34ff5b041511e4e9ba380838ab1be4deab1b55ea97
   category: main
   optional: false
 - name: python
-  version: 3.12.4
+  version: 3.12.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.6.2,<3.0a0'
+    libexpat: '>=2.6.4,<3.0a0'
     libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.46.0,<4.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
+    libsqlite: '>=3.47.0,<4.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
-    openssl: '>=3.3.1,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.4-h30c5eda_0_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.8-hc22306f_1_cpython.conda
   hash:
-    md5: e3e44e0e72aed46dcb810fa3e96784be
-    sha256: 107824b584eb5e43f71df8cb2741019f5c377c734f8309899aa2a6ed53b79a47
+    md5: 54ca5b5d92ef3a3ba61e195ee882a518
+    sha256: 7586a711b1b08a9df8864e26efdc06980bdfb0e18d5ac4651d0fee30a8d3e3a0
   category: main
   optional: false
 - name: python-dateutil
-  version: 2.9.0
+  version: 2.9.0.post0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
   hash:
-    md5: 2cf4264fffb9e6eff6031c5b6884d61c
-    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
+    md5: 5ba79d7c71f03c678c8ead841f347d6e
+    sha256: a50052536f1ef8516ed11a844f9413661829aa083304dc624c5925298d078d79
   category: main
   optional: false
 - name: python-dateutil
-  version: 2.9.0
+  version: 2.9.0.post0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
   hash:
-    md5: 2cf4264fffb9e6eff6031c5b6884d61c
-    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
+    md5: 5ba79d7c71f03c678c8ead841f347d6e
+    sha256: a50052536f1ef8516ed11a844f9413661829aa083304dc624c5925298d078d79
   category: main
   optional: false
 - name: python-dateutil
-  version: 2.9.0
+  version: 2.9.0.post0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.9'
     six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
   hash:
-    md5: 2cf4264fffb9e6eff6031c5b6884d61c
-    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
+    md5: 5ba79d7c71f03c678c8ead841f347d6e
+    sha256: a50052536f1ef8516ed11a844f9413661829aa083304dc624c5925298d078d79
   category: main
   optional: false
 - name: python-jose
@@ -15349,12 +15396,12 @@ package:
     cryptography: ''
     ecdsa: '!=0.15'
     pyasn1: ''
-    python: '>=3.6'
+    python: '>=3.9'
     rsa: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/python-jose-3.3.0-pyh6c4a22f_1.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/python-jose-3.3.0-pyhff2d567_2.conda
   hash:
-    md5: 8fa19760945f1c3754c9419c6459f7e0
-    sha256: 31bcedfa1803116e589602a24db4a01dbda2e0df819f497cb5d48c29d17631ec
+    md5: 45fd78d27f93da0514b7ff45bc037c86
+    sha256: c40bf694bae8c8e5fcdbfa1c43229080783ed96118204e1b59315f31862bda51
   category: dev
   optional: true
 - name: python-jose
@@ -15363,14 +15410,14 @@ package:
   platform: osx-64
   dependencies:
     cryptography: ''
-    ecdsa: '!=0.15'
     pyasn1: ''
-    python: '>=3.6'
     rsa: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/python-jose-3.3.0-pyh6c4a22f_1.tar.bz2
+    python: '>=3.9'
+    ecdsa: '!=0.15'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-jose-3.3.0-pyhff2d567_2.conda
   hash:
-    md5: 8fa19760945f1c3754c9419c6459f7e0
-    sha256: 31bcedfa1803116e589602a24db4a01dbda2e0df819f497cb5d48c29d17631ec
+    md5: 45fd78d27f93da0514b7ff45bc037c86
+    sha256: c40bf694bae8c8e5fcdbfa1c43229080783ed96118204e1b59315f31862bda51
   category: dev
   optional: true
 - name: python-jose
@@ -15379,50 +15426,50 @@ package:
   platform: osx-arm64
   dependencies:
     cryptography: ''
-    ecdsa: '!=0.15'
     pyasn1: ''
-    python: '>=3.6'
     rsa: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/python-jose-3.3.0-pyh6c4a22f_1.tar.bz2
+    python: '>=3.9'
+    ecdsa: '!=0.15'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-jose-3.3.0-pyhff2d567_2.conda
   hash:
-    md5: 8fa19760945f1c3754c9419c6459f7e0
-    sha256: 31bcedfa1803116e589602a24db4a01dbda2e0df819f497cb5d48c29d17631ec
+    md5: 45fd78d27f93da0514b7ff45bc037c86
+    sha256: c40bf694bae8c8e5fcdbfa1c43229080783ed96118204e1b59315f31862bda51
   category: dev
   optional: true
 - name: python-tzdata
-  version: '2024.1'
+  version: '2025.1'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 98206ea9954216ee7540f0c773f2104d
-    sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
+    md5: 392c91c42edd569a7ec99ed8648f597a
+    sha256: 1597d6055d34e709ab8915091973552a0b8764c8032ede07c4e99670da029629
   category: main
   optional: false
 - name: python-tzdata
-  version: '2024.1'
+  version: '2025.1'
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 98206ea9954216ee7540f0c773f2104d
-    sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
+    md5: 392c91c42edd569a7ec99ed8648f597a
+    sha256: 1597d6055d34e709ab8915091973552a0b8764c8032ede07c4e99670da029629
   category: main
   optional: false
 - name: python-tzdata
-  version: '2024.1'
+  version: '2025.1'
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 98206ea9954216ee7540f0c773f2104d
-    sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
+    md5: 392c91c42edd569a7ec99ed8648f597a
+    sha256: 1597d6055d34e709ab8915091973552a0b8764c8032ede07c4e99670da029629
   category: main
   optional: false
 - name: python_abi
@@ -15430,10 +15477,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
   hash:
-    md5: dccc2d142812964fcc6abdc97b672dff
-    sha256: 182a329de10a4165f6e8a3804caf751f918f6ea6176dd4e5abcdae1ed3095bf6
+    md5: 0424ae29b104430108f5218a66db7260
+    sha256: d10e93d759931ffb6372b45d65ff34d95c6000c61a07e298d162a3bc2accebb0
   category: main
   optional: false
 - name: python_abi
@@ -15441,10 +15488,10 @@ package:
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-4_cp312.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
   hash:
-    md5: 87201ac4314b911b74197e588cca3639
-    sha256: 82c154d95c1637604671a02a89e72f1382e89a4269265a03506496bd928f6f14
+    md5: c34dd4920e0addf7cfcc725809f25d8e
+    sha256: 4da26c7508d5bc5d8621e84dc510284402239df56aab3587a7d217de9d3c806d
   category: main
   optional: false
 - name: python_abi
@@ -15452,10 +15499,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-4_cp312.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
   hash:
-    md5: bbb3a02c78b2d8219d7213f76d644a2a
-    sha256: db25428e4f24f8693ffa39f3ff6dfbb8fd53bc298764b775b57edab1c697560f
+    md5: b76f9b1c862128e56ac7aa8cd2333de9
+    sha256: 49d624e4b809c799d2bf257b22c23cf3fc4460f5570d9a58e7ad86350aeaa1f4
   category: main
   optional: false
 - name: pytz
@@ -15534,97 +15581,101 @@ package:
   category: dev
   optional: true
 - name: pyyaml
-  version: 6.0.1
+  version: 6.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-    yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py312h98912ed_1.conda
-  hash:
-    md5: e3fd78d8d490af1d84763b9fe3f2e552
-    sha256: 7f347a10a7121b08d79d21cd4f438c07c23479ea0c74dfb89d6dc416f791bb7f
-  category: main
-  optional: false
-- name: pyyaml
-  version: 6.0.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-    yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py312h104f124_1.conda
-  hash:
-    md5: 260ed90aaf06061edabd7209638cf03b
-    sha256: 04aa180782cb675b960c0bf4aad439b4a7a08553c6af74d0b8e5df9a0c7cc4f4
-  category: main
-  optional: false
-- name: pyyaml
-  version: 6.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-    yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py312h02f2b3b_1.conda
-  hash:
-    md5: a0c843e52a1c4422d8657dd76e9eb994
-    sha256: b6b4027b89c17b9bbd8089aec3e44bc29f802a7d5668d5a75b5358d7ed9705ca
-  category: main
-  optional: false
-- name: pyzmq
-  version: 26.0.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    libstdcxx-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-    zeromq: '>=4.3.5,<4.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.0.3-py312h8fd38d8_0.conda
+    yaml: '>=0.2.5,<0.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h178313f_2.conda
   hash:
-    md5: 27efa6d21e98bcab4585a6b913df7625
-    sha256: a3bf1e1af97a256a3a498cc7f2fedb478df18cf629cc9e9aa73a5b4cfc204d45
-  category: dev
-  optional: true
-- name: pyzmq
-  version: 26.0.3
+    md5: cf2485f39740de96e2a7f2bb18ed2fee
+    sha256: 159cba13a93b3fe084a1eb9bda0a07afc9148147647f0d437c3c3da60980503b
+  category: main
+  optional: false
+- name: pyyaml
+  version: 6.0.2
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
+    __osx: '>=10.13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-    zeromq: '>=4.3.5,<4.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.0.3-py312ha04878a_0.conda
+    yaml: '>=0.2.5,<0.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py312h3520af0_2.conda
   hash:
-    md5: a2a851071ceea5b90391003faf94b203
-    sha256: 65a17e5cbece9fa2d6df687502bcbe504f0fd906aa02a85b23de5ff55d423926
-  category: dev
-  optional: true
-- name: pyzmq
-  version: 26.0.3
+    md5: 4a2d83ac55752681d54f781534ddd209
+    sha256: de96d83b805dba03422d39e855fb33cbeedc8827235d6f76407a3b42dc085910
+  category: main
+  optional: false
+- name: pyyaml
+  version: 6.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    yaml: '>=0.2.5,<0.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py312h998013c_2.conda
+  hash:
+    md5: 68149ed4d4e9e1c42d2ba1f27f08ca96
+    sha256: ad225ad24bfd60f7719709791345042c3cb32da1692e62bd463b084cf140e00d
+  category: main
+  optional: false
+- name: pyzmq
+  version: 26.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libsodium: '>=1.0.20,<1.0.21.0a0'
+    libstdcxx: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     zeromq: '>=4.3.5,<4.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.0.3-py312hfa13136_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.1-py312hbf22597_0.conda
   hash:
-    md5: 7c695aab5ee68adbe8a046b73100e13c
-    sha256: 1118ada24f3eb1c90baa1e5e258c70498b7e1a2b5f12212c7789aa3f7504cd82
+    md5: 7cec8d0dac15a2d9fea8e49879aa779d
+    sha256: 90ec0da0317d3d76990a40c61e1709ef859dd3d8c63838bad2814f46a63c8a2e
+  category: dev
+  optional: true
+- name: pyzmq
+  version: 26.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcxx: '>=18'
+    libsodium: '>=1.0.20,<1.0.21.0a0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    zeromq: '>=4.3.5,<4.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.1-py312h679dbab_0.conda
+  hash:
+    md5: e66197c106bee0f80013a36d7fbcbde9
+    sha256: 48651608646b1689209736720102f3390f4fc22d79701b2d30a66d6ce0dba191
+  category: dev
+  optional: true
+- name: pyzmq
+  version: 26.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=18'
+    libsodium: '>=1.0.20,<1.0.21.0a0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    zeromq: '>=4.3.5,<4.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.1-py312hf4875e0_0.conda
+  hash:
+    md5: bfbefdb140b546a80827ff7c9d5ac7b8
+    sha256: 70d398b334668dc597d33e27847ede1b0829a639b9c91ee845355e52c86c2293
   category: dev
   optional: true
 - name: qhull
@@ -15635,10 +15686,10 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
   hash:
-    md5: 9f0934861973a17e96b1e609dbb0d1cd
-    sha256: 6e34ee9640a04a8c05b97cb18b04065cd88ee38438fdcec274a95f2c49f4cd90
+    md5: 353823361b1d27eb3960efb076dfcaf6
+    sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
   category: main
   optional: false
 - name: qhull
@@ -15648,10 +15699,10 @@ package:
   dependencies:
     __osx: '>=10.13'
     libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
   hash:
-    md5: f6d98ba4de9607410c5be1ed40d1dcd3
-    sha256: acb0cfd78ce4b9aa8dc507cbba31dd9ddda1e65108fcc8827187349d55ce6a4a
+    md5: dd1ea9ff27c93db7c01a7b7656bd4ad4
+    sha256: 79d804fa6af9c750e8b09482559814ae18cd8df549ecb80a4873537a5a31e06e
   category: main
   optional: false
 - name: qhull
@@ -15661,40 +15712,41 @@ package:
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
   hash:
-    md5: 667769cf22f22155d0c23609dd067618
-    sha256: ba13382a69781b4ca93c3754ec96715b24bc96f38b5bfb60b8fa460cc5d5da16
+    md5: 6483b1f59526e05d7d894e466b5b6924
+    sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
   category: main
   optional: false
 - name: rasterio
-  version: 1.3.10
+  version: 1.4.3
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     affine: ''
     attrs: ''
     certifi: ''
     click: '>=4'
     click-plugins: ''
     cligj: '>=0.5'
-    libgcc-ng: '>=12'
-    libgdal: '>=3.9.0,<3.10.0a0'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.19,<3'
-    proj: '>=9.4.0,<9.5.0a0'
+    libgcc: '>=13'
+    libgdal-core: '>=3.10.0,<3.11.0a0'
+    libstdcxx: '>=13'
+    numpy: '>=1.21,<3'
+    proj: '>=9.5.1,<9.6.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     setuptools: '>=0.9.8'
     snuggs: '>=1.4.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.3.10-py312hc022a17_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.4.3-py312h8cae83d_0.conda
   hash:
-    md5: a291a31c046d55ef7c6c4f5036314fe5
-    sha256: 860acfea3f4d6540ab3eb8a8160264daca58e6caa1683a8a56e1ce52666e5cf3
+    md5: 9691edb87ec148887c6488412355ed49
+    sha256: 260a7009182f701077b93b0bf58f94e66c39e11876453a76d0983d983f90acfd
   category: dev
   optional: true
 - name: rasterio
-  version: 1.3.10
+  version: 1.4.3
   manager: conda
   platform: osx-64
   dependencies:
@@ -15705,22 +15757,22 @@ package:
     click: '>=4'
     click-plugins: ''
     cligj: '>=0.5'
-    libcxx: '>=16'
-    libgdal: '>=3.9.0,<3.10.0a0'
-    numpy: '>=1.19,<3'
-    proj: '>=9.4.0,<9.5.0a0'
+    libcxx: '>=18'
+    libgdal-core: '>=3.10.0,<3.11.0a0'
+    numpy: '>=1.21,<3'
+    proj: '>=9.5.1,<9.6.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     setuptools: '>=0.9.8'
     snuggs: '>=1.4.1'
-  url: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.3.10-py312h1c98354_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.4.3-py312h7846a4c_0.conda
   hash:
-    md5: dcec838580fd6e2e4210168608946ac8
-    sha256: 84d06dacb0fdc9c85f6b0c0019d9589a4801c0fa928a37799908f338186cdaab
+    md5: 747e94af058b28ff4363b9610cb45a50
+    sha256: 91669e2e858bf6b81c5d216468bd2957471db52fd415ac308d68b56cd36a04b2
   category: dev
   optional: true
 - name: rasterio
-  version: 1.3.10
+  version: 1.4.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -15731,69 +15783,105 @@ package:
     click: '>=4'
     click-plugins: ''
     cligj: '>=0.5'
-    libcxx: '>=16'
-    libgdal: '>=3.9.0,<3.10.0a0'
-    numpy: '>=1.19,<3'
-    proj: '>=9.4.0,<9.5.0a0'
+    libcxx: '>=18'
+    libgdal-core: '>=3.10.0,<3.11.0a0'
+    numpy: '>=1.21,<3'
+    proj: '>=9.5.1,<9.6.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     setuptools: '>=0.9.8'
     snuggs: '>=1.4.1'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.3.10-py312h6160399_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.4.3-py312h02264c4_0.conda
   hash:
-    md5: c4beef6139f54c1d46a25735676e0402
-    sha256: 397d00fdbcb1fc7eb9f4889b9ff66d93d3bd481ff1ed55917ae1c943fadb5495
+    md5: a4ecd14e35c1b6cf8177565f7938ff03
+    sha256: d0846ad98d0969d365a2919a282825894b783639528b83b425b1dda93409f75e
   category: dev
   optional: true
+- name: rav1e
+  version: 0.6.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.6.6-he8a937b_2.conda
+  hash:
+    md5: 77d9955b4abddb811cb8ab1aa7d743e4
+    sha256: 91b3c1ced90d04ee2eded1f72cf3cbc19ff05a25e41876ef0758266a5bab009f
+  category: main
+  optional: false
+- name: rav1e
+  version: 0.6.6
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/rav1e-0.6.6-h7205ca4_2.conda
+  hash:
+    md5: ab03527926f8ce85f84a91fd35520ef2
+    sha256: 046ac50530590cd2a5d9bcb1e581bdd168e06049230ad3afd8cce2fa71b429d9
+  category: main
+  optional: false
+- name: rav1e
+  version: 0.6.6
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.6.6-h69fbcac_2.conda
+  hash:
+    md5: e309ae86569b1cd55a0285fa4e939844
+    sha256: be6174970193cb4d0ffa7d731a93a4c9542881dbc7ab24e74b460ef312161169
+  category: main
+  optional: false
 - name: rdma-core
-  version: '52.0'
+  version: '55.0'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libnl: '>=3.9.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-52.0-he02047a_0.conda
+    libgcc: '>=13'
+    libnl: '>=3.11.0,<4.0a0'
+    libstdcxx: '>=13'
+    libsystemd0: '>=256.9'
+    libudev1: '>=256.9'
+  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-55.0-h5888daf_0.conda
   hash:
-    md5: b607b8e2361ead79785d77eb4b21e8cc
-    sha256: a16dacd7be08f611787d81ccfd4c7cbc0205fd54f066cc3ceb7fac7b26f6c9d7
+    md5: fd94951ea305bdfe6fb3939db3fb7ce2
+    sha256: 3715a51f1ea6e3765f19b6db90a7edb77a3b5aa201a4f09cbd51a678e8609a88
   category: main
   optional: false
 - name: re2
-  version: 2023.09.01
+  version: 2024.07.02
   manager: conda
   platform: linux-64
   dependencies:
-    libre2-11: 2023.09.01
-  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_2.conda
+    libre2-11: 2024.07.02
+  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h9925aae_2.conda
   hash:
-    md5: 8f70e36268dea8eb666ef14c29bd3cda
-    sha256: f0f520f57e6b58313e8c41abc7dfa48742a05f1681f05654558127b667c769a8
+    md5: e84ddf12bde691e8ec894b00ea829ddf
+    sha256: d213c44958d49ce7e0d4d5b81afec23640cce5016685dbb2d23571a99caa4474
   category: main
   optional: false
 - name: re2
-  version: 2023.09.01
+  version: 2024.07.02
   manager: conda
   platform: osx-64
   dependencies:
-    libre2-11: 2023.09.01
-  url: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.09.01-hb168e87_2.conda
+    libre2-11: 2024.07.02
+  url: https://conda.anaconda.org/conda-forge/osx-64/re2-2024.07.02-ha5e900a_2.conda
   hash:
-    md5: 266f8ca8528fc7e0fa31066c309ad864
-    sha256: 5739ed2cfa62ed7f828eb4b9e6e69ff1df56cb9a9aacdc296451a3cb647034eb
+    md5: 5fd6022c97d78c252f1cc8d7433e97d0
+    sha256: 960729dd943daff21bf2b1f5a9380c17420c5307d4d250766525e266bd0acca7
   category: main
   optional: false
 - name: re2
-  version: 2023.09.01
+  version: 2024.07.02
   manager: conda
   platform: osx-arm64
   dependencies:
-    libre2-11: 2023.09.01
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.09.01-h4cba328_2.conda
+    libre2-11: 2024.07.02
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-h6589ca4_2.conda
   hash:
-    md5: 0342882197116478a42fa4ea35af79c1
-    sha256: 0e0d44414381c39a7e6f3da442cb41c637df0dcb383a07425f19c19ccffa0118
+    md5: 7a8b4ad8c58a3408ca89d78788c78178
+    sha256: 4d3799c05f8f662922a0acd129d119774760a3281b883603678e128d1cb307fb
   category: main
   optional: false
 - name: readline
@@ -15834,428 +15922,436 @@ package:
   category: main
   optional: false
 - name: referencing
-  version: 0.35.1
+  version: 0.36.2
   manager: conda
   platform: linux-64
   dependencies:
     attrs: '>=22.2.0'
-    python: '>=3.8'
+    python: ''
     rpds-py: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+    typing_extensions: '>=4.4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
   hash:
-    md5: 0fc8b52192a8898627c3efae1003e9f6
-    sha256: be8d6d9e86b1a3fef5424127ff81782f8ca63d3058980859609f6f1ecdd34cb3
+    md5: 9140f1c09dd5489549c6a33931b943c7
+    sha256: e20909f474a6cece176dfc0dc1addac265deb5fa92ea90e975fbca48085b20c3
   category: dev
   optional: true
 - name: referencing
-  version: 0.35.1
+  version: 0.36.2
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.9'
     attrs: '>=22.2.0'
-    python: '>=3.8'
+    typing_extensions: '>=4.4.0'
     rpds-py: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
   hash:
-    md5: 0fc8b52192a8898627c3efae1003e9f6
-    sha256: be8d6d9e86b1a3fef5424127ff81782f8ca63d3058980859609f6f1ecdd34cb3
+    md5: 9140f1c09dd5489549c6a33931b943c7
+    sha256: e20909f474a6cece176dfc0dc1addac265deb5fa92ea90e975fbca48085b20c3
   category: dev
   optional: true
 - name: referencing
-  version: 0.35.1
+  version: 0.36.2
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.9'
     attrs: '>=22.2.0'
-    python: '>=3.8'
+    typing_extensions: '>=4.4.0'
     rpds-py: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
   hash:
-    md5: 0fc8b52192a8898627c3efae1003e9f6
-    sha256: be8d6d9e86b1a3fef5424127ff81782f8ca63d3058980859609f6f1ecdd34cb3
+    md5: 9140f1c09dd5489549c6a33931b943c7
+    sha256: e20909f474a6cece176dfc0dc1addac265deb5fa92ea90e975fbca48085b20c3
   category: dev
   optional: true
 - name: regex
-  version: 2024.5.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/regex-2024.5.15-py312h9a8786e_0.conda
-  hash:
-    md5: d3c8a64188a7331e3df3be6b06d5309e
-    sha256: 4050b3f70bd3ef81ae175acab0dfc2019fde84ab71b6b12903b3eb9bbd35661e
-  category: dev
-  optional: true
-- name: regex
-  version: 2024.5.15
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/regex-2024.5.15-py312hbd25219_0.conda
-  hash:
-    md5: 529f6edec2c5cafa758671f5a50ff3d8
-    sha256: b4439a9eb708c3e36e87cc1bdd336004cc469bb61d1626644eb28d746da74d5c
-  category: dev
-  optional: true
-- name: regex
-  version: 2024.5.15
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2024.5.15-py312h7e5086c_0.conda
-  hash:
-    md5: 32fbee5a1711a9ad21c157f1b9ee6ea3
-    sha256: 7cf8fe1c9c70c0fb9c162dba3a9043319710311bff7fd8ab4c1510337ba8fae0
-  category: dev
-  optional: true
-- name: reproc
-  version: 14.2.4.post0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.4.post0-hd590300_1.conda
-  hash:
-    md5: 82ca53502dfd5a64a80dee76dae14685
-    sha256: bb2e4e0ce93bc61bc7c03c4f66abcb8161b0a4f1c41b5156cf1e5e17892b05d8
-  category: main
-  optional: false
-- name: reproc
-  version: 14.2.4.post0
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/reproc-14.2.4.post0-h10d778d_1.conda
-  hash:
-    md5: d7c3258e871481be5bbaf28b4729e29f
-    sha256: 41c7fb3ef17684c98c1d2c50d0eaba388beed400dbc4cc099a9f31a2819ef594
-  category: main
-  optional: false
-- name: reproc
-  version: 14.2.4.post0
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-14.2.4.post0-h93a5062_1.conda
-  hash:
-    md5: ef7ae6d7bb50c8c735551d825e1ea287
-    sha256: e12534c909613b56c539eed6f4cd55da2eb03086435101fad79c383a9c3df527
-  category: main
-  optional: false
-- name: reproc-cpp
-  version: 14.2.4.post0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    reproc: 14.2.4.post0
-  url: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.4.post0-h59595ed_1.conda
-  hash:
-    md5: 715e1d720ec1a03715bebd237972fca5
-    sha256: 8f0c6852471c0f2b02ab21d7c2877e30fc7f4d7d8034ca90bd9fdc3a22277fe9
-  category: main
-  optional: false
-- name: reproc-cpp
-  version: 14.2.4.post0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    reproc: 14.2.4.post0
-  url: https://conda.anaconda.org/conda-forge/osx-64/reproc-cpp-14.2.4.post0-h93d8f39_1.conda
-  hash:
-    md5: a32e95ada0ee860c91e87266700970c3
-    sha256: dfdf987c7584d61a690a390872f89f968fb25ba44c76a9417f73e09bba1da3bc
-  category: main
-  optional: false
-- name: reproc-cpp
-  version: 14.2.4.post0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    reproc: 14.2.4.post0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.4.post0-h965bd2d_1.conda
-  hash:
-    md5: f81d00496e13ee828f84b3ef17e41346
-    sha256: 83736a55ff9cf3a54591aa44c3ee1181cd570c0a452b8d8a2ab113f3e0b0974b
-  category: main
-  optional: false
-- name: requests
-  version: 2.32.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    certifi: '>=2017.4.17'
-    charset-normalizer: '>=2,<4'
-    idna: '>=2.5,<4'
-    python: '>=3.8'
-    urllib3: '>=1.21.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5ede4753180c7a550a443c430dc8ab52
-    sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
-  category: main
-  optional: false
-- name: requests
-  version: 2.32.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    certifi: '>=2017.4.17'
-    charset-normalizer: '>=2,<4'
-    idna: '>=2.5,<4'
-    python: '>=3.8'
-    urllib3: '>=1.21.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5ede4753180c7a550a443c430dc8ab52
-    sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
-  category: main
-  optional: false
-- name: requests
-  version: 2.32.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    certifi: '>=2017.4.17'
-    charset-normalizer: '>=2,<4'
-    idna: '>=2.5,<4'
-    python: '>=3.8'
-    urllib3: '>=1.21.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5ede4753180c7a550a443c430dc8ab52
-    sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
-  category: main
-  optional: false
-- name: responses
-  version: 0.25.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    pyyaml: ''
-    requests: '>=2.30.0,<3.0'
-    types-pyyaml: ''
-    typing_extensions: ''
-    urllib3: '>=1.25.10,<3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/responses-0.25.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7137d863733da70447de5f18cfca9301
-    sha256: 5fac12ae11b0581b98fe26b34b1e4476ad593205c3fb163e681e453aa93e84ee
-  category: dev
-  optional: true
-- name: responses
-  version: 0.25.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-    pyyaml: ''
-    requests: '>=2.30.0,<3.0'
-    types-pyyaml: ''
-    typing_extensions: ''
-    urllib3: '>=1.25.10,<3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/responses-0.25.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7137d863733da70447de5f18cfca9301
-    sha256: 5fac12ae11b0581b98fe26b34b1e4476ad593205c3fb163e681e453aa93e84ee
-  category: dev
-  optional: true
-- name: responses
-  version: 0.25.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    pyyaml: ''
-    requests: '>=2.30.0,<3.0'
-    types-pyyaml: ''
-    typing_extensions: ''
-    urllib3: '>=1.25.10,<3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/responses-0.25.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7137d863733da70447de5f18cfca9301
-    sha256: 5fac12ae11b0581b98fe26b34b1e4476ad593205c3fb163e681e453aa93e84ee
-  category: dev
-  optional: true
-- name: returns
-  version: 0.23.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9,<4.0'
-    typing_extensions: '>=4.0,<5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/returns-0.23.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 42669dba8c7ed62b79a6621f0eb1d093
-    sha256: 89b7ab848e0e41baaf08e044e12be12cb5606775380c8bb246ba7b01b3b329ab
-  category: main
-  optional: false
-- name: returns
-  version: 0.23.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9,<4.0'
-    typing_extensions: '>=4.0,<5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/returns-0.23.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 42669dba8c7ed62b79a6621f0eb1d093
-    sha256: 89b7ab848e0e41baaf08e044e12be12cb5606775380c8bb246ba7b01b3b329ab
-  category: main
-  optional: false
-- name: returns
-  version: 0.23.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9,<4.0'
-    typing_extensions: '>=4.0,<5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/returns-0.23.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 42669dba8c7ed62b79a6621f0eb1d093
-    sha256: 89b7ab848e0e41baaf08e044e12be12cb5606775380c8bb246ba7b01b3b329ab
-  category: main
-  optional: false
-- name: rfc3339-validator
-  version: 0.1.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: fed45fc5ea0813240707998abe49f520
-    sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
-  category: dev
-  optional: true
-- name: rfc3339-validator
-  version: 0.1.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.5'
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: fed45fc5ea0813240707998abe49f520
-    sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
-  category: dev
-  optional: true
-- name: rfc3339-validator
-  version: 0.1.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: fed45fc5ea0813240707998abe49f520
-    sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
-  category: dev
-  optional: true
-- name: rich
-  version: 13.7.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    markdown-it-py: '>=2.2.0'
-    pygments: '>=2.13.0,<3.0.0'
-    python: '>=3.7.0'
-    typing_extensions: '>=4.0.0,<5.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: ba445bf767ae6f0d959ff2b40c20912b
-    sha256: 2b26d58aa59e46f933c3126367348651b0dab6e0bf88014e857415bb184a4667
-  category: main
-  optional: false
-- name: rich
-  version: 13.7.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    markdown-it-py: '>=2.2.0'
-    pygments: '>=2.13.0,<3.0.0'
-    python: '>=3.7.0'
-    typing_extensions: '>=4.0.0,<5.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: ba445bf767ae6f0d959ff2b40c20912b
-    sha256: 2b26d58aa59e46f933c3126367348651b0dab6e0bf88014e857415bb184a4667
-  category: main
-  optional: false
-- name: rich
-  version: 13.7.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    markdown-it-py: '>=2.2.0'
-    pygments: '>=2.13.0,<3.0.0'
-    python: '>=3.7.0'
-    typing_extensions: '>=4.0.0,<5.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: ba445bf767ae6f0d959ff2b40c20912b
-    sha256: 2b26d58aa59e46f933c3126367348651b0dab6e0bf88014e857415bb184a4667
-  category: main
-  optional: false
-- name: rpds-py
-  version: 0.19.0
+  version: 2024.11.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.19.0-py312hf008fa9_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/regex-2024.11.6-py312h66e93f0_0.conda
   hash:
-    md5: 66ebbe714bafd06ba298a0c6bc2f04ad
-    sha256: 75af7e5a0906ed4856f917020e4b7641dc61d414bcf97b6a4801c0acb1945dcd
+    md5: 647770db979b43f9c9ca25dcfa7dc4e4
+    sha256: fcb5687d3ec5fff580b64b8fb649d9d65c999a91a5c3108a313ecdd2de99f06b
   category: dev
   optional: true
-- name: rpds-py
-  version: 0.19.0
+- name: regex
+  version: 2024.11.6
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.19.0-py312ha47ea1c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/regex-2024.11.6-py312h01d7ebd_0.conda
   hash:
-    md5: d92edd61e8e16a218a821e1cf6d983f9
-    sha256: f952828a1980e2a3d445a9836ac2ac481114d230acf2c2276092d426ad7a3dc0
+    md5: 05befb3ed0af9933089d2a1d495482ff
+    sha256: 315237ccf38ce31f97eff2efecbea22aaed940803933ae234f1e6cb815237128
   category: dev
   optional: true
-- name: rpds-py
-  version: 0.19.0
+- name: regex
+  version: 2024.11.6
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.19.0-py312h552d48e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2024.11.6-py312hea69d52_0.conda
   hash:
-    md5: 17a379a348d6946ffb8c62f31b0f7608
-    sha256: 16bcdedd216724a2e11edede285ea4451d07373d021bc72000cccc2ad38cb187
+    md5: e73cda1f18846b608284bd784f061eac
+    sha256: dcdec32f2c7dd37986baa692bedf9db126ad34e92e5e9b64f707cba3d04d2525
+  category: dev
+  optional: true
+- name: reproc
+  version: 14.2.5.post0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.5.post0-hb9d3cd8_0.conda
+  hash:
+    md5: 69fbc0a9e42eb5fe6733d2d60d818822
+    sha256: a1973f41a6b956f1305f9aaefdf14b2f35a8c9615cfe5f143f1784ed9aa6bf47
+  category: main
+  optional: false
+- name: reproc
+  version: 14.2.5.post0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/reproc-14.2.5.post0-h6e16a3a_0.conda
+  hash:
+    md5: eda18d4a7dce3831016086a482965345
+    sha256: dda2a8bc1bf16b563b74c2a01dccea657bda573b0c45e708bfeee01c208bcbaf
+  category: main
+  optional: false
+- name: reproc
+  version: 14.2.5.post0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-14.2.5.post0-h5505292_0.conda
+  hash:
+    md5: f1d129089830365d9dac932c4dd8c675
+    sha256: a5f0dbfa8099a3d3c281ea21932b6359775fd8ce89acc53877a6ee06f50642bc
+  category: main
+  optional: false
+- name: reproc-cpp
+  version: 14.2.5.post0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    reproc: 14.2.5.post0
+  url: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.5.post0-h5888daf_0.conda
+  hash:
+    md5: 828302fca535f9cfeb598d5f7c204323
+    sha256: 568485837b905b1ea7bdb6e6496d914b83db57feda57f6050d5a694977478691
+  category: main
+  optional: false
+- name: reproc-cpp
+  version: 14.2.5.post0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcxx: '>=18'
+    reproc: 14.2.5.post0
+  url: https://conda.anaconda.org/conda-forge/osx-64/reproc-cpp-14.2.5.post0-h240833e_0.conda
+  hash:
+    md5: 420229341978751bd96faeced92c200e
+    sha256: 4d8638b7f44082302c7687c99079789f42068d34cddc0959c11ad5d28aab3d47
+  category: main
+  optional: false
+- name: reproc-cpp
+  version: 14.2.5.post0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=18'
+    reproc: 14.2.5.post0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.5.post0-h286801f_0.conda
+  hash:
+    md5: 11a3d09937d250fc4423bf28837d9363
+    sha256: f1b6aa9d9131ea159a5883bc5990b91b4b8f56eb52e0dc2b01aa9622e14edc81
+  category: main
+  optional: false
+- name: requests
+  version: 2.32.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    certifi: '>=2017.4.17'
+    charset-normalizer: '>=2,<4'
+    idna: '>=2.5,<4'
+    python: '>=3.9'
+    urllib3: '>=1.21.1,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+  hash:
+    md5: a9b9368f3701a417eac9edbcae7cb737
+    sha256: d701ca1136197aa121bbbe0e8c18db6b5c94acbd041c2b43c70e5ae104e1d8ad
+  category: main
+  optional: false
+- name: requests
+  version: 2.32.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    idna: '>=2.5,<4'
+    certifi: '>=2017.4.17'
+    charset-normalizer: '>=2,<4'
+    urllib3: '>=1.21.1,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+  hash:
+    md5: a9b9368f3701a417eac9edbcae7cb737
+    sha256: d701ca1136197aa121bbbe0e8c18db6b5c94acbd041c2b43c70e5ae104e1d8ad
+  category: main
+  optional: false
+- name: requests
+  version: 2.32.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    idna: '>=2.5,<4'
+    certifi: '>=2017.4.17'
+    charset-normalizer: '>=2,<4'
+    urllib3: '>=1.21.1,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
+  hash:
+    md5: a9b9368f3701a417eac9edbcae7cb737
+    sha256: d701ca1136197aa121bbbe0e8c18db6b5c94acbd041c2b43c70e5ae104e1d8ad
+  category: main
+  optional: false
+- name: responses
+  version: 0.25.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    pyyaml: ''
+    requests: '>=2.30.0,<3.0'
+    types-pyyaml: ''
+    typing_extensions: ''
+    urllib3: '>=1.25.10,<3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/responses-0.25.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: 379df83e5599580b1fee333adaf8196e
+    sha256: 27cc365d9aa9f340422907058001a703de95601000dcea03276d1a86be36ff77
+  category: dev
+  optional: true
+- name: responses
+  version: 0.25.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pyyaml: ''
+    typing_extensions: ''
+    types-pyyaml: ''
+    python: '>=3.9'
+    requests: '>=2.30.0,<3.0'
+    urllib3: '>=1.25.10,<3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/responses-0.25.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: 379df83e5599580b1fee333adaf8196e
+    sha256: 27cc365d9aa9f340422907058001a703de95601000dcea03276d1a86be36ff77
+  category: dev
+  optional: true
+- name: responses
+  version: 0.25.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pyyaml: ''
+    typing_extensions: ''
+    types-pyyaml: ''
+    python: '>=3.9'
+    requests: '>=2.30.0,<3.0'
+    urllib3: '>=1.25.10,<3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/responses-0.25.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: 379df83e5599580b1fee333adaf8196e
+    sha256: 27cc365d9aa9f340422907058001a703de95601000dcea03276d1a86be36ff77
+  category: dev
+  optional: true
+- name: returns
+  version: 0.24.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.10'
+    typing_extensions: '>=4.0,<5.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/returns-0.24.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 986a872617ae09c82cb75b73b538f60a
+    sha256: 0a95ea720c533ea01b859624aac6cdf78038341df1576bf5e7b4f3044d67c746
+  category: main
+  optional: false
+- name: returns
+  version: 0.24.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.10'
+    typing_extensions: '>=4.0,<5.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/returns-0.24.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 986a872617ae09c82cb75b73b538f60a
+    sha256: 0a95ea720c533ea01b859624aac6cdf78038341df1576bf5e7b4f3044d67c746
+  category: main
+  optional: false
+- name: returns
+  version: 0.24.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.10'
+    typing_extensions: '>=4.0,<5.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/returns-0.24.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 986a872617ae09c82cb75b73b538f60a
+    sha256: 0a95ea720c533ea01b859624aac6cdf78038341df1576bf5e7b4f3044d67c746
+  category: main
+  optional: false
+- name: rfc3339-validator
+  version: 0.1.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: 36de09a8d3e5d5e6f4ee63af49e59706
+    sha256: 2e4372f600490a6e0b3bac60717278448e323cab1c0fecd5f43f7c56535a99c5
+  category: dev
+  optional: true
+- name: rfc3339-validator
+  version: 0.1.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    six: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: 36de09a8d3e5d5e6f4ee63af49e59706
+    sha256: 2e4372f600490a6e0b3bac60717278448e323cab1c0fecd5f43f7c56535a99c5
+  category: dev
+  optional: true
+- name: rfc3339-validator
+  version: 0.1.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    six: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: 36de09a8d3e5d5e6f4ee63af49e59706
+    sha256: 2e4372f600490a6e0b3bac60717278448e323cab1c0fecd5f43f7c56535a99c5
+  category: dev
+  optional: true
+- name: rich
+  version: 13.9.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    markdown-it-py: '>=2.2.0'
+    pygments: '>=2.13.0,<3.0.0'
+    python: '>=3.9'
+    typing_extensions: '>=4.0.0,<5.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: 7aed65d4ff222bfb7335997aa40b7da5
+    sha256: 06a760c5ae572e72e865d5a87e9fe3cc171e1a9c996e63daf3db52ff1a0b4457
+  category: main
+  optional: false
+- name: rich
+  version: 13.9.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    typing_extensions: '>=4.0.0,<5.0.0'
+    pygments: '>=2.13.0,<3.0.0'
+    markdown-it-py: '>=2.2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: 7aed65d4ff222bfb7335997aa40b7da5
+    sha256: 06a760c5ae572e72e865d5a87e9fe3cc171e1a9c996e63daf3db52ff1a0b4457
+  category: main
+  optional: false
+- name: rich
+  version: 13.9.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    typing_extensions: '>=4.0.0,<5.0.0'
+    pygments: '>=2.13.0,<3.0.0'
+    markdown-it-py: '>=2.2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
+  hash:
+    md5: 7aed65d4ff222bfb7335997aa40b7da5
+    sha256: 06a760c5ae572e72e865d5a87e9fe3cc171e1a9c996e63daf3db52ff1a0b4457
+  category: main
+  optional: false
+- name: rpds-py
+  version: 0.22.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.22.3-py312h12e396e_0.conda
+  hash:
+    md5: bfb49da0cc9098597d527def04d66f8b
+    sha256: e8662d21ca3c912ac8941725392b838a29458b106ef22d9489cdf0f8de145fad
+  category: dev
+  optional: true
+- name: rpds-py
+  version: 0.22.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.22.3-py312h0d0de52_0.conda
+  hash:
+    md5: 7d02722a6793508593338f5ecba60d09
+    sha256: d3afcb6988079b6534675fb5c0c269766daf35c90a28ff84867d8c79a67bebdc
+  category: dev
+  optional: true
+- name: rpds-py
+  version: 0.22.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.22.3-py312hcd83bfe_0.conda
+  hash:
+    md5: 2f7c4d01946fa2ce73d7ef3eeb041877
+    sha256: 0a8b50bf22400004a706ba160d7cb31f82b8d8c328a59aec73a9e0d3372d1964
   category: dev
   optional: true
 - name: rsa
@@ -16264,11 +16360,11 @@ package:
   platform: linux-64
   dependencies:
     pyasn1: '>=0.1.3'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_1.conda
   hash:
-    md5: 03bf410858b2cefc267316408a77c436
-    sha256: 23214cdc15a41d14136754857fd9cd46ca3c55a7e751da3b3a48c673f0ee2a57
+    md5: 91def14612d11100329d53a75993a4d5
+    sha256: 210ff0e3aaa8ce8e9d45a5fd578ce7b2d5bcd7d3054dc779c3a159b8f72104d6
   category: dev
   optional: true
 - name: rsa
@@ -16276,12 +16372,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.9'
     pyasn1: '>=0.1.3'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_1.conda
   hash:
-    md5: 03bf410858b2cefc267316408a77c436
-    sha256: 23214cdc15a41d14136754857fd9cd46ca3c55a7e751da3b3a48c673f0ee2a57
+    md5: 91def14612d11100329d53a75993a4d5
+    sha256: 210ff0e3aaa8ce8e9d45a5fd578ce7b2d5bcd7d3054dc779c3a159b8f72104d6
   category: dev
   optional: true
 - name: rsa
@@ -16289,55 +16385,58 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.9'
     pyasn1: '>=0.1.3'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_1.conda
   hash:
-    md5: 03bf410858b2cefc267316408a77c436
-    sha256: 23214cdc15a41d14136754857fd9cd46ca3c55a7e751da3b3a48c673f0ee2a57
+    md5: 91def14612d11100329d53a75993a4d5
+    sha256: 210ff0e3aaa8ce8e9d45a5fd578ce7b2d5bcd7d3054dc779c3a159b8f72104d6
   category: dev
   optional: true
 - name: ruamel.yaml
-  version: 0.18.6
+  version: 0.18.10
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     ruamel.yaml.clib: '>=0.1.2'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.6-py312h98912ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.10-py312h66e93f0_0.conda
   hash:
-    md5: a99a06a875138829ef65f44bbe2c30ca
-    sha256: 26856daba883254736b7f3767c08f445b5d010eebbf4fc7aa384ee80e24aa663
+    md5: 5260b7fb19694ee5bc4ed0ee7a2a769f
+    sha256: cd8ed10671111f15245cebadc06b88d6f5fc91f1f7f92456daa568e9d9f5bc42
   category: main
   optional: false
 - name: ruamel.yaml
-  version: 0.18.6
+  version: 0.18.10
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     ruamel.yaml.clib: '>=0.1.2'
-  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.6-py312h41838bb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.10-py312h01d7ebd_0.conda
   hash:
-    md5: 9db93e711729ec70dacdfa58bf970cfd
-    sha256: 27ab446d39a46f7db365265a48ce74929c672e14c86b1ce8955f59e2d92dff39
+    md5: e6fb89d650ea648b6be3bf2fa5026523
+    sha256: 1d4ce5cfa530c3971b95a41fa1b1a952cd934f2ed1f34ac22736eece17727ab2
   category: main
   optional: false
 - name: ruamel.yaml
-  version: 0.18.6
+  version: 0.18.10
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     ruamel.yaml.clib: '>=0.1.2'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.6-py312he37b823_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.10-py312hea69d52_0.conda
   hash:
-    md5: cb9f9b4797001b2c52383f4007fa1f4b
-    sha256: 4a27b50445842e97a31e3f412816d4a0d576b4f1ee327b9a892a183ba5c60f6f
+    md5: 29a66b19662a643786715a8885c645d0
+    sha256: bb946732dec6943a56650d2690e37d7eed0fc7ffb9d616ae09000b52894f8baf
   category: main
   optional: false
 - name: ruamel.yaml.clib
@@ -16345,13 +16444,14 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py312h98912ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py312h66e93f0_1.conda
   hash:
-    md5: 05f31c2a79ba61df8d6d903ce4a4ce7b
-    sha256: 5965302881d8b1049291e3ba3912286cdc72cb82303230cbbf0a048c6f6dd7c1
+    md5: 532c3e5d0280be4fea52396ec1fa7d5d
+    sha256: ac987b1c186d79e4e1ce4354a84724fc68db452b2bd61de3a3e1b6fc7c26138d
   category: main
   optional: false
 - name: ruamel.yaml.clib
@@ -16359,12 +16459,13 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py312h41838bb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py312h3d0f464_1.conda
   hash:
-    md5: a134bf1778eb7add92ea760e801dc245
-    sha256: c0a321d14505b3621d6301e1ed9bc0129b4c8b2812e7520040d2609aaeb07845
+    md5: f4c0464f98dabcd65064e89991c3c9c2
+    sha256: b5ddb73db7ca3d4d8780af1761efb97a5f555ae489f287a91367624d4425f498
   category: main
   optional: false
 - name: ruamel.yaml.clib
@@ -16372,109 +16473,111 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.8-py312he37b823_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.8-py312h0bf5046_1.conda
   hash:
-    md5: 2fa02324046cfcb7a67fae30fd06a945
-    sha256: c3138824f484cca2804d22758c75965b578cd35b35243ff02e64da06bda03477
+    md5: 2ed5f254c9ea57b6d0fd4e12baa4b87f
+    sha256: ce979a9bcb4b987e30c4aadfbd4151006cd6ac480bdbee1d059e6f0186b48bca
   category: main
   optional: false
 - name: s2n
-  version: 1.4.17
+  version: 1.5.7
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.17-he19d79f_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.7-hd3e8b83_0.conda
   hash:
-    md5: e25ac9bf10f8e6aa67727b1cdbe762ef
-    sha256: 6d1aa582964771a6cf47d120e2c5cdc700fe3744101cd5660af1eb81d47d689a
+    md5: b0de6ca344b9255f4adb98e419e130ad
+    sha256: faf555b03adea3b5f9affb2307c8324deab88d0be7dd3ca14704dd018905d0d6
   category: main
   optional: false
 - name: s3fs
-  version: 2024.6.1
+  version: 2024.12.0
   manager: conda
   platform: linux-64
   dependencies:
     aiobotocore: '>=2.5.4,<3.0.0'
     aiohttp: ''
-    fsspec: 2024.6.1
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.6.1-pyhd8ed1ab_0.conda
+    fsspec: 2024.12.0
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.12.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2120af180562f945c3fccc39972023da
-    sha256: ce9c6c147b0ad563f3decdb11381a8784b297da0a75d3b6c0ea1fd016df4be6a
+    md5: d91e140ebbb494372695d7b5ac829c09
+    sha256: e231ad3a9172af66c3ff984e7dd06e9fde4c898f2930f2c8043e5d7b641485a2
   category: main
   optional: false
 - name: s3fs
-  version: 2024.6.1
+  version: 2024.12.0
   manager: conda
   platform: osx-64
   dependencies:
-    aiobotocore: '>=2.5.4,<3.0.0'
     aiohttp: ''
-    fsspec: 2024.6.1
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.6.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    aiobotocore: '>=2.5.4,<3.0.0'
+    fsspec: 2024.12.0
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.12.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2120af180562f945c3fccc39972023da
-    sha256: ce9c6c147b0ad563f3decdb11381a8784b297da0a75d3b6c0ea1fd016df4be6a
+    md5: d91e140ebbb494372695d7b5ac829c09
+    sha256: e231ad3a9172af66c3ff984e7dd06e9fde4c898f2930f2c8043e5d7b641485a2
   category: main
   optional: false
 - name: s3fs
-  version: 2024.6.1
+  version: 2024.12.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    aiobotocore: '>=2.5.4,<3.0.0'
     aiohttp: ''
-    fsspec: 2024.6.1
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.6.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    aiobotocore: '>=2.5.4,<3.0.0'
+    fsspec: 2024.12.0
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.12.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2120af180562f945c3fccc39972023da
-    sha256: ce9c6c147b0ad563f3decdb11381a8784b297da0a75d3b6c0ea1fd016df4be6a
+    md5: d91e140ebbb494372695d7b5ac829c09
+    sha256: e231ad3a9172af66c3ff984e7dd06e9fde4c898f2930f2c8043e5d7b641485a2
   category: main
   optional: false
 - name: s3transfer
-  version: 0.10.2
+  version: 0.11.2
   manager: conda
   platform: linux-64
   dependencies:
-    botocore: '>=1.33.2,<2.0a.0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
+    botocore: '>=1.36.0,<2.0a.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.11.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 80f00f9033aee2358171207746e09ea0
-    sha256: aea88a1be4be3d71ebb4c10ecdadcfa852115e9071c36c063fa315319fb25cae
+    md5: ec4579a36a8c7082f28090b860b623f6
+    sha256: fdc3c7853ceca4979f83a8943cab79c89642365cea46113243555bbe98ae13cb
   category: main
   optional: false
 - name: s3transfer
-  version: 0.10.2
+  version: 0.11.2
   manager: conda
   platform: osx-64
   dependencies:
-    botocore: '>=1.33.2,<2.0a.0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    botocore: '>=1.36.0,<2.0a.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.11.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 80f00f9033aee2358171207746e09ea0
-    sha256: aea88a1be4be3d71ebb4c10ecdadcfa852115e9071c36c063fa315319fb25cae
+    md5: ec4579a36a8c7082f28090b860b623f6
+    sha256: fdc3c7853ceca4979f83a8943cab79c89642365cea46113243555bbe98ae13cb
   category: main
   optional: false
 - name: s3transfer
-  version: 0.10.2
+  version: 0.11.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    botocore: '>=1.33.2,<2.0a.0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    botocore: '>=1.36.0,<2.0a.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.11.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 80f00f9033aee2358171207746e09ea0
-    sha256: aea88a1be4be3d71ebb4c10ecdadcfa852115e9071c36c063fa315319fb25cae
+    md5: ec4579a36a8c7082f28090b860b623f6
+    sha256: fdc3c7853ceca4979f83a8943cab79c89642365cea46113243555bbe98ae13cb
   category: main
   optional: false
 - name: sarif-om
@@ -16484,11 +16587,11 @@ package:
   dependencies:
     attrs: ''
     pbr: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/sarif-om-1.0.4-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/sarif-om-1.0.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 010e6280a9dc265d0488b598c45103d9
-    sha256: 02e18825ab15654d6555aa2d78c396e726e200e398691bd0bce3b810205e28df
+    md5: 6c4dcc5be71a1ff181eab2031c5d2a9d
+    sha256: 6b959a918f2f33c9e66e0cd88db722ffedcbb94f9be44329dbbb6a439ba658c6
   category: dev
   optional: true
 - name: sarif-om
@@ -16498,11 +16601,11 @@ package:
   dependencies:
     attrs: ''
     pbr: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/sarif-om-1.0.4-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/sarif-om-1.0.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 010e6280a9dc265d0488b598c45103d9
-    sha256: 02e18825ab15654d6555aa2d78c396e726e200e398691bd0bce3b810205e28df
+    md5: 6c4dcc5be71a1ff181eab2031c5d2a9d
+    sha256: 6b959a918f2f33c9e66e0cd88db722ffedcbb94f9be44329dbbb6a439ba658c6
   category: dev
   optional: true
 - name: sarif-om
@@ -16512,11 +16615,11 @@ package:
   dependencies:
     attrs: ''
     pbr: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/sarif-om-1.0.4-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/sarif-om-1.0.4-pyhd8ed1ab_1.conda
   hash:
-    md5: 010e6280a9dc265d0488b598c45103d9
-    sha256: 02e18825ab15654d6555aa2d78c396e726e200e398691bd0bce3b810205e28df
+    md5: 6c4dcc5be71a1ff181eab2031c5d2a9d
+    sha256: 6b959a918f2f33c9e66e0cd88db722ffedcbb94f9be44329dbbb6a439ba658c6
   category: dev
   optional: true
 - name: scalene
@@ -16583,127 +16686,128 @@ package:
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.5.1
+  version: 1.6.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
     joblib: '>=1.2.0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
     numpy: '>=1.19,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     scipy: ''
     threadpoolctl: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.1-py312h775a589_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.6.1-py312h7a48858_0.conda
   hash:
-    md5: bd8c79ccb9498336cbb174cf0151024a
-    sha256: cf9735937209d01febf1f912559e28dc3bb753906460e5b85dc24f0d57a78d96
+    md5: 102727f71df02a51e9e173f2e6f87d57
+    sha256: 7c869c73c95ef09edef839448ae3d153c4e3a208fb110c4260225f342d23e08e
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.5.1
+  version: 1.6.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     joblib: '>=1.2.0'
-    libcxx: '>=16'
-    llvm-openmp: '>=16.0.6'
+    libcxx: '>=18'
+    llvm-openmp: '>=18.1.8'
     numpy: '>=1.19,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     scipy: ''
     threadpoolctl: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.5.1-py312hc214ba5_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.6.1-py312he1a5313_0.conda
   hash:
-    md5: 32625e0f29884a4704070c07a25edf94
-    sha256: 62a33e1266c9e2e99e5bb68127160e04a592b62e553faa4f6ad2df264b9654f0
+    md5: c177b3800953875a115ecba027a66d63
+    sha256: dcdb37893344a321442ce97fd37a5d45b2c6d93a6638fb6e876c638284088d2c
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.5.1
+  version: 1.6.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     joblib: '>=1.2.0'
-    libcxx: '>=16'
-    llvm-openmp: '>=16.0.6'
+    libcxx: '>=18'
+    llvm-openmp: '>=18.1.8'
     numpy: '>=1.19,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     scipy: ''
     threadpoolctl: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.5.1-py312h1b546db_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.6.1-py312h39203ce_0.conda
   hash:
-    md5: e9448f28dfa360ab849f89319fc145f4
-    sha256: 84dbdad6be17824cc188cd9f80d13707bb6e75afb64444476269b06643526225
+    md5: 3d38707ed1991a65dd165c5460d7f3a2
+    sha256: 63e7751b861b5d8a6bfe32a58e67b446b8235f8768e860db955b394e4c7a9edc
   category: main
   optional: false
 - name: scipy
-  version: 1.14.0
+  version: 1.15.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
+    libgcc: '>=13'
+    libgfortran: ''
+    libgfortran5: '>=13.3.0'
     liblapack: '>=3.9.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.19,<3'
+    libstdcxx: '>=13'
+    numpy: '>=1.23.5'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py312hc2bc53b_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.1-py312h180e4f1_0.conda
   hash:
-    md5: eae80145f63aa04a02dda456d4883b46
-    sha256: 6bd24bc823863bb568ffe0ebdfb506d4413d94d15b478b12a0b223d9373f531e
+    md5: 355bcf0f629159c9bd10a406cd8b6c3a
+    sha256: 2c5c2ef30a1e540fc71a6c27fa773f47567c4d40889f7e8d6bdb7756ffc2aae8
   category: main
   optional: false
 - name: scipy
-  version: 1.14.0
+  version: 1.15.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
-    libcxx: '>=16'
+    libcxx: '>=18'
     libgfortran: 5.*
     libgfortran5: '>=13.2.0'
     liblapack: '>=3.9.0,<4.0a0'
-    numpy: '>=1.19,<3'
+    numpy: '>=1.23.5'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.0-py312hb9702fa_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.15.1-py312hb4e66ee_0.conda
   hash:
-    md5: 9899db3cf8965c3aecab3daf5227d3eb
-    sha256: 259651aa3966f9735aab2b3ee9c25d4fa93914484e9b757c0b6fda87bac78a0f
+    md5: 161c7826e391a443805c68d034333de0
+    sha256: 9e9ca1a9633f85e67164a93b3da18e9f4f3b7d0c501e35d5635e0012ccde6e69
   category: main
   optional: false
 - name: scipy
-  version: 1.14.0
+  version: 1.15.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
-    libcxx: '>=16'
+    libcxx: '>=18'
     libgfortran: 5.*
     libgfortran5: '>=13.2.0'
     liblapack: '>=3.9.0,<4.0a0'
-    numpy: '>=1.19,<3'
+    numpy: '>=1.23.5'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.0-py312h14ffa8f_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.15.1-py312hb7ffdcd_0.conda
   hash:
-    md5: 6c8c8842ce810d963e032c6595153ef5
-    sha256: f07e8b093a3ee2990b373a3764a66a07af52be37a54c56040d9a30bcc68a3050
+    md5: a914a657e33833c5c708861bcdd6c5e8
+    sha256: a78228fee262bc62927f75e54020953fab9aff34a349730fcbc9e9388ff7dd94
   category: main
   optional: false
 - name: secretstorage
@@ -16714,97 +16818,97 @@ package:
     cryptography: ''
     dbus: ''
     jeepney: '>=0.6'
-    python: '>=3.12.0rc3,<3.13.0a0'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py312h7900ff3_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py312h7900ff3_3.conda
   hash:
-    md5: 39067833cbb620066d492f8bd6f11dbf
-    sha256: 0479e3f8c8e90049a6d92d4c7e67916c6d6cdafd11a1a31c54c785cce44aeb20
+    md5: 4840da9db2808db946a0d979603c6de4
+    sha256: c6d5d0bc7fb6cbfa3b8be8f2399a3c1308b3392a4e20bd1a0f29a828fda5ab20
   category: main
   optional: false
 - name: setuptools
-  version: 70.2.0
+  version: 75.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.2.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
   hash:
-    md5: 10170a48c48cfe65eab923f76f982087
-    sha256: 354781a1ce4f8f229bf4a19fe48550d5f73d5b511df78a07b1b78fb2c78e52ad
+    md5: 8f28e299c11afdd79e0ec1e279dcdc52
+    sha256: e0778e4f276e9a81b51c56f51ec22a27b4d8fc955abc0be77ad09ca9bea06bb9
   category: main
   optional: false
 - name: setuptools
-  version: 70.2.0
+  version: 75.8.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.2.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
   hash:
-    md5: 10170a48c48cfe65eab923f76f982087
-    sha256: 354781a1ce4f8f229bf4a19fe48550d5f73d5b511df78a07b1b78fb2c78e52ad
+    md5: 8f28e299c11afdd79e0ec1e279dcdc52
+    sha256: e0778e4f276e9a81b51c56f51ec22a27b4d8fc955abc0be77ad09ca9bea06bb9
   category: main
   optional: false
 - name: setuptools
-  version: 70.2.0
+  version: 75.8.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.2.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.0-pyhff2d567_0.conda
   hash:
-    md5: 10170a48c48cfe65eab923f76f982087
-    sha256: 354781a1ce4f8f229bf4a19fe48550d5f73d5b511df78a07b1b78fb2c78e52ad
+    md5: 8f28e299c11afdd79e0ec1e279dcdc52
+    sha256: e0778e4f276e9a81b51c56f51ec22a27b4d8fc955abc0be77ad09ca9bea06bb9
   category: main
   optional: false
 - name: shapely
-  version: 2.0.4
+  version: 2.0.7
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    geos: '>=3.12.2,<3.12.3.0a0'
-    libgcc-ng: '>=12'
+    geos: '>=3.13.0,<3.13.1.0a0'
+    libgcc: '>=13'
     numpy: '>=1.19,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.4-py312h8413631_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.7-py312h391bc85_0.conda
   hash:
-    md5: d5e52d9b72a86920926ca5fd8fec7394
-    sha256: 9f790057c29af8f4f15ca75eaee62c8cc3ac1563f2ce3842704160aa9b609f44
+    md5: 3491bd7e78aa7407c965312c4a5a9254
+    sha256: 424f0e237d6d59f9c027445d6022ca65960ffeea41adc6b52d8460ea1962fee1
   category: main
   optional: false
 - name: shapely
-  version: 2.0.4
+  version: 2.0.7
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    geos: '>=3.12.2,<3.12.3.0a0'
+    geos: '>=3.13.0,<3.13.1.0a0'
     numpy: '>=1.19,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.4-py312h594820c_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.7-py312hfb9f375_0.conda
   hash:
-    md5: e13fa66eb9191a1594a9119ebf8a729f
-    sha256: f012554e11f332d4b2f69211a93906ff5086c89b5494396a0b819ff4fee9240e
+    md5: 1b2d5fb0f7da7c64cd4afd5613a04ce1
+    sha256: 6dc53e1ce0b54a3a9cb4bab405488774250f0712dcf91eeb377e3ed68096bb52
   category: main
   optional: false
 - name: shapely
-  version: 2.0.4
+  version: 2.0.7
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    geos: '>=3.12.2,<3.12.3.0a0'
+    geos: '>=3.13.0,<3.13.1.0a0'
     numpy: '>=1.19,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.4-py312hbab3d11_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.7-py312ha6455e5_0.conda
   hash:
-    md5: a22715c4d2be23fc62b336c1cc27d04d
-    sha256: d7335c65a24ae524d8b99c3d42c692ec4578cfe5344ab4ec885f2d1ce3379769
+    md5: fe6dc4f29cf78ea0d68946c18a44ec24
+    sha256: 1e4712903ba44aac06eb24f2f374424737578ea3270199cd1dccad5902462330
   category: main
   optional: false
 - name: shellcheck
@@ -16847,11 +16951,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
   hash:
-    md5: d08db09a552699ee9e7eec56b4eb3899
-    sha256: 3c49a0a101c41b7cf6ac05a1872d7a1f91f1b6d02eecb4a36b605a19517862bb
+    md5: 7c3c2a0f3ebdea2bbc35538d162b43bf
+    sha256: 0557c090913aa63cdbe821dbdfa038a321b488e22bc80196c4b3b1aace4914ef
   category: main
   optional: false
 - name: shellingham
@@ -16859,11 +16963,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
   hash:
-    md5: d08db09a552699ee9e7eec56b4eb3899
-    sha256: 3c49a0a101c41b7cf6ac05a1872d7a1f91f1b6d02eecb4a36b605a19517862bb
+    md5: 7c3c2a0f3ebdea2bbc35538d162b43bf
+    sha256: 0557c090913aa63cdbe821dbdfa038a321b488e22bc80196c4b3b1aace4914ef
   category: main
   optional: false
 - name: shellingham
@@ -16871,514 +16975,508 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
   hash:
-    md5: d08db09a552699ee9e7eec56b4eb3899
-    sha256: 3c49a0a101c41b7cf6ac05a1872d7a1f91f1b6d02eecb4a36b605a19517862bb
+    md5: 7c3c2a0f3ebdea2bbc35538d162b43bf
+    sha256: 0557c090913aa63cdbe821dbdfa038a321b488e22bc80196c4b3b1aace4914ef
   category: main
   optional: false
-- name: six
-  version: 1.16.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-  hash:
-    md5: e5f25f8dbc060e9a8d912e432202afc2
-    sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
-  category: main
-  optional: false
-- name: six
-  version: 1.16.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-  hash:
-    md5: e5f25f8dbc060e9a8d912e432202afc2
-    sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
-  category: main
-  optional: false
-- name: six
-  version: 1.16.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-  hash:
-    md5: e5f25f8dbc060e9a8d912e432202afc2
-    sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
-  category: main
-  optional: false
-- name: smmap
-  version: 5.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 62f26a3d1387acee31322208f0cfa3e0
-    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  category: main
-  optional: false
-- name: smmap
-  version: 5.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 62f26a3d1387acee31322208f0cfa3e0
-    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  category: main
-  optional: false
-- name: smmap
-  version: 5.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 62f26a3d1387acee31322208f0cfa3e0
-    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  category: main
-  optional: false
-- name: snappy
-  version: 1.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
-  hash:
-    md5: 6b7dcc7349efd123d493d2dbe85a045f
-    sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
-  category: main
-  optional: false
-- name: snappy
-  version: 1.2.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
-  hash:
-    md5: ddceef5df973c8ff7d6b32353c0cb358
-    sha256: a979319cd4916f0e7450aa92bb3cf4c2518afa80be50de99f31d075e693a6dd9
-  category: main
-  optional: false
-- name: snappy
-  version: 1.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
-  hash:
-    md5: 69d0f9694f3294418ee935da3d5f7272
-    sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
-  category: main
-  optional: false
-- name: snuggs
-  version: 1.4.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    numpy: ''
-    pyparsing: '>=2.1.6'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
-  hash:
-    md5: cb83a3d6ecf73f50117635192414426a
-    sha256: ebb8f5f9e362f186fb7d732e656f85c969b86309494436eba51cc3b8b96683f7
-  category: dev
-  optional: true
-- name: snuggs
-  version: 1.4.7
-  manager: conda
-  platform: osx-64
-  dependencies:
-    numpy: ''
-    pyparsing: '>=2.1.6'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
-  hash:
-    md5: cb83a3d6ecf73f50117635192414426a
-    sha256: ebb8f5f9e362f186fb7d732e656f85c969b86309494436eba51cc3b8b96683f7
-  category: dev
-  optional: true
-- name: snuggs
-  version: 1.4.7
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    numpy: ''
-    pyparsing: '>=2.1.6'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
-  hash:
-    md5: cb83a3d6ecf73f50117635192414426a
-    sha256: ebb8f5f9e362f186fb7d732e656f85c969b86309494436eba51cc3b8b96683f7
-  category: dev
-  optional: true
-- name: spdlog
-  version: 1.13.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    fmt: '>=10.2.1,<11.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.13.0-hd2e6256_0.conda
-  hash:
-    md5: 18f9348f064632785d54dbd1db9344bb
-    sha256: 2027b971e83a9c9d292c12880269fe08e782fe9b15b93b5a3ddc8697116e6750
-  category: main
-  optional: false
-- name: spdlog
-  version: 1.13.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    fmt: '>=10.2.1,<11.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.13.0-h1a4aec9_0.conda
-  hash:
-    md5: 2288eabc17f9fec9b64dac2cfe07b8ac
-    sha256: 2f1a981d8d1e06511081ef10068c083965bf1ea0fe7546f8a5f1e37a2982110a
-  category: main
-  optional: false
-- name: spdlog
-  version: 1.13.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    fmt: '>=10.2.1,<11.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.13.0-h5fcca99_0.conda
-  hash:
-    md5: 1907a70a6494b95f3961417e7a9564d2
-    sha256: 161ad4bb6de140ca00024dd5004b4ab99189767df7f83362d6c252c03213e29a
-  category: main
-  optional: false
-- name: sqlite
-  version: 3.46.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libsqlite: 3.46.0
-    libzlib: '>=1.2.13,<2.0a0'
-    ncurses: '>=6.5,<7.0a0'
-    readline: '>=8.2,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.46.0-h6d4b2fc_0.conda
-  hash:
-    md5: 77ea8dff5cf8550cc8f5629a6af56323
-    sha256: e849d576e52bf3e6fc5786f89b7d76978f2e2438587826c95570324cb572e52b
-  category: main
-  optional: false
-- name: sqlite
-  version: 3.46.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libsqlite: 3.46.0
-    libzlib: '>=1.2.13,<2.0a0'
-    ncurses: '>=6.5,<7.0a0'
-    readline: '>=8.2,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.46.0-h28673e1_0.conda
-  hash:
-    md5: b76e50276ebb3131cb84aac8123ca75d
-    sha256: 7d868d34348615450c43cb4737b44987a0e45fdf4759502b323494dc8c931409
-  category: main
-  optional: false
-- name: sqlite
-  version: 3.46.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libsqlite: 3.46.0
-    libzlib: '>=1.2.13,<2.0a0'
-    ncurses: '>=6.5,<7.0a0'
-    readline: '>=8.2,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.46.0-h5838104_0.conda
-  hash:
-    md5: 05c5dc8cd793dcfc5849d0569da9b175
-    sha256: e13b719f70b3a20f40b59f814d32483ae8cd95fef83224127b10091828026f7d
-  category: main
-  optional: false
-- name: sshpubkeys
-  version: 3.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cryptography: '>=2.1.4'
-    ecdsa: '>=0.13'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/sshpubkeys-3.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b8359fec314d52ccb52b59d47cd2c2c0
-    sha256: d19ddc51a4e0c09172f3d70a4f75d2b7f67a9b0204eb25ae586e94830ffe4b44
-  category: dev
-  optional: true
-- name: sshpubkeys
-  version: 3.3.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    cryptography: '>=2.1.4'
-    ecdsa: '>=0.13'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/sshpubkeys-3.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b8359fec314d52ccb52b59d47cd2c2c0
-    sha256: d19ddc51a4e0c09172f3d70a4f75d2b7f67a9b0204eb25ae586e94830ffe4b44
-  category: dev
-  optional: true
-- name: sshpubkeys
-  version: 3.3.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    cryptography: '>=2.1.4'
-    ecdsa: '>=0.13'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/sshpubkeys-3.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b8359fec314d52ccb52b59d47cd2c2c0
-    sha256: d19ddc51a4e0c09172f3d70a4f75d2b7f67a9b0204eb25ae586e94830ffe4b44
-  category: dev
-  optional: true
-- name: stack_data
-  version: 0.6.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    asttokens: ''
-    executing: ''
-    pure_eval: ''
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e7df0fdd404616638df5ece6e69ba7af
-    sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-  category: dev
-  optional: true
-- name: stack_data
-  version: 0.6.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    asttokens: ''
-    executing: ''
-    pure_eval: ''
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e7df0fdd404616638df5ece6e69ba7af
-    sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-  category: dev
-  optional: true
-- name: stack_data
-  version: 0.6.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    asttokens: ''
-    executing: ''
-    pure_eval: ''
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e7df0fdd404616638df5ece6e69ba7af
-    sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-  category: dev
-  optional: true
-- name: sympy
-  version: 1.12.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-    gmpy2: '>=2.0.8'
-    mpmath: '>=0.19'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12.1-pypyh2585a3b_103.conda
-  hash:
-    md5: 4af9db19148140eb2ff3b2a93697063b
-    sha256: a365a6d6f47953cd1fe8be234c2d51b1ac6990a288865126cf32197b3f256a15
-  category: dev
-  optional: true
-- name: sympy
-  version: 1.12.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __unix: ''
-    gmpy2: '>=2.0.8'
-    mpmath: '>=0.19'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12.1-pypyh2585a3b_103.conda
-  hash:
-    md5: 4af9db19148140eb2ff3b2a93697063b
-    sha256: a365a6d6f47953cd1fe8be234c2d51b1ac6990a288865126cf32197b3f256a15
-  category: dev
-  optional: true
-- name: sympy
-  version: 1.12.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: ''
-    gmpy2: '>=2.0.8'
-    mpmath: '>=0.19'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12.1-pypyh2585a3b_103.conda
-  hash:
-    md5: 4af9db19148140eb2ff3b2a93697063b
-    sha256: a365a6d6f47953cd1fe8be234c2d51b1ac6990a288865126cf32197b3f256a15
-  category: dev
-  optional: true
-- name: threadpoolctl
-  version: 3.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
-  hash:
-    md5: df68d78237980a159bd7149f33c0e8fd
-    sha256: 45e402941f6bed094022c5726a2ca494e6224b85180d2367fb6ddd9aea68079d
-  category: main
-  optional: false
-- name: threadpoolctl
-  version: 3.5.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
-  hash:
-    md5: df68d78237980a159bd7149f33c0e8fd
-    sha256: 45e402941f6bed094022c5726a2ca494e6224b85180d2367fb6ddd9aea68079d
-  category: main
-  optional: false
-- name: threadpoolctl
-  version: 3.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
-  hash:
-    md5: df68d78237980a159bd7149f33c0e8fd
-    sha256: 45e402941f6bed094022c5726a2ca494e6224b85180d2367fb6ddd9aea68079d
-  category: main
-  optional: false
-- name: tiledb
-  version: 2.24.2
+- name: simdjson
+  version: 3.11.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-crt-cpp: '>=0.27.2,<0.27.3.0a0'
-    aws-sdk-cpp: '>=1.11.329,<1.11.330.0a0'
-    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
-    azure-identity-cpp: '>=1.8.0,<1.8.1.0a0'
-    azure-storage-blobs-cpp: '>=12.11.0,<12.11.1.0a0'
-    azure-storage-common-cpp: '>=12.6.0,<12.6.1.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    fmt: '>=10.2.1,<11.0a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libgoogle-cloud: '>=2.26.0,<2.27.0a0'
-    libgoogle-cloud-storage: '>=2.26.0,<2.27.0a0'
-    libstdcxx-ng: '>=12'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    spdlog: '>=1.13.0,<1.14.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.24.2-h9260d03_1.conda
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/simdjson-3.11.6-h84d6215_0.conda
   hash:
-    md5: 4b55dfbdc38db6488f3496f7175f8f10
-    sha256: 80d34c15146759cf36a086a2135ba151fcbc188b707b07d375674c3ebd01941a
+    md5: 43441b4e82401da7b59236bca7fcb6ee
+    sha256: 52d5db006ea2535ccffba730c2b48601462f10e4d9b981e9614774b2f9e88bfa
   category: main
   optional: false
-- name: tiledb
-  version: 2.24.2
+- name: simdjson
+  version: 3.11.6
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-crt-cpp: '>=0.27.2,<0.27.3.0a0'
-    aws-sdk-cpp: '>=1.11.329,<1.11.330.0a0'
-    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
-    azure-identity-cpp: '>=1.8.0,<1.8.1.0a0'
-    azure-storage-blobs-cpp: '>=12.11.0,<12.11.1.0a0'
-    azure-storage-common-cpp: '>=12.6.0,<12.6.1.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    fmt: '>=10.2.1,<11.0a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
-    libgoogle-cloud: '>=2.26.0,<2.27.0a0'
-    libgoogle-cloud-storage: '>=2.26.0,<2.27.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    spdlog: '>=1.13.0,<1.14.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.24.2-h493d6f2_1.conda
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-64/simdjson-3.11.6-h9275861_0.conda
   hash:
-    md5: 7937e9373961828fee68e8b8d6f0ed44
-    sha256: 081fb092a0a086a6b89558e2555da29857f144c358f5e130c06a149ce3c604fb
+    md5: e3080147a168002188318b4ac6362332
+    sha256: 12e8a0df36e7132b9f90067576a1ecf26a5317b2547aae24b924f18cf7164d49
   category: main
   optional: false
-- name: tiledb
-  version: 2.24.2
+- name: simdjson
+  version: 3.11.6
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-crt-cpp: '>=0.27.2,<0.27.3.0a0'
-    aws-sdk-cpp: '>=1.11.329,<1.11.330.0a0'
-    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
-    azure-identity-cpp: '>=1.8.0,<1.8.1.0a0'
-    azure-storage-blobs-cpp: '>=12.11.0,<12.11.1.0a0'
-    azure-storage-common-cpp: '>=12.6.0,<12.6.1.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    fmt: '>=10.2.1,<11.0a0'
-    libabseil: '>=20240116.2,<20240117.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libcxx: '>=16'
-    libgoogle-cloud: '>=2.26.0,<2.27.0a0'
-    libgoogle-cloud-storage: '>=2.26.0,<2.27.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    spdlog: '>=1.13.0,<1.14.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tiledb-2.24.2-h577ba9b_1.conda
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/simdjson-3.11.6-ha393de7_0.conda
   hash:
-    md5: 5a5d39635c16bd401fc630889a8b13ed
-    sha256: 8139548cb498ade8f4718747f77ef2799bde5c79478714ea3791b6ad7051e4bc
+    md5: 169f4929d02ec7e29ffd13459274da46
+    sha256: 86cc0194b2eb7049b97546ab16720ecee4b8d9273f5745364e9e65c590a7e3b9
+  category: main
+  optional: false
+- name: six
+  version: 1.17.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a451d576819089b0d672f18768be0f65
+    sha256: 41db0180680cc67c3fa76544ffd48d6a5679d96f4b71d7498a759e94edc9a2db
+  category: main
+  optional: false
+- name: six
+  version: 1.17.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a451d576819089b0d672f18768be0f65
+    sha256: 41db0180680cc67c3fa76544ffd48d6a5679d96f4b71d7498a759e94edc9a2db
+  category: main
+  optional: false
+- name: six
+  version: 1.17.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a451d576819089b0d672f18768be0f65
+    sha256: 41db0180680cc67c3fa76544ffd48d6a5679d96f4b71d7498a759e94edc9a2db
+  category: main
+  optional: false
+- name: smmap
+  version: 5.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 62f26a3d1387acee31322208f0cfa3e0
+    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
+  category: main
+  optional: false
+- name: smmap
+  version: 5.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 62f26a3d1387acee31322208f0cfa3e0
+    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
+  category: main
+  optional: false
+- name: smmap
+  version: 5.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 62f26a3d1387acee31322208f0cfa3e0
+    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
+  category: main
+  optional: false
+- name: snappy
+  version: 1.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-h8bd8927_1.conda
+  hash:
+    md5: 3b3e64af585eadfb52bb90b553db5edf
+    sha256: ec91e86eeb2c6bbf09d51351b851e945185d70661d2ada67204c9a6419d282d3
+  category: main
+  optional: false
+- name: snappy
+  version: 1.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-haf3c120_1.conda
+  hash:
+    md5: 9d6ae6d5232233e1a01eb7db524078fb
+    sha256: 26e8a2edd2a12618d9adcdcfc6cfd9adaca8da71aa334615d29e803d225b52be
+  category: main
+  optional: false
+- name: snappy
+  version: 1.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-h98b9ce2_1.conda
+  hash:
+    md5: ded86dee325290da2967a3fea3800eb5
+    sha256: 4242f95b215127a006eb664fe26ed5a82df87e90cbdbc7ce7ff4971f0720997f
+  category: main
+  optional: false
+- name: snuggs
+  version: 1.4.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    numpy: ''
+    pyparsing: '>=2.1.6'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
+  hash:
+    md5: 9aa358575bbd4be126eaa5e0039f835c
+    sha256: 61f9373709e7d9009e3a062b135dbe44b16e684a4fcfe2dd624143bc0f80d402
+  category: dev
+  optional: true
+- name: snuggs
+  version: 1.4.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    numpy: ''
+    python: '>=3.9'
+    pyparsing: '>=2.1.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
+  hash:
+    md5: 9aa358575bbd4be126eaa5e0039f835c
+    sha256: 61f9373709e7d9009e3a062b135dbe44b16e684a4fcfe2dd624143bc0f80d402
+  category: dev
+  optional: true
+- name: snuggs
+  version: 1.4.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    numpy: ''
+    python: '>=3.9'
+    pyparsing: '>=2.1.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
+  hash:
+    md5: 9aa358575bbd4be126eaa5e0039f835c
+    sha256: 61f9373709e7d9009e3a062b135dbe44b16e684a4fcfe2dd624143bc0f80d402
+  category: dev
+  optional: true
+- name: spdlog
+  version: 1.15.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    fmt: '>=11.0.2,<12.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.1-hb29a8c4_0.conda
+  hash:
+    md5: 3666458a0c6a5c1ab099e0813ea2dc86
+    sha256: 6a8fbb341a43c58d46cb57c6146f1443084be58dfa16583a53f87dbcbb8acea2
+  category: main
+  optional: false
+- name: spdlog
+  version: 1.15.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    fmt: '>=11.0.2,<12.0a0'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.15.1-h65da0ee_0.conda
+  hash:
+    md5: 869e2924e6f2f44803b550b7059e7395
+    sha256: ebebbfdcd5eb360c974af934c5d94c7237b57a9139343cbc8d0b2d9f7903a5cd
+  category: main
+  optional: false
+- name: spdlog
+  version: 1.15.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    fmt: '>=11.0.2,<12.0a0'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.15.1-hed1c2b2_0.conda
+  hash:
+    md5: 95277d613352000a8cd51533076bf1db
+    sha256: 076353705f6d9b530b24a795dd5cf3687bdd07e3bd63fff337dc3073e9bd7364
+  category: main
+  optional: false
+- name: sqlite
+  version: 3.48.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libsqlite: 3.48.0
+    libzlib: '>=1.3.1,<2.0a0'
+    ncurses: '>=6.5,<7.0a0'
+    readline: '>=8.2,<9.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.48.0-h9eae976_1.conda
+  hash:
+    md5: 0ca48fd3357c877f21ea4440fe18e2b7
+    sha256: 6fc397698fa5b3d283c69e3ec35c9b50b953267deec3e96e599ebe26f809d7d9
+  category: main
+  optional: false
+- name: sqlite
+  version: 3.48.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libsqlite: 3.48.0
+    libzlib: '>=1.3.1,<2.0a0'
+    ncurses: '>=6.5,<7.0a0'
+    readline: '>=8.2,<9.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.48.0-h2e4c9dc_1.conda
+  hash:
+    md5: f0d4e053e7d85d30f689e731e62762bc
+    sha256: 3da756d4a6f7412620f49b4363a7263ef6fa72c55f48944adbb31ce688cd8c2a
+  category: main
+  optional: false
+- name: sqlite
+  version: 3.48.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libsqlite: 3.48.0
+    libzlib: '>=1.3.1,<2.0a0'
+    ncurses: '>=6.5,<7.0a0'
+    readline: '>=8.2,<9.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.48.0-hd7222ec_1.conda
+  hash:
+    md5: 802cc94c9fa238cb3f802d430a528bd5
+    sha256: 6c1609abe16ed39dd099eb7e32e2f3228105ab81bdd8da65700d46ee0984013e
+  category: main
+  optional: false
+- name: sshpubkeys
+  version: 3.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cryptography: '>=2.1.4'
+    ecdsa: '>=0.13'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/sshpubkeys-3.3.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: cef6c96c700c6312bd63186e4c0504d4
+    sha256: 951ab5d6174f511ad0480efe260eefb8ba42fd22d203c42d7929e40f8e1c54dd
+  category: dev
+  optional: true
+- name: sshpubkeys
+  version: 3.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+    cryptography: '>=2.1.4'
+    ecdsa: '>=0.13'
+  url: https://conda.anaconda.org/conda-forge/noarch/sshpubkeys-3.3.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: cef6c96c700c6312bd63186e4c0504d4
+    sha256: 951ab5d6174f511ad0480efe260eefb8ba42fd22d203c42d7929e40f8e1c54dd
+  category: dev
+  optional: true
+- name: sshpubkeys
+  version: 3.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+    cryptography: '>=2.1.4'
+    ecdsa: '>=0.13'
+  url: https://conda.anaconda.org/conda-forge/noarch/sshpubkeys-3.3.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: cef6c96c700c6312bd63186e4c0504d4
+    sha256: 951ab5d6174f511ad0480efe260eefb8ba42fd22d203c42d7929e40f8e1c54dd
+  category: dev
+  optional: true
+- name: stack_data
+  version: 0.6.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    asttokens: ''
+    executing: ''
+    pure_eval: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+  hash:
+    md5: b1b505328da7a6b246787df4b5a49fbc
+    sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
+  category: dev
+  optional: true
+- name: stack_data
+  version: 0.6.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    asttokens: ''
+    executing: ''
+    pure_eval: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+  hash:
+    md5: b1b505328da7a6b246787df4b5a49fbc
+    sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
+  category: dev
+  optional: true
+- name: stack_data
+  version: 0.6.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    asttokens: ''
+    executing: ''
+    pure_eval: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+  hash:
+    md5: b1b505328da7a6b246787df4b5a49fbc
+    sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
+  category: dev
+  optional: true
+- name: svt-av1
+  version: 2.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
+  hash:
+    md5: 355898d24394b2af353eb96358db9fdd
+    sha256: df30a9be29f1a8b5a2e314dd5b16ccfbcbd1cc6a4f659340e8bc2bd4de37bc6f
+  category: main
+  optional: false
+- name: svt-av1
+  version: 2.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-2.3.0-h97d8b74_0.conda
+  hash:
+    md5: c54053b3d1752308a38a9a8c48ce10da
+    sha256: 8cd3878eb1d31ecf21fe982e6d2ca557787100aed2f0c7fd44d01d504e704e30
+  category: main
+  optional: false
+- name: svt-av1
+  version: 2.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.3.0-hf24288c_0.conda
+  hash:
+    md5: 114c33e9eec335a379c9ee6c498bb807
+    sha256: ab876ed8bdd20e22a868dcb8d03e9ce9bbba7762d7e652d49bfff6af768a5b8f
+  category: main
+  optional: false
+- name: sympy
+  version: 1.13.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+    cpython: ''
+    gmpy2: '>=2.0.8'
+    mpmath: '>=0.19'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.13.3-pyh2585a3b_105.conda
+  hash:
+    md5: 254cd5083ffa04d96e3173397a3d30f4
+    sha256: 929d939c5a8bcdc10a17501890918da68cf14a5883b36fddf77b8f0fbf040be2
+  category: dev
+  optional: true
+- name: sympy
+  version: 1.13.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+    cpython: ''
+    python: '>=3.9'
+    mpmath: '>=0.19'
+    gmpy2: '>=2.0.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.13.3-pyh2585a3b_105.conda
+  hash:
+    md5: 254cd5083ffa04d96e3173397a3d30f4
+    sha256: 929d939c5a8bcdc10a17501890918da68cf14a5883b36fddf77b8f0fbf040be2
+  category: dev
+  optional: true
+- name: sympy
+  version: 1.13.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __unix: ''
+    cpython: ''
+    python: '>=3.9'
+    mpmath: '>=0.19'
+    gmpy2: '>=2.0.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.13.3-pyh2585a3b_105.conda
+  hash:
+    md5: 254cd5083ffa04d96e3173397a3d30f4
+    sha256: 929d939c5a8bcdc10a17501890918da68cf14a5883b36fddf77b8f0fbf040be2
+  category: dev
+  optional: true
+- name: threadpoolctl
+  version: 3.5.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+  hash:
+    md5: df68d78237980a159bd7149f33c0e8fd
+    sha256: 45e402941f6bed094022c5726a2ca494e6224b85180d2367fb6ddd9aea68079d
+  category: main
+  optional: false
+- name: threadpoolctl
+  version: 3.5.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+  hash:
+    md5: df68d78237980a159bd7149f33c0e8fd
+    sha256: 45e402941f6bed094022c5726a2ca494e6224b85180d2367fb6ddd9aea68079d
+  category: main
+  optional: false
+- name: threadpoolctl
+  version: 3.5.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+  hash:
+    md5: df68d78237980a159bd7149f33c0e8fd
+    sha256: 45e402941f6bed094022c5726a2ca494e6224b85180d2367fb6ddd9aea68079d
   category: main
   optional: false
 - name: tk
@@ -17419,75 +17517,75 @@ package:
   category: main
   optional: false
 - name: tomli
-  version: 2.0.1
+  version: 2.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+    md5: ac944244f1fed2eb49bae07193ae8215
+    sha256: 18636339a79656962723077df9a56c0ac7b8a864329eb8f847ee3d38495b863e
   category: main
   optional: false
 - name: tomli
-  version: 2.0.1
+  version: 2.2.1
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+    md5: ac944244f1fed2eb49bae07193ae8215
+    sha256: 18636339a79656962723077df9a56c0ac7b8a864329eb8f847ee3d38495b863e
   category: main
   optional: false
 - name: tomli
-  version: 2.0.1
+  version: 2.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+    md5: ac944244f1fed2eb49bae07193ae8215
+    sha256: 18636339a79656962723077df9a56c0ac7b8a864329eb8f847ee3d38495b863e
   category: main
   optional: false
 - name: tomlkit
-  version: 0.13.0
+  version: 0.13.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.0-pyha770c72_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.2-pyha770c72_1.conda
   hash:
-    md5: 810ba6f354ddef812d0ddc4669cc8de6
-    sha256: 8e61623213c620776f1328da4bee03f8828dbf2730f1a4fbd9b8af5398f5848e
+    md5: 1d9ab4fc875c52db83f9c9b40af4e2c8
+    sha256: 986fae65f5568e95dbf858d08d77a0f9cca031345a98550f1d4b51d36d8811e2
   category: main
   optional: false
 - name: tomlkit
-  version: 0.13.0
+  version: 0.13.2
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.0-pyha770c72_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.2-pyha770c72_1.conda
   hash:
-    md5: 810ba6f354ddef812d0ddc4669cc8de6
-    sha256: 8e61623213c620776f1328da4bee03f8828dbf2730f1a4fbd9b8af5398f5848e
+    md5: 1d9ab4fc875c52db83f9c9b40af4e2c8
+    sha256: 986fae65f5568e95dbf858d08d77a0f9cca031345a98550f1d4b51d36d8811e2
   category: main
   optional: false
 - name: tomlkit
-  version: 0.13.0
+  version: 0.13.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.0-pyha770c72_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.2-pyha770c72_1.conda
   hash:
-    md5: 810ba6f354ddef812d0ddc4669cc8de6
-    sha256: 8e61623213c620776f1328da4bee03f8828dbf2730f1a4fbd9b8af5398f5848e
+    md5: 1d9ab4fc875c52db83f9c9b40af4e2c8
+    sha256: 986fae65f5568e95dbf858d08d77a0f9cca031345a98550f1d4b51d36d8811e2
   category: main
   optional: false
 - name: toolz
@@ -17527,84 +17625,85 @@ package:
   category: main
   optional: false
 - name: tornado
-  version: 6.4.1
+  version: 6.4.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py312h9a8786e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py312h66e93f0_0.conda
   hash:
-    md5: fd9c83fde763b494f07acee1404c280e
-    sha256: fcf92fde5bac323921d97f8f2e66ee134ea01094f14d4e99c56f98187241c638
+    md5: e417822cb989e80a0d2b1b576fdd1657
+    sha256: 062a3a3a37fa8615ce57929ba7e982c76f5a5810bcebd435950f6d6c4147c310
   category: dev
   optional: true
 - name: tornado
-  version: 6.4.1
+  version: 6.4.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.1-py312hbd25219_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.2-py312h01d7ebd_0.conda
   hash:
-    md5: 5a40db69b327c71511248f8186965bd3
-    sha256: efba7cd7d5c311f57fd1a658c0f8ae65f9c5f3c9c41111a689dcad45407944c8
+    md5: 1b977164053085b356297127d3d6be49
+    sha256: a7b0796b9f8a02121a866ee396f0f8674c302504ccb9a3a2830699eedbc000b0
   category: dev
   optional: true
 - name: tornado
-  version: 6.4.1
+  version: 6.4.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py312h7e5086c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.2-py312hea69d52_0.conda
   hash:
-    md5: d16255fe62cc07ece877c4d3eac29bb4
-    sha256: 7c2010a0feed6aa87154ef77cfa9088b70586a587c5079c2d2ed931cb8eed75c
+    md5: fb0605888a475d6a380ae1d1a819d976
+    sha256: 964a2705a36c50040c967b18b45b9cc8de3c2aff4af546979a574e0b38e58e39
   category: dev
   optional: true
 - name: tqdm
-  version: 4.66.4
+  version: 4.67.1
   manager: conda
   platform: linux-64
   dependencies:
     colorama: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
   hash:
-    md5: e74cd796e70a4261f86699ee0a3a7a24
-    sha256: 75342f40a69e434a1a23003c3e254a95dca695fb14955bc32f1819cd503964b2
+    md5: 9efbfdc37242619130ea42b1cc4ed861
+    sha256: 11e2c85468ae9902d24a27137b6b39b4a78099806e551d390e394a8c34b48e40
   category: main
   optional: false
 - name: tqdm
-  version: 4.66.4
+  version: 4.67.1
   manager: conda
   platform: osx-64
   dependencies:
     colorama: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
   hash:
-    md5: e74cd796e70a4261f86699ee0a3a7a24
-    sha256: 75342f40a69e434a1a23003c3e254a95dca695fb14955bc32f1819cd503964b2
+    md5: 9efbfdc37242619130ea42b1cc4ed861
+    sha256: 11e2c85468ae9902d24a27137b6b39b4a78099806e551d390e394a8c34b48e40
   category: main
   optional: false
 - name: tqdm
-  version: 4.66.4
+  version: 4.67.1
   manager: conda
   platform: osx-arm64
   dependencies:
     colorama: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.4-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
   hash:
-    md5: e74cd796e70a4261f86699ee0a3a7a24
-    sha256: 75342f40a69e434a1a23003c3e254a95dca695fb14955bc32f1819cd503964b2
+    md5: 9efbfdc37242619130ea42b1cc4ed861
+    sha256: 11e2c85468ae9902d24a27137b6b39b4a78099806e551d390e394a8c34b48e40
   category: main
   optional: false
 - name: traitlets
@@ -17612,11 +17711,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 3df84416a021220d8b5700c613af2dc5
-    sha256: 8a64fa0f19022828513667c2c7176cfd125001f3f4b9bc00d33732e627dd2592
+    md5: 019a7385be9af33791c989871317e1ed
+    sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
   category: dev
   optional: true
 - name: traitlets
@@ -17624,11 +17723,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 3df84416a021220d8b5700c613af2dc5
-    sha256: 8a64fa0f19022828513667c2c7176cfd125001f3f4b9bc00d33732e627dd2592
+    md5: 019a7385be9af33791c989871317e1ed
+    sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
   category: dev
   optional: true
 - name: traitlets
@@ -17636,281 +17735,281 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 3df84416a021220d8b5700c613af2dc5
-    sha256: 8a64fa0f19022828513667c2c7176cfd125001f3f4b9bc00d33732e627dd2592
+    md5: 019a7385be9af33791c989871317e1ed
+    sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
   category: dev
   optional: true
 - name: truststore
-  version: 0.8.0
+  version: 0.10.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/truststore-0.8.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/truststore-0.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 08316d001eca8854392cf2837828ea11
-    sha256: ba49bed74ca170c5a3bf995c33a6179fd74b33abb2444f511862e7f9f57f9149
+    md5: ad1c20cd193e3044bcf17798c33b9d67
+    sha256: 0d23d3b370fc0393d05468fbff5152826317d4495446f6b2cc4d446e21050808
   category: main
   optional: false
 - name: truststore
-  version: 0.8.0
+  version: 0.10.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/truststore-0.8.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/truststore-0.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 08316d001eca8854392cf2837828ea11
-    sha256: ba49bed74ca170c5a3bf995c33a6179fd74b33abb2444f511862e7f9f57f9149
+    md5: ad1c20cd193e3044bcf17798c33b9d67
+    sha256: 0d23d3b370fc0393d05468fbff5152826317d4495446f6b2cc4d446e21050808
   category: main
   optional: false
 - name: truststore
-  version: 0.8.0
+  version: 0.10.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/truststore-0.8.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/truststore-0.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 08316d001eca8854392cf2837828ea11
-    sha256: ba49bed74ca170c5a3bf995c33a6179fd74b33abb2444f511862e7f9f57f9149
+    md5: ad1c20cd193e3044bcf17798c33b9d67
+    sha256: 0d23d3b370fc0393d05468fbff5152826317d4495446f6b2cc4d446e21050808
   category: main
   optional: false
 - name: typer
-  version: 0.12.3
+  version: 0.15.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-    typer-slim-standard: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    typer-slim-standard: 0.15.1
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 10efd02b22c39c0a46312ef7cb16d237
-    sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
+    md5: 170a0398946d8f5b454e592672b6fc20
+    sha256: ef695490e895c2ad552c77ec497b899b09fd4ad4ab07edcf5649f5994cf92a35
   category: main
   optional: false
 - name: typer
-  version: 0.12.3
+  version: 0.15.1
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-    typer-slim-standard: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    typer-slim-standard: 0.15.1
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 10efd02b22c39c0a46312ef7cb16d237
-    sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
+    md5: 170a0398946d8f5b454e592672b6fc20
+    sha256: ef695490e895c2ad552c77ec497b899b09fd4ad4ab07edcf5649f5994cf92a35
   category: main
   optional: false
 - name: typer
-  version: 0.12.3
+  version: 0.15.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    typer-slim-standard: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    typer-slim-standard: 0.15.1
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 10efd02b22c39c0a46312ef7cb16d237
-    sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
+    md5: 170a0398946d8f5b454e592672b6fc20
+    sha256: ef695490e895c2ad552c77ec497b899b09fd4ad4ab07edcf5649f5994cf92a35
   category: main
   optional: false
 - name: typer-slim
-  version: 0.12.3
+  version: 0.15.1
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=8.0.0'
-    python: '>=3.7'
+    python: '>=3.9'
     typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.1-pyhd8ed1ab_0.conda
   hash:
-    md5: cf2c3a89f89644c53cadbfeb124914e9
-    sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
+    md5: 0218b16f5a1dd569e575a7a6415489db
+    sha256: d4965516f35e0805199de6596c4ac76c4ad3d6b012be35e532102f9e53ecb860
   category: main
   optional: false
 - name: typer-slim
-  version: 0.12.3
+  version: 0.15.1
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.9'
     click: '>=8.0.0'
-    python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.1-pyhd8ed1ab_0.conda
   hash:
-    md5: cf2c3a89f89644c53cadbfeb124914e9
-    sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
+    md5: 0218b16f5a1dd569e575a7a6415489db
+    sha256: d4965516f35e0805199de6596c4ac76c4ad3d6b012be35e532102f9e53ecb860
   category: main
   optional: false
 - name: typer-slim
-  version: 0.12.3
+  version: 0.15.1
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.9'
     click: '>=8.0.0'
-    python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.15.1-pyhd8ed1ab_0.conda
   hash:
-    md5: cf2c3a89f89644c53cadbfeb124914e9
-    sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
+    md5: 0218b16f5a1dd569e575a7a6415489db
+    sha256: d4965516f35e0805199de6596c4ac76c4ad3d6b012be35e532102f9e53ecb860
   category: main
   optional: false
 - name: typer-slim-standard
-  version: 0.12.3
+  version: 0.15.1
   manager: conda
   platform: linux-64
   dependencies:
     rich: ''
     shellingham: ''
-    typer-slim: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.3-hd8ed1ab_0.conda
+    typer-slim: 0.15.1
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.1-hd8ed1ab_0.conda
   hash:
-    md5: 8e56b98837d17e6ace4dc455d905709a
-    sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
+    md5: 4e603c43bfdfc7b533be087c3e070cc9
+    sha256: f31c56fe98315da8b9ce848256c17e0b9f87896b41a6ccf0c9cc74644dcef20f
   category: main
   optional: false
 - name: typer-slim-standard
-  version: 0.12.3
+  version: 0.15.1
   manager: conda
   platform: osx-64
   dependencies:
     rich: ''
     shellingham: ''
-    typer-slim: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.3-hd8ed1ab_0.conda
+    typer-slim: 0.15.1
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.1-hd8ed1ab_0.conda
   hash:
-    md5: 8e56b98837d17e6ace4dc455d905709a
-    sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
+    md5: 4e603c43bfdfc7b533be087c3e070cc9
+    sha256: f31c56fe98315da8b9ce848256c17e0b9f87896b41a6ccf0c9cc74644dcef20f
   category: main
   optional: false
 - name: typer-slim-standard
-  version: 0.12.3
+  version: 0.15.1
   manager: conda
   platform: osx-arm64
   dependencies:
     rich: ''
     shellingham: ''
-    typer-slim: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.3-hd8ed1ab_0.conda
+    typer-slim: 0.15.1
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.15.1-hd8ed1ab_0.conda
   hash:
-    md5: 8e56b98837d17e6ace4dc455d905709a
-    sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
+    md5: 4e603c43bfdfc7b533be087c3e070cc9
+    sha256: f31c56fe98315da8b9ce848256c17e0b9f87896b41a6ccf0c9cc74644dcef20f
   category: main
   optional: false
 - name: types-awscrt
-  version: 0.21.0
+  version: 0.23.9
   manager: conda
   platform: linux-64
   dependencies:
     pip: ''
-    python: '>=3.7,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.21.0-pyhd8ed1ab_0.conda
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.23.9-pyhd8ed1ab_0.conda
   hash:
-    md5: 578d02db7173000ed2b7c5a24b47edb2
-    sha256: 85f7e60601fb53656275cbf9e3fcc324f6d86e29ad0efcc11f717f84d0d8b22d
+    md5: 5d2b85e93054764ee5cfd9a238a6d569
+    sha256: ea7f47b3e3441e666c720279678180f33b128eb3fa3b9b777d7ecbe5c3c2ffa9
   category: dev
   optional: true
 - name: types-awscrt
-  version: 0.21.0
+  version: 0.23.9
   manager: conda
   platform: osx-64
   dependencies:
     pip: ''
-    python: '>=3.7,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.21.0-pyhd8ed1ab_0.conda
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.23.9-pyhd8ed1ab_0.conda
   hash:
-    md5: 578d02db7173000ed2b7c5a24b47edb2
-    sha256: 85f7e60601fb53656275cbf9e3fcc324f6d86e29ad0efcc11f717f84d0d8b22d
+    md5: 5d2b85e93054764ee5cfd9a238a6d569
+    sha256: ea7f47b3e3441e666c720279678180f33b128eb3fa3b9b777d7ecbe5c3c2ffa9
   category: dev
   optional: true
 - name: types-awscrt
-  version: 0.21.0
+  version: 0.23.9
   manager: conda
   platform: osx-arm64
   dependencies:
     pip: ''
-    python: '>=3.7,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.21.0-pyhd8ed1ab_0.conda
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.23.9-pyhd8ed1ab_0.conda
   hash:
-    md5: 578d02db7173000ed2b7c5a24b47edb2
-    sha256: 85f7e60601fb53656275cbf9e3fcc324f6d86e29ad0efcc11f717f84d0d8b22d
+    md5: 5d2b85e93054764ee5cfd9a238a6d569
+    sha256: ea7f47b3e3441e666c720279678180f33b128eb3fa3b9b777d7ecbe5c3c2ffa9
   category: dev
   optional: true
 - name: types-pytz
-  version: 2024.1.0.20240417
+  version: 2025.1.0.20250204
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.1.0.20240417-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2025.1.0.20250204-pyhd8ed1ab_0.conda
   hash:
-    md5: 7b71ace1b99195041329427c435b8125
-    sha256: cc3913a5504b867c748981ba302e82dbc2bda71837f4894d29db8f6cb490e25d
+    md5: 54716284517555784c24794d76a045f9
+    sha256: 66963ccd62a10772715b6e8d21ef26cd7b8bfadf3589a973c303d3dd2cfb3bdc
   category: dev
   optional: true
 - name: types-pytz
-  version: 2024.1.0.20240417
+  version: 2025.1.0.20250204
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.1.0.20240417-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2025.1.0.20250204-pyhd8ed1ab_0.conda
   hash:
-    md5: 7b71ace1b99195041329427c435b8125
-    sha256: cc3913a5504b867c748981ba302e82dbc2bda71837f4894d29db8f6cb490e25d
+    md5: 54716284517555784c24794d76a045f9
+    sha256: 66963ccd62a10772715b6e8d21ef26cd7b8bfadf3589a973c303d3dd2cfb3bdc
   category: dev
   optional: true
 - name: types-pytz
-  version: 2024.1.0.20240417
+  version: 2025.1.0.20250204
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.1.0.20240417-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2025.1.0.20250204-pyhd8ed1ab_0.conda
   hash:
-    md5: 7b71ace1b99195041329427c435b8125
-    sha256: cc3913a5504b867c748981ba302e82dbc2bda71837f4894d29db8f6cb490e25d
+    md5: 54716284517555784c24794d76a045f9
+    sha256: 66963ccd62a10772715b6e8d21ef26cd7b8bfadf3589a973c303d3dd2cfb3bdc
   category: dev
   optional: true
 - name: types-pyyaml
-  version: 6.0.12.20240311
+  version: 6.0.12.20241230
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240311-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20241230-pyhd8ed1ab_0.conda
   hash:
-    md5: df5d4b66033ecb54c7a4040627215529
-    sha256: 0101df6ec0d1bf632f215795225eb7d0308ae542c61a2f3a3ce66c39dad956fb
+    md5: 99c1ed80714baf80417c937664d41cb1
+    sha256: 523022421f5b4a6695ab65f0cf038ea27a5705d83d06abeb9bd910a02fdbf0c6
   category: dev
   optional: true
 - name: types-pyyaml
-  version: 6.0.12.20240311
+  version: 6.0.12.20241230
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240311-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20241230-pyhd8ed1ab_0.conda
   hash:
-    md5: df5d4b66033ecb54c7a4040627215529
-    sha256: 0101df6ec0d1bf632f215795225eb7d0308ae542c61a2f3a3ce66c39dad956fb
+    md5: 99c1ed80714baf80417c937664d41cb1
+    sha256: 523022421f5b4a6695ab65f0cf038ea27a5705d83d06abeb9bd910a02fdbf0c6
   category: dev
   optional: true
 - name: types-pyyaml
-  version: 6.0.12.20240311
+  version: 6.0.12.20241230
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240311-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20241230-pyhd8ed1ab_0.conda
   hash:
-    md5: df5d4b66033ecb54c7a4040627215529
-    sha256: 0101df6ec0d1bf632f215795225eb7d0308ae542c61a2f3a3ce66c39dad956fb
+    md5: 99c1ed80714baf80417c937664d41cb1
+    sha256: 523022421f5b4a6695ab65f0cf038ea27a5705d83d06abeb9bd910a02fdbf0c6
   category: dev
   optional: true
 - name: types-requests
@@ -17952,16 +18051,55 @@ package:
     sha256: 2ec1bfb9ffbcdd880f60139d46df88e60cd8d0a404f4e0e498500671b34c1d5b
   category: dev
   optional: true
+- name: types-s3transfer
+  version: 0.6.0.post4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    pip: ''
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.6.0.post4-pyhd8ed1ab_1.conda
+  hash:
+    md5: e44e7c8040cf43d15b47449550c45838
+    sha256: bba47dcb97fb2822810cf3536e931862c15d74f4903ededb0aba495e3fa16636
+  category: dev
+  optional: true
+- name: types-s3transfer
+  version: 0.6.0.post4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pip: ''
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.6.0.post4-pyhd8ed1ab_1.conda
+  hash:
+    md5: e44e7c8040cf43d15b47449550c45838
+    sha256: bba47dcb97fb2822810cf3536e931862c15d74f4903ededb0aba495e3fa16636
+  category: dev
+  optional: true
+- name: types-s3transfer
+  version: 0.6.0.post4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pip: ''
+    python: '>=3.9,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-s3transfer-0.6.0.post4-pyhd8ed1ab_1.conda
+  hash:
+    md5: e44e7c8040cf43d15b47449550c45838
+    sha256: bba47dcb97fb2822810cf3536e931862c15d74f4903ededb0aba495e3fa16636
+  category: dev
+  optional: true
 - name: types-urllib3
   version: 1.26.25.14
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-urllib3-1.26.25.14-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-urllib3-1.26.25.14-pyhd8ed1ab_1.conda
   hash:
-    md5: 06118f39abab2ab953276a50b2775509
-    sha256: 43bcd4e976c9b95a0a3d99d500e7ba294f70f713d9808511296a3f450b2f7898
+    md5: 71064752383d8b42a1e1208064fe5960
+    sha256: e6378ff2de225a0f0f9b1bc884c3f05193a28d6ab13ca5ea20ce6a2fa5e0cff9
   category: dev
   optional: true
 - name: types-urllib3
@@ -17969,11 +18107,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-urllib3-1.26.25.14-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-urllib3-1.26.25.14-pyhd8ed1ab_1.conda
   hash:
-    md5: 06118f39abab2ab953276a50b2775509
-    sha256: 43bcd4e976c9b95a0a3d99d500e7ba294f70f713d9808511296a3f450b2f7898
+    md5: 71064752383d8b42a1e1208064fe5960
+    sha256: e6378ff2de225a0f0f9b1bc884c3f05193a28d6ab13ca5ea20ce6a2fa5e0cff9
   category: dev
   optional: true
 - name: types-urllib3
@@ -17981,11 +18119,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-urllib3-1.26.25.14-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-urllib3-1.26.25.14-pyhd8ed1ab_1.conda
   hash:
-    md5: 06118f39abab2ab953276a50b2775509
-    sha256: 43bcd4e976c9b95a0a3d99d500e7ba294f70f713d9808511296a3f450b2f7898
+    md5: 71064752383d8b42a1e1208064fe5960
+    sha256: e6378ff2de225a0f0f9b1bc884c3f05193a28d6ab13ca5ea20ce6a2fa5e0cff9
   category: dev
   optional: true
 - name: typing-extensions
@@ -17994,10 +18132,10 @@ package:
   platform: linux-64
   dependencies:
     typing_extensions: 4.12.2
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
   hash:
-    md5: 52d648bd608f5737b123f510bb5514b5
-    sha256: d3b9a8ed6da7c9f9553c5fd8a4fca9c3e0ab712fa5f497859f82337d67533b73
+    md5: b6a408c64b78ec7b779a3e5c7a902433
+    sha256: c8e9c1c467b5f960b627d7adc1c65fece8e929a3de89967e91ef0f726422fd32
   category: main
   optional: false
 - name: typing-extensions
@@ -18006,10 +18144,10 @@ package:
   platform: osx-64
   dependencies:
     typing_extensions: 4.12.2
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
   hash:
-    md5: 52d648bd608f5737b123f510bb5514b5
-    sha256: d3b9a8ed6da7c9f9553c5fd8a4fca9c3e0ab712fa5f497859f82337d67533b73
+    md5: b6a408c64b78ec7b779a3e5c7a902433
+    sha256: c8e9c1c467b5f960b627d7adc1c65fece8e929a3de89967e91ef0f726422fd32
   category: main
   optional: false
 - name: typing-extensions
@@ -18018,10 +18156,10 @@ package:
   platform: osx-arm64
   dependencies:
     typing_extensions: 4.12.2
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_1.conda
   hash:
-    md5: 52d648bd608f5737b123f510bb5514b5
-    sha256: d3b9a8ed6da7c9f9553c5fd8a4fca9c3e0ab712fa5f497859f82337d67533b73
+    md5: b6a408c64b78ec7b779a3e5c7a902433
+    sha256: c8e9c1c467b5f960b627d7adc1c65fece8e929a3de89967e91ef0f726422fd32
   category: main
   optional: false
 - name: typing_extensions
@@ -18029,11 +18167,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
   hash:
-    md5: ebe6952715e1d5eb567eeebf25250fa7
-    sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
+    md5: d17f13df8b65464ca316cbc000a3cb64
+    sha256: 337be7af5af8b2817f115b3b68870208b30c31d3439bec07bfb2d8f4823e3568
   category: main
   optional: false
 - name: typing_extensions
@@ -18041,11 +18179,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
   hash:
-    md5: ebe6952715e1d5eb567eeebf25250fa7
-    sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
+    md5: d17f13df8b65464ca316cbc000a3cb64
+    sha256: 337be7af5af8b2817f115b3b68870208b30c31d3439bec07bfb2d8f4823e3568
   category: main
   optional: false
 - name: typing_extensions
@@ -18053,95 +18191,62 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
   hash:
-    md5: ebe6952715e1d5eb567eeebf25250fa7
-    sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
-  category: main
-  optional: false
-- name: tzcode
-  version: 2024a
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2024a-h3f72095_0.conda
-  hash:
-    md5: 32146e34aaec3745a08b6f49af3f41b0
-    sha256: d3ea2927cabd6c9f27ee0cb498f893ac0133687d6a9e65e0bce4861c732a18df
-  category: main
-  optional: false
-- name: tzcode
-  version: 2024a
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/tzcode-2024a-h10d778d_0.conda
-  hash:
-    md5: 8d50ba6668dbd193cd42ccd9099fa2ae
-    sha256: e3ee34b2711500f3b1d38309d47cfd7e4d05c0144f0b2b2bdfbc271a28cfdd76
-  category: main
-  optional: false
-- name: tzcode
-  version: 2024a
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tzcode-2024a-h93a5062_0.conda
-  hash:
-    md5: 33ebc94eb6420500a4aeb0fc45112bba
-    sha256: 70bce0410d77b6ba3c32079aa87a98877ea970d8e96f2e4503e9b81198ece1f4
+    md5: d17f13df8b65464ca316cbc000a3cb64
+    sha256: 337be7af5af8b2817f115b3b68870208b30c31d3439bec07bfb2d8f4823e3568
   category: main
   optional: false
 - name: tzdata
-  version: 2024a
+  version: 2025a
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025a-h78e105d_0.conda
   hash:
-    md5: 161081fc7cec0bfda0d86d7cb595f8d8
-    sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
+    md5: dbcace4706afdfb7eb891f7b37d07c04
+    sha256: c4b1ae8a2931fe9b274c44af29c5475a85b37693999f8c792dad0f8c6734b1de
   category: main
   optional: false
 - name: tzdata
-  version: 2024a
+  version: 2025a
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025a-h78e105d_0.conda
   hash:
-    md5: 161081fc7cec0bfda0d86d7cb595f8d8
-    sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
+    md5: dbcace4706afdfb7eb891f7b37d07c04
+    sha256: c4b1ae8a2931fe9b274c44af29c5475a85b37693999f8c792dad0f8c6734b1de
   category: main
   optional: false
 - name: tzdata
-  version: 2024a
+  version: 2025a
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025a-h78e105d_0.conda
   hash:
-    md5: 161081fc7cec0bfda0d86d7cb595f8d8
-    sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
+    md5: dbcace4706afdfb7eb891f7b37d07c04
+    sha256: c4b1ae8a2931fe9b274c44af29c5475a85b37693999f8c792dad0f8c6734b1de
   category: main
   optional: false
 - name: ucx
-  version: 1.16.0
+  version: 1.17.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
+    libgcc: ''
     libgcc-ng: '>=12'
+    libstdcxx: ''
     libstdcxx-ng: '>=12'
-    rdma-core: '>=51.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.16.0-h209287a_5.conda
+    rdma-core: '>=55.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.17.0-h53fb5aa_4.conda
   hash:
-    md5: 1bd6b5d51b155a3c03b6aa2702d37f3f
-    sha256: 9e6a347f0a04a773469f7ec44d50216080892c291286aec64755100419282da9
+    md5: ba6c7ec20d51a27f60699f2125f00fef
+    sha256: 8041718faf0625dfdd943e162e1eb3f30cf2687b01489b1f94c895acb0c8b204
   category: main
   optional: false
 - name: ukkonen
@@ -18149,15 +18254,16 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cffi: ''
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.12.0rc3,<3.13.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312h8572e83_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312h68727a3_5.conda
   hash:
-    md5: 52c9e25ee0a32485a102eeecdb7eef52
-    sha256: f9a4384d466f4d8b5b497d951329dd4407ebe02f8f93456434e9ab789d6e23ce
+    md5: f9664ee31aed96c85b7319ab0a693341
+    sha256: 9fb020083a7f4fee41f6ece0f4840f59739b3e249f157c8a407bb374ffb733b5
   category: dev
   optional: true
 - name: ukkonen
@@ -18165,14 +18271,15 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     cffi: ''
-    libcxx: '>=15.0.7'
-    python: '>=3.12.0rc3,<3.13.0a0'
+    libcxx: '>=17'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py312h49ebfd2_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py312hc5c4d5f_5.conda
   hash:
-    md5: 4e6b5a8025cd8fd97b3cfe103ffce6b1
-    sha256: efca19a5e73e4aacfc5e90a5389272b2508e41dc4adab9eb5353c5200ba37041
+    md5: f270aa502d8817e9cb3eb33541f78418
+    sha256: f6433143294c1ca52410bf8bbca6029a04f2061588d32e6d2b67c7fd886bc4e0
   category: dev
   optional: true
 - name: ukkonen
@@ -18180,16 +18287,60 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     cffi: ''
-    libcxx: '>=15.0.7'
-    python: '>=3.12.0rc3,<3.13.0a0'
+    libcxx: '>=17'
+    python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py312h389731b_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py312h6142ec9_5.conda
   hash:
-    md5: 6407429e0969b58b8717dbb4c6c15513
-    sha256: 7336cf66feba973207f4903c20b05c3c82e351246df4b6113f72d92b9ee55b81
+    md5: 2b485a809d1572cbe7f0ad9ee107e4b0
+    sha256: 1e4452b4a12d8a69c237f14b876fbf0cdc456914170b49ba805779c749c31eca
   category: dev
   optional: true
+- name: unicodedata2
+  version: 16.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py312h66e93f0_0.conda
+  hash:
+    md5: 617f5d608ff8c28ad546e5d9671cbb95
+    sha256: 638916105a836973593547ba5cf4891d1f2cb82d1cf14354fcef93fd5b941cdc
+  category: main
+  optional: false
+- name: unicodedata2
+  version: 16.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-16.0.0-py312h01d7ebd_0.conda
+  hash:
+    md5: 27740ecb2764b1cddbe1e7412ed16034
+    sha256: ac5cc7728c3052777aa2d54dde8735f677386b38e3a4c09a805120274a8b3475
+  category: main
+  optional: false
+- name: unicodedata2
+  version: 16.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-16.0.0-py312hea69d52_0.conda
+  hash:
+    md5: 9a835052506b91ea8f0d8e352cd12246
+    sha256: c6ca9ea11eecc650df4bce4b3daa843821def6d753eeab6d81de35bb43f9d984
+  category: main
+  optional: false
 - name: uriparser
   version: 0.9.8
   manager: conda
@@ -18248,9 +18399,9 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
-    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
     md5: 6bb37c314b3cc1515dcf086ffe01c46e
@@ -18262,9 +18413,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
-    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
     md5: 6bb37c314b3cc1515dcf086ffe01c46e
@@ -18272,105 +18423,124 @@ package:
   category: main
   optional: false
 - name: vcrpy
-  version: 6.0.1
+  version: 6.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
+    python: '>=3.9'
     pyyaml: ''
+    urllib3: <2
     wrapt: ''
     yarl: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/vcrpy-6.0.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/vcrpy-6.0.2-pyhd8ed1ab_2.conda
   hash:
-    md5: 1506a513a8fc5776645a80658d15b3d1
-    sha256: 2718e7a7360a367b4310c0882298c0678e19b1d4e9ae11c80bc8b02ab46e43d1
+    md5: fb56617ac2deabbb6be5ec9169c913a4
+    sha256: d35e14231bcb56e7f0acb27b401c27f9e52201b85ae2cc3d17178d160174e275
   category: dev
   optional: true
 - name: vcrpy
-  version: 6.0.1
+  version: 6.0.2
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
     pyyaml: ''
     wrapt: ''
     yarl: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/vcrpy-6.0.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    urllib3: <2
+  url: https://conda.anaconda.org/conda-forge/noarch/vcrpy-6.0.2-pyhd8ed1ab_2.conda
   hash:
-    md5: 1506a513a8fc5776645a80658d15b3d1
-    sha256: 2718e7a7360a367b4310c0882298c0678e19b1d4e9ae11c80bc8b02ab46e43d1
+    md5: fb56617ac2deabbb6be5ec9169c913a4
+    sha256: d35e14231bcb56e7f0acb27b401c27f9e52201b85ae2cc3d17178d160174e275
   category: dev
   optional: true
 - name: vcrpy
-  version: 6.0.1
+  version: 6.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     pyyaml: ''
     wrapt: ''
     yarl: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/vcrpy-6.0.1-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    urllib3: <2
+  url: https://conda.anaconda.org/conda-forge/noarch/vcrpy-6.0.2-pyhd8ed1ab_2.conda
   hash:
-    md5: 1506a513a8fc5776645a80658d15b3d1
-    sha256: 2718e7a7360a367b4310c0882298c0678e19b1d4e9ae11c80bc8b02ab46e43d1
+    md5: fb56617ac2deabbb6be5ec9169c913a4
+    sha256: d35e14231bcb56e7f0acb27b401c27f9e52201b85ae2cc3d17178d160174e275
   category: dev
   optional: true
 - name: virtualenv
-  version: 20.26.3
+  version: 20.29.1
   manager: conda
   platform: linux-64
   dependencies:
-    distlib: <1,>=0.3.7
-    filelock: <4,>=3.12.2
-    platformdirs: <5,>=3.9.1
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
+    distlib: '>=0.3.7,<1'
+    filelock: '>=3.12.2,<4'
+    platformdirs: '>=3.9.1,<5'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.29.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 284008712816c64c85bf2b7fa9f3b264
-    sha256: f78961b194e33eed5fdccb668774651ec9423a043069fa7a4e3e2f853b08aa0c
+    md5: de06336c9833cffd2a4bd6f27c4cf8ea
+    sha256: f09a9f2034669762ae875858253d472588f03689843e5f0b8ddc5cc48a1d0e50
   category: main
   optional: false
 - name: virtualenv
-  version: 20.26.3
+  version: 20.29.1
   manager: conda
   platform: osx-64
   dependencies:
-    distlib: <1,>=0.3.7
-    filelock: <4,>=3.12.2
-    platformdirs: <5,>=3.9.1
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    distlib: '>=0.3.7,<1'
+    filelock: '>=3.12.2,<4'
+    platformdirs: '>=3.9.1,<5'
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.29.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 284008712816c64c85bf2b7fa9f3b264
-    sha256: f78961b194e33eed5fdccb668774651ec9423a043069fa7a4e3e2f853b08aa0c
+    md5: de06336c9833cffd2a4bd6f27c4cf8ea
+    sha256: f09a9f2034669762ae875858253d472588f03689843e5f0b8ddc5cc48a1d0e50
   category: main
   optional: false
 - name: virtualenv
-  version: 20.26.3
+  version: 20.29.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    distlib: <1,>=0.3.7
-    filelock: <4,>=3.12.2
-    platformdirs: <5,>=3.9.1
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+    distlib: '>=0.3.7,<1'
+    filelock: '>=3.12.2,<4'
+    platformdirs: '>=3.9.1,<5'
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.29.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 284008712816c64c85bf2b7fa9f3b264
-    sha256: f78961b194e33eed5fdccb668774651ec9423a043069fa7a4e3e2f853b08aa0c
+    md5: de06336c9833cffd2a4bd6f27c4cf8ea
+    sha256: f09a9f2034669762ae875858253d472588f03689843e5f0b8ddc5cc48a1d0e50
   category: main
   optional: false
+- name: wayland
+  version: 1.23.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libexpat: '>=2.6.2,<3.0a0'
+    libffi: '>=3.4,<4.0a0'
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
+  hash:
+    md5: 0a732427643ae5e0486a727927791da1
+    sha256: 0884b2023a32d2620192cf2e2fc6784b8d1e31cf9f137e49e00802d4daf7d1c1
+  category: dev
+  optional: true
 - name: wcwidth
   version: 0.2.13
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
   hash:
-    md5: 68f0738df502a14213624b288c60c9ad
-    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+    md5: b68980f2495d096e71c7fd9d7ccf63e6
+    sha256: f21e63e8f7346f9074fd00ca3b079bd3d2fa4d71f1f89d5b6934bf31446dc2a5
   category: dev
   optional: true
 - name: wcwidth
@@ -18378,11 +18548,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
   hash:
-    md5: 68f0738df502a14213624b288c60c9ad
-    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+    md5: b68980f2495d096e71c7fd9d7ccf63e6
+    sha256: f21e63e8f7346f9074fd00ca3b079bd3d2fa4d71f1f89d5b6934bf31446dc2a5
   category: dev
   optional: true
 - name: wcwidth
@@ -18390,11 +18560,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
   hash:
-    md5: 68f0738df502a14213624b288c60c9ad
-    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+    md5: b68980f2495d096e71c7fd9d7ccf63e6
+    sha256: f21e63e8f7346f9074fd00ca3b079bd3d2fa4d71f1f89d5b6934bf31446dc2a5
   category: dev
   optional: true
 - name: webencodings
@@ -18402,11 +18572,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
   hash:
-    md5: daf5160ff9cde3a468556965329085b9
-    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+    md5: 2841eb5bfc75ce15e9a0054b98dcd64d
+    sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
   category: main
   optional: false
 - name: webencodings
@@ -18414,11 +18584,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
   hash:
-    md5: daf5160ff9cde3a468556965329085b9
-    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+    md5: 2841eb5bfc75ce15e9a0054b98dcd64d
+    sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
   category: main
   optional: false
 - name: webencodings
@@ -18426,11 +18596,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
   hash:
-    md5: daf5160ff9cde3a468556965329085b9
-    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+    md5: 2841eb5bfc75ce15e9a0054b98dcd64d
+    sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
   category: main
   optional: false
 - name: websocket-client
@@ -18438,11 +18608,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
   hash:
-    md5: f372c576b8774922da83cda2b12f9d29
-    sha256: 44a5e3b97feef24cd719f7851cca9af9799dc9c17d3e0298d5856baab2d682f5
+    md5: 84f8f77f0a9c6ef401ee96611745da8f
+    sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
   category: dev
   optional: true
 - name: websocket-client
@@ -18450,11 +18620,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
   hash:
-    md5: f372c576b8774922da83cda2b12f9d29
-    sha256: 44a5e3b97feef24cd719f7851cca9af9799dc9c17d3e0298d5856baab2d682f5
+    md5: 84f8f77f0a9c6ef401ee96611745da8f
+    sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
   category: dev
   optional: true
 - name: websocket-client
@@ -18462,126 +18632,166 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
   hash:
-    md5: f372c576b8774922da83cda2b12f9d29
-    sha256: 44a5e3b97feef24cd719f7851cca9af9799dc9c17d3e0298d5856baab2d682f5
+    md5: 84f8f77f0a9c6ef401ee96611745da8f
+    sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
   category: dev
   optional: true
 - name: werkzeug
-  version: 3.0.3
+  version: 3.1.3
   manager: conda
   platform: linux-64
   dependencies:
     markupsafe: '>=2.1.1'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.3-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 2e60f5f388845027ee87fca6bee4ac23
-    sha256: a77d0c67096999c35854e0480e3b978ef72ee008e295e92b0dc67116b2398661
+    md5: 0a9b57c159d56b508613cc39022c1b9e
+    sha256: cd9a603beae0b237be7d9dfae8ae0b36ad62666ac4bb073969bce7da6f55157c
   category: dev
   optional: true
 - name: werkzeug
-  version: 3.0.3
+  version: 3.1.3
   manager: conda
   platform: osx-64
   dependencies:
+    python: '>=3.9'
     markupsafe: '>=2.1.1'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 2e60f5f388845027ee87fca6bee4ac23
-    sha256: a77d0c67096999c35854e0480e3b978ef72ee008e295e92b0dc67116b2398661
+    md5: 0a9b57c159d56b508613cc39022c1b9e
+    sha256: cd9a603beae0b237be7d9dfae8ae0b36ad62666ac4bb073969bce7da6f55157c
   category: dev
   optional: true
 - name: werkzeug
-  version: 3.0.3
+  version: 3.1.3
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.9'
     markupsafe: '>=2.1.1'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 2e60f5f388845027ee87fca6bee4ac23
-    sha256: a77d0c67096999c35854e0480e3b978ef72ee008e295e92b0dc67116b2398661
+    md5: 0a9b57c159d56b508613cc39022c1b9e
+    sha256: cd9a603beae0b237be7d9dfae8ae0b36ad62666ac4bb073969bce7da6f55157c
   category: dev
   optional: true
 - name: wheel
-  version: 0.43.0
+  version: 0.45.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 0b5293a157c2b5cd513dd1b03d8d3aae
-    sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
+    md5: 75cb7132eb58d97896e173ef12ac9986
+    sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
   category: main
   optional: false
 - name: wheel
-  version: 0.43.0
+  version: 0.45.1
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 0b5293a157c2b5cd513dd1b03d8d3aae
-    sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
+    md5: 75cb7132eb58d97896e173ef12ac9986
+    sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
   category: main
   optional: false
 - name: wheel
-  version: 0.43.0
+  version: 0.45.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
   hash:
-    md5: 0b5293a157c2b5cd513dd1b03d8d3aae
-    sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
+    md5: 75cb7132eb58d97896e173ef12ac9986
+    sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
   category: main
   optional: false
 - name: wrapt
-  version: 1.16.0
+  version: 1.17.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py312h98912ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.2-py312h66e93f0_0.conda
   hash:
-    md5: fa957a1c7bee7e47ad44633caf7be8bc
-    sha256: dc8431b343961347ad93b33d2d8270e8c15d8825382f4f2540835c94aba2de05
+    md5: 669e63af87710f8d52fdec9d4d63b404
+    sha256: ed3a1700ecc5d38c7e7dc7d2802df1bc1da6ba3d6f6017448b8ded0affb4ae00
   category: main
   optional: false
 - name: wrapt
-  version: 1.16.0
+  version: 1.17.2
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py312h41838bb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.17.2-py312h01d7ebd_0.conda
   hash:
-    md5: d87798aa7210da2c5eaf96c0346dca00
-    sha256: 9ed208c4c844c50f161764df7ed7a226c42822917c892ab7c8f67eec6ca96dff
+    md5: 6a860c98c6aea375eea574693a98d409
+    sha256: 476ea998d7279d9f71ff7b2e30408e69e5a0b921090c07a124f3f52ff7d3424b
   category: main
   optional: false
 - name: wrapt
-  version: 1.16.0
+  version: 1.17.2
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py312he37b823_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.17.2-py312hea69d52_0.conda
   hash:
-    md5: 86726ebb1f6da39c68f306ae624ee4ed
-    sha256: 25824dd9a22f2c1e8f205eb55c906b28b2f4748a68cb8e3d95ffdf73f08cbac9
+    md5: e49608c832fcf438f70cbcae09c3adc5
+    sha256: 6a3e68b57de29802e8703d1791dcacb7613bfdc17bbb087c6b2ea2796e6893ef
+  category: main
+  optional: false
+- name: x265
+  version: '3.5'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=10.3.0'
+    libstdcxx-ng: '>=10.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+  hash:
+    md5: e7f6ed84d4623d52ee581325c1587a6b
+    sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
+  category: main
+  optional: false
+- name: x265
+  version: '3.5'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=12.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
+  hash:
+    md5: a3bf3e95b7795871a6734a784400fcea
+    sha256: 6b6a57710192764d0538f72ea1ccecf2c6174a092e0bc76d790f8ca36bbe90e4
+  category: main
+  optional: false
+- name: x265
+  version: '3.5'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libcxx: '>=12.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+  hash:
+    md5: b1f7f2780feffe310b068c021e8ff9b2
+    sha256: 2fed6987dba7dee07bd9adc1a6f8e6c699efb851431bcb6ebad7de196e87841d
   category: main
   optional: false
 - name: xerces-c
@@ -18589,15 +18799,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    icu: '>=73.2,<74.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=75.1,<76.0a0'
+    libgcc: '>=13'
     libnsl: '>=2.0.1,<2.1.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-hac6953d_0.conda
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
   hash:
-    md5: 63b80ca78d29380fe69e69412dcbe4ac
-    sha256: 75d06ca406f03f653d7a3183f2a1ccfdb3a3c6c830493933ec4c3c98e06a32bb
+    md5: 9dda9667feba914e0e80b95b82f7402b
+    sha256: 339ab0ff05170a295e59133cd0fa9a9c4ba32b6941c8a2a73484cc13f81e248a
   category: main
   optional: false
 - name: xerces-c
@@ -18605,13 +18815,13 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    icu: '>=73.2,<74.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-hbbe9ea5_0.conda
+    __osx: '>=10.13'
+    icu: '>=75.1,<76.0a0'
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-h197e74d_2.conda
   hash:
-    md5: ade166000a13c81d9a75f65281e302b0
-    sha256: 10487c0b28ee2303570c6d0867000587a8c36836fffd4d634d8778c494d16965
+    md5: 559e2c3fb2fe4bfc985e8486bad8ecaa
+    sha256: 6218762b3ecff8e365f2880bb6a762b195e350159510d3f2dba58fa53f90a1bf
   category: main
   optional: false
 - name: xerces-c
@@ -18619,305 +18829,497 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    icu: '>=73.2,<74.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-hf393695_0.conda
+    __osx: '>=11.0'
+    icu: '>=75.1,<76.0a0'
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-h92fc2f4_2.conda
   hash:
-    md5: 5e4741a1e687aee5fc9c409a0476bef2
-    sha256: 8ad901a5fe535ebd16b469cf8e46cf174f7e6e4d9b432cc8cc02666a87e7e2ee
+    md5: 50b7325437ef0901fe25dc5c9e743b88
+    sha256: 863a7c2a991a4399d362d42c285ebc20748a4ea417647ebd3a171e2220c7457d
   category: main
   optional: false
-- name: xmltodict
-  version: 0.13.0
+- name: xkeyboard-config
+  version: '2.43'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/xmltodict-0.13.0-pyhd8ed1ab_0.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
   hash:
-    md5: b5b33faed6ed2b4ba47a690b8f5c0818
-    sha256: eb40b33ae953e0020406318c9be0eb6edf62f3aa8e64ab0bf1953440b1a92763
+    md5: f725c7425d6d7c15e31f3b99a88ea02f
+    sha256: 0d89b5873515a1f05d311f37ea4e087bbccc0418afa38f2f6189e97280db3179
   category: dev
   optional: true
 - name: xmltodict
-  version: 0.13.0
+  version: 0.14.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/xmltodict-0.14.2-pyhd8ed1ab_1.conda
+  hash:
+    md5: 96ef17b8734b174d35346da0762f0137
+    sha256: 7f6f4551da59ec3612783905c67ce825f2f067481bf79cb161ab2665ae2068a1
+  category: dev
+  optional: true
+- name: xmltodict
+  version: 0.14.2
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/xmltodict-0.13.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/xmltodict-0.14.2-pyhd8ed1ab_1.conda
   hash:
-    md5: b5b33faed6ed2b4ba47a690b8f5c0818
-    sha256: eb40b33ae953e0020406318c9be0eb6edf62f3aa8e64ab0bf1953440b1a92763
+    md5: 96ef17b8734b174d35346da0762f0137
+    sha256: 7f6f4551da59ec3612783905c67ce825f2f067481bf79cb161ab2665ae2068a1
   category: dev
   optional: true
 - name: xmltodict
-  version: 0.13.0
+  version: 0.14.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/xmltodict-0.13.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/xmltodict-0.14.2-pyhd8ed1ab_1.conda
   hash:
-    md5: b5b33faed6ed2b4ba47a690b8f5c0818
-    sha256: eb40b33ae953e0020406318c9be0eb6edf62f3aa8e64ab0bf1953440b1a92763
+    md5: 96ef17b8734b174d35346da0762f0137
+    sha256: 7f6f4551da59ec3612783905c67ce825f2f067481bf79cb161ab2665ae2068a1
   category: dev
   optional: true
-- name: xorg-kbproto
-  version: 1.0.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
-  hash:
-    md5: 4b230e8381279d76131116660f5a241a
-    sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
-  category: main
-  optional: false
 - name: xorg-libice
-  version: 1.1.1
+  version: 1.1.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
   hash:
-    md5: b462a33c0be1421532f28bfe8f4a7514
-    sha256: 5aa9b3682285bb2bf1a8adc064cb63aff76ef9178769740d855abb42b0d24236
-  category: main
-  optional: false
+    md5: fb901ff28063514abb6046c9ec2c4a45
+    sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
+  category: dev
+  optional: true
 - name: xorg-libsm
-  version: 1.2.4
+  version: 1.2.5
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     libuuid: '>=2.38.1,<3.0a0'
-    xorg-libice: '>=1.1.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
+    xorg-libice: '>=1.1.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.5-he73a12e_0.conda
   hash:
-    md5: 93ee23f12bc2e684548181256edd2cf6
-    sha256: 089ad5f0453c604e18985480218a84b27009e9e6de9a0fa5f4a20b8778ede1f1
-  category: main
-  optional: false
+    md5: 4c3e9fab69804ec6077697922d70c6e2
+    sha256: 760f43df6c2ce8cbbbcb8f2f3b7fc0f306716c011e28d1d340f3dfa8ccf29185
+  category: dev
+  optional: true
 - name: xorg-libx11
-  version: 1.8.9
+  version: 1.8.11
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libxcb: '>=1.16,<1.17.0a0'
-    xorg-kbproto: ''
-    xorg-xextproto: '>=7.3.0,<8.0a0'
-    xorg-xproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-hb711507_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libxcb: '>=1.17.0,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.11-h4f16b4b_0.conda
   hash:
-    md5: 4a6d410296d7e39f00bacdee7df046e9
-    sha256: 66eabe62b66c1597c4a755dcd3f4ce2c78adaf7b32e25dfee45504d67d7735c1
-  category: main
-  optional: false
+    md5: b6eb6d0cb323179af168df8fe16fb0a1
+    sha256: a0e7fca9e341dc2455b20cd320fc1655e011f7f5f28367ecf8617cccd4bb2821
+  category: dev
+  optional: true
 - name: xorg-libxau
-  version: 1.0.11
+  version: 1.0.12
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
   hash:
-    md5: 2c80dc38fface310c9bd81b17037fee5
-    sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
+    md5: f6ebe2cb3f82ba6c057dde5d9debe4f7
+    sha256: ed10c9283974d311855ae08a16dfd7e56241fac632aec3b92e3cfe73cff31038
   category: main
   optional: false
 - name: xorg-libxau
-  version: 1.0.11
+  version: 1.0.12
   manager: conda
   platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.12-h6e16a3a_0.conda
   hash:
-    md5: 9566b4c29274125b0266d0177b5eb97b
-    sha256: 8a2e398c4f06f10c64e69f56bcf3ddfa30b432201446a0893505e735b346619a
+    md5: 4cf40e60b444d56512a64f39d12c20bd
+    sha256: b4d2225135aa44e551576c4f3cf999b3252da6ffe7b92f0ad45bb44b887976fc
   category: main
   optional: false
 - name: xorg-libxau
-  version: 1.0.11
+  version: 1.0.12
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h5505292_0.conda
   hash:
-    md5: ca73dc4f01ea91e44e3ed76602c5ea61
-    sha256: 02c313a1cada46912e5b9bdb355cfb4534bfe22143b4ea4ecc419690e793023b
+    md5: 50901e0764b7701d8ed7343496f4f301
+    sha256: f33e6f013fc36ebc200f09ddead83468544cb5c353a3b50499b07b8c34e28a8d
   category: main
   optional: false
-- name: xorg-libxdmcp
-  version: 1.1.3
+- name: xorg-libxcomposite
+  version: 0.4.6
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxfixes: '>=6.0.1,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.6-hb9d3cd8_2.conda
   hash:
-    md5: be93aabceefa2fac576e971aef407908
-    sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+    md5: d3c295b50f092ab525ffe3c2aa4b7413
+    sha256: 753f73e990c33366a91fd42cc17a3d19bb9444b9ca5ff983605fa9e953baf57f
+  category: dev
+  optional: true
+- name: xorg-libxcursor
+  version: 1.2.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxfixes: '>=6.0.1,<7.0a0'
+    xorg-libxrender: '>=0.9.11,<0.10.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+  hash:
+    md5: 2ccd714aa2242315acaf0a67faea780b
+    sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
+  category: dev
+  optional: true
+- name: xorg-libxdamage
+  version: 1.1.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxfixes: '>=6.0.1,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+  hash:
+    md5: b5fcc7172d22516e1f965490e65e33a4
+    sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
+  category: dev
+  optional: true
+- name: xorg-libxdmcp
+  version: 1.1.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  hash:
+    md5: 8035c64cb77ed555e3f150b7b3972480
+    sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
   category: main
   optional: false
 - name: xorg-libxdmcp
-  version: 1.1.3
+  version: 1.1.5
   manager: conda
   platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+  dependencies:
+    __osx: '>=10.13'
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
   hash:
-    md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
-    sha256: 485421c16f03a01b8ed09984e0b2ababdbb3527e1abf354ff7646f8329be905f
+    md5: 9f438e1b6f4e73fd9e6d78bfe7c36743
+    sha256: bb4d1ef9cafef535494adf9296130b6193b3a44375883185b5167de03eb1ac7f
   category: main
   optional: false
 - name: xorg-libxdmcp
-  version: 1.1.3
+  version: 1.1.5
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
   hash:
-    md5: 6738b13f7fadc18725965abdd4129c36
-    sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
+    md5: 77c447f48cab5d3a15ac224edb86a968
+    sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
   category: main
   optional: false
 - name: xorg-libxext
-  version: 1.3.4
+  version: 1.3.6
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    xorg-libx11: '>=1.7.2,<2.0a0'
-    xorg-xextproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
   hash:
-    md5: 82b6df12252e6f32402b96dacc656fec
-    sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
-  category: main
-  optional: false
+    md5: febbab7d15033c913d53c7a2c102309d
+    sha256: da5dc921c017c05f38a38bd75245017463104457b63a1ce633ed41f214159c14
+  category: dev
+  optional: true
+- name: xorg-libxfixes
+  version: 6.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
+  hash:
+    md5: 4bdb303603e9821baf5fe5fdff1dc8f8
+    sha256: 2fef37e660985794617716eb915865ce157004a4d567ed35ec16514960ae9271
+  category: dev
+  optional: true
+- name: xorg-libxi
+  version: 1.8.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxfixes: '>=6.0.1,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+  hash:
+    md5: 17dcc85db3c7886650b8908b183d6876
+    sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
+  category: dev
+  optional: true
+- name: xorg-libxinerama
+  version: 1.1.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
+  hash:
+    md5: 5e2eb9bf77394fc2e5918beefec9f9ab
+    sha256: 1b9141c027f9d84a9ee5eb642a0c19457c788182a5a73c5a9083860ac5c20a8c
+  category: dev
+  optional: true
+- name: xorg-libxrandr
+  version: 1.5.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxrender: '>=0.9.11,<0.10.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
+  hash:
+    md5: 2de7f99d6581a4a7adbff607b5c278ca
+    sha256: ac0f037e0791a620a69980914a77cb6bb40308e26db11698029d6708f5aa8e0d
+  category: dev
+  optional: true
 - name: xorg-libxrender
-  version: 0.9.11
+  version: 0.9.12
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    xorg-libx11: '>=1.8.6,<2.0a0'
-    xorg-renderproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
   hash:
-    md5: ed67c36f215b310412b2af935bf3e530
-    sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
-  category: main
-  optional: false
-- name: xorg-renderproto
-  version: 0.11.1
+    md5: 96d57aba173e878a2089d5638016dc5e
+    sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
+  category: dev
+  optional: true
+- name: xorg-libxtst
+  version: 1.2.5
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    xorg-libx11: '>=1.8.10,<2.0a0'
+    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxi: '>=1.7.10,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
   hash:
-    md5: 06feff3d2634e3097ce2fe681474b534
-    sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
-  category: main
-  optional: false
-- name: xorg-xextproto
-  version: 7.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
-  hash:
-    md5: bce9f945da8ad2ae9b1d7165a64d0f87
-    sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
-  category: main
-  optional: false
-- name: xorg-xproto
-  version: 7.0.31
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
-  hash:
-    md5: b4a4381d54784606820704f7b5f05a15
-    sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
-  category: main
-  optional: false
+    md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
+    sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
+  category: dev
+  optional: true
 - name: xyzservices
-  version: 2024.6.0
+  version: 2025.1.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: de631703d59e40af41c56c4b4e2928ab
-    sha256: da2e54cb68776e62a708cb6d5f026229d8405ff4cfd8a2446f7d386f07ebc5c1
+    md5: fdf07e281a9e5e10fc75b2dd444136e9
+    sha256: 9978c22319e85026d5a4134944f73bac820c948ca6b6c32af6b6985b5221cd8a
   category: main
   optional: false
 - name: xyzservices
-  version: 2024.6.0
+  version: 2025.1.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: de631703d59e40af41c56c4b4e2928ab
-    sha256: da2e54cb68776e62a708cb6d5f026229d8405ff4cfd8a2446f7d386f07ebc5c1
+    md5: fdf07e281a9e5e10fc75b2dd444136e9
+    sha256: 9978c22319e85026d5a4134944f73bac820c948ca6b6c32af6b6985b5221cd8a
   category: main
   optional: false
 - name: xyzservices
-  version: 2024.6.0
+  version: 2025.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: de631703d59e40af41c56c4b4e2928ab
-    sha256: da2e54cb68776e62a708cb6d5f026229d8405ff4cfd8a2446f7d386f07ebc5c1
+    md5: fdf07e281a9e5e10fc75b2dd444136e9
+    sha256: 9978c22319e85026d5a4134944f73bac820c948ca6b6c32af6b6985b5221cd8a
   category: main
   optional: false
 - name: xz
-  version: 5.2.6
+  version: 5.6.4
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    liblzma: 5.6.4
+    liblzma-devel: 5.6.4
+    xz-gpl-tools: 5.6.4
+    xz-tools: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.6.4-hbcc6ac9_0.conda
   hash:
-    md5: 2161070d867d1b1204ea749c8eec4ef0
-    sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+    md5: bb511c87804cf7220246a3a6efc45c22
+    sha256: 91fc251034fa5199919680aa50299296d89da54b2d066fb6e6a60461c17c0c4a
   category: main
   optional: false
 - name: xz
-  version: 5.2.6
+  version: 5.6.4
   manager: conda
   platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  dependencies:
+    __osx: '>=10.13'
+    liblzma: 5.6.4
+    liblzma-devel: 5.6.4
+    xz-gpl-tools: 5.6.4
+    xz-tools: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.6.4-h357f2ed_0.conda
   hash:
-    md5: a72f9d4ea13d55d745ff1ed594747f10
-    sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+    md5: 702db4b35cffa4f94b94414066ffbb2b
+    sha256: 6412811e1592b530e84ea5030dedd7088fbe3258fdad9e60253d681b5be367a2
   category: main
   optional: false
 - name: xz
-  version: 5.2.6
+  version: 5.6.4
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  dependencies:
+    __osx: '>=11.0'
+    liblzma: 5.6.4
+    liblzma-devel: 5.6.4
+    xz-gpl-tools: 5.6.4
+    xz-tools: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.6.4-h9a6d368_0.conda
   hash:
-    md5: 39c6b54e94014701dd157f4f576ed211
-    sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+    md5: b6e676c2c7fde19f56e052acb6acc540
+    sha256: 0ca773e9d3af963414ac9d78c699c5048902bd336fbc989480c5e8a297cfcd10
+  category: main
+  optional: false
+- name: xz-gpl-tools
+  version: 5.6.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    liblzma: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.6.4-hbcc6ac9_0.conda
+  hash:
+    md5: 246840b451f7a66bd68869e56b066dd5
+    sha256: 300fc4e5993a36c979e61b1a38d00f0c23c0c56d5989be537cbc7bd8658254ed
+  category: main
+  optional: false
+- name: xz-gpl-tools
+  version: 5.6.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    liblzma: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/osx-64/xz-gpl-tools-5.6.4-h357f2ed_0.conda
+  hash:
+    md5: bbe2c5315d02654eb195bdf012bad66c
+    sha256: 57430768c0f26413dadec7fa4ac203984372a67e906a271f68777d1ad0085d20
+  category: main
+  optional: false
+- name: xz-gpl-tools
+  version: 5.6.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    liblzma: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.6.4-h9a6d368_0.conda
+  hash:
+    md5: a2580f5af9e67d0e44a97c015eea94d3
+    sha256: a380a32a392df8e9c03399197d3e3c6da1b98873b8733b8a9e22d3689a775471
+  category: main
+  optional: false
+- name: xz-tools
+  version: 5.6.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    liblzma: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.6.4-hb9d3cd8_0.conda
+  hash:
+    md5: a098f9f949af52610fdceb8e35b57513
+    sha256: 57506a312d8cfbee98217fb382822bd49794ea6318dd4e0413a0d588dc6f4f69
+  category: main
+  optional: false
+- name: xz-tools
+  version: 5.6.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    liblzma: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/osx-64/xz-tools-5.6.4-hd471939_0.conda
+  hash:
+    md5: 479783497192d1ad6671cbd0080f6dcb
+    sha256: 5361cadd518a24a19b009cfea1c113bea979b040858a15bbbd3a58c4d4f9774a
+  category: main
+  optional: false
+- name: xz-tools
+  version: 5.6.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    liblzma: 5.6.4
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.6.4-h39f12f2_0.conda
+  hash:
+    md5: e0ecdb9bfea05d0a763453071e375fc6
+    sha256: 4f18cc820f63ad3783c38763eb84132db00940d3291c0d03dc66ec8582e0cf84
   category: main
   optional: false
 - name: yaml
@@ -18992,49 +19394,55 @@ package:
   category: main
   optional: false
 - name: yarl
-  version: 1.9.4
+  version: 1.18.3
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     idna: '>=2.0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     multidict: '>=4.0'
+    propcache: '>=0.2.1'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.4-py312h98912ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.18.3-py312h178313f_1.conda
   hash:
-    md5: ec3eb4803df33e90a41bc216a68d02f1
-    sha256: 7bf7e32c5a18a1c5d21e0b7891133fb0cd38774f8014acdc5b548c601d4d47c3
+    md5: 6822c49f294d4355f19d314b8b6063d8
+    sha256: 6b054c93dd19fd7544af51b41a8eacca2ab62271f6c0c5a2a0cffe80dc37a0ce
   category: main
   optional: false
 - name: yarl
-  version: 1.9.4
+  version: 1.18.3
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     idna: '>=2.0'
     multidict: '>=4.0'
+    propcache: '>=0.2.1'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.9.4-py312h41838bb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.18.3-py312h3520af0_1.conda
   hash:
-    md5: 5d15d92a788612cf319ecfac53e0c542
-    sha256: 748199e3d7725e8e50c6b3d87066de383a2bedd8248d89dd80c8c6e78f2bc8b9
+    md5: c9c69a722e1cb1250608ed6c58bd2215
+    sha256: 0aa40f238e282d8b0a549732722ec655b752ff1bf6c0e0b5248aba16cc57a527
   category: main
   optional: false
 - name: yarl
-  version: 1.9.4
+  version: 1.18.3
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     idna: '>=2.0'
     multidict: '>=4.0'
+    propcache: '>=0.2.1'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.9.4-py312he37b823_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.18.3-py312h998013c_1.conda
   hash:
-    md5: 44ead39ed723937c4701dcb040ff8df6
-    sha256: 4ed261d50453813ceff0777b439d1646999ae3f8eba86775655a78d5411c9769
+    md5: 092d3b40acc67c470f379049be343a7a
+    sha256: 48821d23567ca0f853eee6f7812c74392867e123798b5b3c44f58758d8eb580e
   category: main
   optional: false
 - name: zeromq
@@ -19042,14 +19450,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libgcc-ng: '>=12'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h75354e8_4.conda
+    __glibc: '>=2.17,<3.0.a0'
+    krb5: '>=1.21.3,<1.22.0a0'
+    libgcc: '>=13'
+    libsodium: '>=1.0.20,<1.0.21.0a0'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_7.conda
   hash:
-    md5: 03cc8d9838ad9dd0060ab532e81ccb21
-    sha256: bc9aaee39e7be107d7daff237435dfd8f791aca460a98583a36a263615205262
+    md5: 3947a35e916fcc6b9825449affbf4214
+    sha256: a4dc72c96848f764bb5a5176aa93dd1e9b9e52804137b99daeebba277b31ea10
   category: dev
   optional: true
 - name: zeromq
@@ -19058,13 +19467,13 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    krb5: '>=1.21.2,<1.22.0a0'
-    libcxx: '>=16'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-hde137ed_4.conda
+    krb5: '>=1.21.3,<1.22.0a0'
+    libcxx: '>=18'
+    libsodium: '>=1.0.20,<1.0.21.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h7130eaa_7.conda
   hash:
-    md5: e56609055da6c658aa329d42a6c6b9f2
-    sha256: 871625ce993e6c61649b14659a3d1d6011fbb242b7d6a25cadbc6300b2356f32
+    md5: 6a0a76cd2b3d575e1b7aaeb283b9c3ed
+    sha256: b932dce8c9de9a8ffbf0db0365d29677636e599f7763ca51e554c43a0c5f8389
   category: dev
   optional: true
 - name: zeromq
@@ -19073,49 +19482,49 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    krb5: '>=1.21.2,<1.22.0a0'
-    libcxx: '>=16'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hcc0f68c_4.conda
+    krb5: '>=1.21.3,<1.22.0a0'
+    libcxx: '>=18'
+    libsodium: '>=1.0.20,<1.0.21.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hc1bb282_7.conda
   hash:
-    md5: 39fb79e7a7a880a03f82c1f2eb7f7c73
-    sha256: c22520d6d66a80f17c5f2b3719ad4a6ee809b210b8ac87d6f05ab98b94b3abda
+    md5: f7e6b65943cb73bce0143737fded08f1
+    sha256: 9e585569fe2e7d3bea71972cd4b9f06b1a7ab8fa7c5139f92a31cbceecf25a8a
   category: dev
   optional: true
 - name: zipp
-  version: 3.19.2
+  version: 3.21.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 49808e59df5535116f6878b2a820d6f4
-    sha256: e3e9c8501f581bfdc4700b83ea283395e237ec6b9b5cbfbedb556e1da6f4fdc9
+    md5: 0c3cc595284c5e8f0f9900a9b228a332
+    sha256: 567c04f124525c97a096b65769834b7acb047db24b15a56888a322bf3966c3e1
   category: main
   optional: false
 - name: zipp
-  version: 3.19.2
+  version: 3.21.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 49808e59df5535116f6878b2a820d6f4
-    sha256: e3e9c8501f581bfdc4700b83ea283395e237ec6b9b5cbfbedb556e1da6f4fdc9
+    md5: 0c3cc595284c5e8f0f9900a9b228a332
+    sha256: 567c04f124525c97a096b65769834b7acb047db24b15a56888a322bf3966c3e1
   category: main
   optional: false
 - name: zipp
-  version: 3.19.2
+  version: 3.21.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 49808e59df5535116f6878b2a820d6f4
-    sha256: e3e9c8501f581bfdc4700b83ea283395e237ec6b9b5cbfbedb556e1da6f4fdc9
+    md5: 0c3cc595284c5e8f0f9900a9b228a332
+    sha256: 567c04f124525c97a096b65769834b7acb047db24b15a56888a322bf3966c3e1
   category: main
   optional: false
 - name: zlib
@@ -19123,12 +19532,13 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     libzlib: 1.3.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-h4ab18f5_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
   hash:
-    md5: 9653f1bf3766164d0e65fa723cabbc54
-    sha256: cee16ab07a11303de721915f0a269e8c7a54a5c834aa52f74b1cc3a59000ade8
+    md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+    sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
   category: main
   optional: false
 - name: zlib
@@ -19138,10 +19548,10 @@ package:
   dependencies:
     __osx: '>=10.13'
     libzlib: 1.3.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-h87427d6_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
   hash:
-    md5: 3ac9ef8975965f9698dbedd2a4cc5894
-    sha256: 41bd5fef28b2755d637e3a8ea5c84010628392fbcf80c7e3d7370aaced7ee4fe
+    md5: c989e0295dcbdc08106fe5d9e935f0b9
+    sha256: 219edbdfe7f073564375819732cbf7cc0d7c7c18d3f546a09c2dfaf26e4d69f3
   category: main
   optional: false
 - name: zlib
@@ -19151,30 +19561,31 @@ package:
   dependencies:
     __osx: '>=11.0'
     libzlib: 1.3.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-hfb2fe0b_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
   hash:
-    md5: f27e021db7862b6ddbc1d3578f10d883
-    sha256: 87360c2dc662916aac37cf01e53324b4f4f78db6f399220818076752b093ede5
+    md5: e3170d898ca6cb48f1bb567afb92f775
+    sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
   category: main
   optional: false
 - name: zstandard
-  version: 0.22.0
+  version: 0.23.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     cffi: '>=1.11'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.22.0-py312h5b18bf6_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312hef9b889_1.conda
   hash:
-    md5: 27fe79bbc4dd3767be554fb171df362c
-    sha256: 3bd22e769ea6bf2c9f59cc9905b9b43058208bde1ecca9d9f656ecd834c137d0
+    md5: 8b7069e9792ee4e5b4919a7a306d2e67
+    sha256: b97015e146437283f2213ff0e95abdc8e2480150634d81fbae6b96ee09f5e50b
   category: main
   optional: false
 - name: zstandard
-  version: 0.22.0
+  version: 0.23.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -19183,14 +19594,14 @@ package:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.22.0-py312h331e495_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py312h7122b0e_1.conda
   hash:
-    md5: b355647d5ee25f78565028ace80844d1
-    sha256: ad6c48685ef9ac57a452cfdd107da7cd2dad01972502b192ba5e7eff9ebf5aab
+    md5: bd132ba98f3fc0a6067f355f8efe4cb6
+    sha256: 2685dde42478fae0780fba5d1f8a06896a676ae105f215d32c9f9e76f3c6d8fd
   category: main
   optional: false
 - name: zstandard
-  version: 0.22.0
+  version: 0.23.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -19199,10 +19610,10 @@ package:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.22.0-py312h721a963_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py312h15fbf35_1.conda
   hash:
-    md5: 13b5cc78a710f6f13ff3c5bee14355d2
-    sha256: 3aea4c16de85cfe932ba523dc1bdec3d267e06ee5a8528e478e6258b2f419ea5
+    md5: a4cde595509a7ad9c13b1a3809bcfe51
+    sha256: d00ca25c1e28fd31199b26a94f8c96574475704a825d244d7a6351ad3745eeeb
   category: main
   optional: false
 - name: zstd
@@ -19275,6 +19686,84 @@ package:
     sha256: fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255
   category: main
   optional: false
+- name: boto3
+  version: 1.34.162
+  manager: pip
+  platform: linux-64
+  dependencies:
+    botocore: '>=1.34.162,<1.35.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    s3transfer: '>=0.10.0,<0.11.0'
+  url: https://files.pythonhosted.org/packages/65/41/faa5081761be3bac3999f912996c14c4dc9d06eab86c234bd6441f54bd64/boto3-1.34.162-py3-none-any.whl
+  hash:
+    sha256: d6f6096bdab35a0c0deff469563b87d184a28df7689790f7fe7be98502b7c590
+  category: main
+  optional: false
+- name: boto3
+  version: 1.34.162
+  manager: pip
+  platform: osx-64
+  dependencies:
+    botocore: '>=1.34.162,<1.35.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    s3transfer: '>=0.10.0,<0.11.0'
+  url: https://files.pythonhosted.org/packages/65/41/faa5081761be3bac3999f912996c14c4dc9d06eab86c234bd6441f54bd64/boto3-1.34.162-py3-none-any.whl
+  hash:
+    sha256: d6f6096bdab35a0c0deff469563b87d184a28df7689790f7fe7be98502b7c590
+  category: main
+  optional: false
+- name: boto3
+  version: 1.34.162
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    botocore: '>=1.34.162,<1.35.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    s3transfer: '>=0.10.0,<0.11.0'
+  url: https://files.pythonhosted.org/packages/65/41/faa5081761be3bac3999f912996c14c4dc9d06eab86c234bd6441f54bd64/boto3-1.34.162-py3-none-any.whl
+  hash:
+    sha256: d6f6096bdab35a0c0deff469563b87d184a28df7689790f7fe7be98502b7c590
+  category: main
+  optional: false
+- name: botocore
+  version: 1.34.162
+  manager: pip
+  platform: linux-64
+  dependencies:
+    jmespath: '>=0.7.1,<2.0.0'
+    python-dateutil: '>=2.1,<3.0.0'
+    urllib3: '>=1.25.4,<2.2.0 || >2.2.0,<3'
+  url: https://files.pythonhosted.org/packages/bc/47/e35f788047c91110f48703a6254e5c84e33111b3291f7b57a653ca00accf/botocore-1.34.162-py3-none-any.whl
+  hash:
+    sha256: 2d918b02db88d27a75b48275e6fb2506e9adaaddbec1ffa6a8a0898b34e769be
+  category: main
+  optional: false
+- name: botocore
+  version: 1.34.162
+  manager: pip
+  platform: osx-64
+  dependencies:
+    jmespath: '>=0.7.1,<2.0.0'
+    python-dateutil: '>=2.1,<3.0.0'
+    urllib3: '>=1.25.4,<2.2.0 || >2.2.0,<3'
+  url: https://files.pythonhosted.org/packages/bc/47/e35f788047c91110f48703a6254e5c84e33111b3291f7b57a653ca00accf/botocore-1.34.162-py3-none-any.whl
+  hash:
+    sha256: 2d918b02db88d27a75b48275e6fb2506e9adaaddbec1ffa6a8a0898b34e769be
+  category: main
+  optional: false
+- name: botocore
+  version: 1.34.162
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    jmespath: '>=0.7.1,<2.0.0'
+    python-dateutil: '>=2.1,<3.0.0'
+    urllib3: '>=1.25.4,<2.2.0 || >2.2.0,<3'
+  url: https://files.pythonhosted.org/packages/bc/47/e35f788047c91110f48703a6254e5c84e33111b3291f7b57a653ca00accf/botocore-1.34.162-py3-none-any.whl
+  hash:
+    sha256: 2d918b02db88d27a75b48275e6fb2506e9adaaddbec1ffa6a8a0898b34e769be
+  category: main
+  optional: false
 - name: chroma-py
   version: 0.1.0.dev1
   manager: pip
@@ -19563,5 +20052,38 @@ package:
   url: https://files.pythonhosted.org/packages/4f/e1/cdaa6c2f6d3a7a29b0b9a675dcfc25f4c481d577d137da8c769f13014ce5/mapboxgl-0.10.2-py2.py3-none-any.whl
   hash:
     sha256: 19a81d16d66da49ba4a55a7a28eb2f1fd8d07f2885f6b3a6d386769eefab17ae
+  category: main
+  optional: false
+- name: s3transfer
+  version: 0.10.4
+  manager: pip
+  platform: linux-64
+  dependencies:
+    botocore: '>=1.33.2,<2.0a.0'
+  url: https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl
+  hash:
+    sha256: 244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e
+  category: main
+  optional: false
+- name: s3transfer
+  version: 0.10.4
+  manager: pip
+  platform: osx-64
+  dependencies:
+    botocore: '>=1.33.2,<2.0a.0'
+  url: https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl
+  hash:
+    sha256: 244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e
+  category: main
+  optional: false
+- name: s3transfer
+  version: 0.10.4
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    botocore: '>=1.33.2,<2.0a.0'
+  url: https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl
+  hash:
+    sha256: 244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e
   category: main
   optional: false

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -15,9 +15,9 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: 1b6f5ad71ad319a1e725f3b20e7eb288018c136bdbf44f867a0272f082ffa53f
-    osx-64: afac3f1f6a4aee32b7a40b012959622381cea961e84274bfdb86cc8ab118a789
-    osx-arm64: aaf98718596b0d0aaf5c13aa2391b167dbfeb6ce238950e00b7ed88ce5618f2c
+    linux-64: 521a2b01730373fd86ff74f738fb0150310084e06334a154ebd624640d801e0a
+    osx-64: 9d739528879c5973101c18123bc73962309048896ff621fefe55ebd65aa0c40e
+    osx-arm64: 36fa91456e95442d57b0ddf9e88c137c94e72f3cabc8c7926c860e92c3a4da03
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -55,48 +55,6 @@ package:
     sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
   category: main
   optional: false
-- name: adwaita-icon-theme
-  version: '47.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-    hicolor-icon-theme: ''
-    librsvg: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-47.0-unix_0.conda
-  hash:
-    md5: 49436a5c604f99058473d84580f0e341
-    sha256: 188dca9a847f474b3df71eda9fe828fbe10b53aa6f4313c7e117f3114b1dd84e
-  category: dev
-  optional: true
-- name: adwaita-icon-theme
-  version: '47.0'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __unix: ''
-    librsvg: ''
-    hicolor-icon-theme: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-47.0-unix_0.conda
-  hash:
-    md5: 49436a5c604f99058473d84580f0e341
-    sha256: 188dca9a847f474b3df71eda9fe828fbe10b53aa6f4313c7e117f3114b1dd84e
-  category: dev
-  optional: true
-- name: adwaita-icon-theme
-  version: '47.0'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: ''
-    librsvg: ''
-    hicolor-icon-theme: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-47.0-unix_0.conda
-  hash:
-    md5: 49436a5c604f99058473d84580f0e341
-    sha256: 188dca9a847f474b3df71eda9fe828fbe10b53aa6f4313c7e117f3114b1dd84e
-  category: dev
-  optional: true
 - name: affine
   version: 2.4.0
   manager: conda
@@ -133,244 +91,6 @@ package:
     sha256: 0deeaf0c001d5543719db9b2686bc1920c86c7e142f9bec74f35e1ce611b1fc2
   category: dev
   optional: true
-- name: aiobotocore
-  version: 2.19.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aiohttp: '>=3.9.2,<4.0.0'
-    aioitertools: '>=0.5.1,<1.0.0'
-    botocore: '>=1.36.0,<1.36.4'
-    jmespath: '>=0.7.1,<2.0.0'
-    multidict: '>=6.0.0,<7.0.0'
-    python: '>=3.9'
-    python-dateutil: '>=2.1,<3.0.0'
-    urllib3: '>=1.25.4,!=2.2.0,<3'
-    wrapt: '>=1.10.10,<2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.19.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 6dc626c926419c14546daedf1cffb4d4
-    sha256: 0072feb6220733066b0b8a4293fa7d4e170490d52bab64f4491818325b2f6ffd
-  category: main
-  optional: false
-- name: aiobotocore
-  version: 2.19.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-    python-dateutil: '>=2.1,<3.0.0'
-    jmespath: '>=0.7.1,<2.0.0'
-    urllib3: '>=1.25.4,!=2.2.0,<3'
-    wrapt: '>=1.10.10,<2.0.0'
-    aioitertools: '>=0.5.1,<1.0.0'
-    aiohttp: '>=3.9.2,<4.0.0'
-    multidict: '>=6.0.0,<7.0.0'
-    botocore: '>=1.36.0,<1.36.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.19.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 6dc626c926419c14546daedf1cffb4d4
-    sha256: 0072feb6220733066b0b8a4293fa7d4e170490d52bab64f4491818325b2f6ffd
-  category: main
-  optional: false
-- name: aiobotocore
-  version: 2.19.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-    python-dateutil: '>=2.1,<3.0.0'
-    jmespath: '>=0.7.1,<2.0.0'
-    urllib3: '>=1.25.4,!=2.2.0,<3'
-    wrapt: '>=1.10.10,<2.0.0'
-    aioitertools: '>=0.5.1,<1.0.0'
-    aiohttp: '>=3.9.2,<4.0.0'
-    multidict: '>=6.0.0,<7.0.0'
-    botocore: '>=1.36.0,<1.36.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.19.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 6dc626c926419c14546daedf1cffb4d4
-    sha256: 0072feb6220733066b0b8a4293fa7d4e170490d52bab64f4491818325b2f6ffd
-  category: main
-  optional: false
-- name: aiohappyeyeballs
-  version: 2.4.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_1.conda
-  hash:
-    md5: 296b403617bafa89df4971567af79013
-    sha256: 95d4713e49ea92ae50cf42393683ede706b7875af5f7cb14c253438180afa732
-  category: main
-  optional: false
-- name: aiohappyeyeballs
-  version: 2.4.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_1.conda
-  hash:
-    md5: 296b403617bafa89df4971567af79013
-    sha256: 95d4713e49ea92ae50cf42393683ede706b7875af5f7cb14c253438180afa732
-  category: main
-  optional: false
-- name: aiohappyeyeballs
-  version: 2.4.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.4-pyhd8ed1ab_1.conda
-  hash:
-    md5: 296b403617bafa89df4971567af79013
-    sha256: 95d4713e49ea92ae50cf42393683ede706b7875af5f7cb14c253438180afa732
-  category: main
-  optional: false
-- name: aiohttp
-  version: 3.11.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    aiohappyeyeballs: '>=2.3.0'
-    aiosignal: '>=1.1.2'
-    attrs: '>=17.3.0'
-    frozenlist: '>=1.1.1'
-    libgcc: '>=13'
-    multidict: '>=4.5,<7.0'
-    propcache: '>=0.2.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    yarl: '>=1.17.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.11.12-py312h178313f_0.conda
-  hash:
-    md5: 9f96d8b6fb9bab11e46c12132283b5b1
-    sha256: 223f271deceaf71d0cbee21162084104a6eca06e79c04ecb322706be3e406ea1
-  category: main
-  optional: false
-- name: aiohttp
-  version: 3.11.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    aiohappyeyeballs: '>=2.3.0'
-    aiosignal: '>=1.1.2'
-    attrs: '>=17.3.0'
-    frozenlist: '>=1.1.1'
-    multidict: '>=4.5,<7.0'
-    propcache: '>=0.2.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    yarl: '>=1.17.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.11.12-py312h3520af0_0.conda
-  hash:
-    md5: c31e7180a4a86b5a8339689133deea9b
-    sha256: 3274f863fffdd612a18ae4f03ff047ad122799c48195f7cce5b494fc752908d6
-  category: main
-  optional: false
-- name: aiohttp
-  version: 3.11.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    aiohappyeyeballs: '>=2.3.0'
-    aiosignal: '>=1.1.2'
-    attrs: '>=17.3.0'
-    frozenlist: '>=1.1.1'
-    multidict: '>=4.5,<7.0'
-    propcache: '>=0.2.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    yarl: '>=1.17.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.11.12-py312h998013c_0.conda
-  hash:
-    md5: 7675cee14b7e7d9ccf17ad37a4bdf53a
-    sha256: a4d04942bdeedbb7260b41eafb0302b6f8c3799f578c4389984c084a8fc34c16
-  category: main
-  optional: false
-- name: aioitertools
-  version: 0.12.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-    typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 3eb47adbffac44483f59e580f8600a1e
-    sha256: 7d56e547a819a03c058dd8793ca9df6ff9825812da52c214192edb61a7de1c95
-  category: main
-  optional: false
-- name: aioitertools
-  version: 0.12.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-    typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 3eb47adbffac44483f59e580f8600a1e
-    sha256: 7d56e547a819a03c058dd8793ca9df6ff9825812da52c214192edb61a7de1c95
-  category: main
-  optional: false
-- name: aioitertools
-  version: 0.12.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-    typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 3eb47adbffac44483f59e580f8600a1e
-    sha256: 7d56e547a819a03c058dd8793ca9df6ff9825812da52c214192edb61a7de1c95
-  category: main
-  optional: false
-- name: aiosignal
-  version: 1.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    frozenlist: '>=1.1.0'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1a3981115a398535dbe3f6d5faae3d36
-    sha256: 7de8ced1918bbdadecf8e1c1c68237fe5709c097bd9e0d254f4cad118f4345d0
-  category: main
-  optional: false
-- name: aiosignal
-  version: 1.3.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-    frozenlist: '>=1.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1a3981115a398535dbe3f6d5faae3d36
-    sha256: 7de8ced1918bbdadecf8e1c1c68237fe5709c097bd9e0d254f4cad118f4345d0
-  category: main
-  optional: false
-- name: aiosignal
-  version: 1.3.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-    frozenlist: '>=1.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1a3981115a398535dbe3f6d5faae3d36
-    sha256: 7de8ced1918bbdadecf8e1c1c68237fe5709c097bd9e0d254f4cad118f4345d0
-  category: main
-  optional: false
 - name: annotated-types
   version: 0.7.0
   manager: conda
@@ -581,95 +301,6 @@ package:
     sha256: 93b14414b3b3ed91e286e1cbe4e7a60c4e1b1c730b0814d1e452a8ac4b9af593
   category: dev
   optional: true
-- name: at-spi2-atk
-  version: 2.38.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    at-spi2-core: '>=2.40.0,<2.41.0a0'
-    atk-1.0: '>=2.36.0'
-    dbus: '>=1.13.6,<2.0a0'
-    libgcc-ng: '>=9.3.0'
-    libglib: '>=2.68.1,<3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
-  hash:
-    md5: 6b889f174df1e0f816276ae69281af4d
-    sha256: 26ab9386e80bf196e51ebe005da77d57decf6d989b4f34d96130560bc133479c
-  category: dev
-  optional: true
-- name: at-spi2-core
-  version: 2.40.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    dbus: '>=1.13.6,<2.0a0'
-    libgcc-ng: '>=9.3.0'
-    libglib: '>=2.68.3,<3.0a0'
-    xorg-libx11: ''
-    xorg-libxi: ''
-    xorg-libxtst: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
-  hash:
-    md5: 8cb2fc4cd6cc63f1369cfa318f581cc3
-    sha256: c4f9b66bd94c40d8f1ce1fad2d8b46534bdefda0c86e3337b28f6c25779f258d
-  category: dev
-  optional: true
-- name: atk-1.0
-  version: 2.38.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.0,<3.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
-  hash:
-    md5: f730d54ba9cd543666d7220c9f7ed563
-    sha256: df682395d05050cd1222740a42a551281210726a67447e5258968dd55854302e
-  category: dev
-  optional: true
-- name: atk-1.0
-  version: 2.38.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16'
-    libglib: '>=2.80.0,<3.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/atk-1.0-2.38.0-h4bec284_2.conda
-  hash:
-    md5: d9684247c943d492d9aac8687bc5db77
-    sha256: a5972a943764e46478c966b26be61de70dcd7d0cfda4bd0b0c46916ae32e0492
-  category: dev
-  optional: true
-- name: atk-1.0
-  version: 2.38.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=16'
-    libglib: '>=2.80.0,<3.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
-  hash:
-    md5: 57301986d02d30d6805fdce6c99074ee
-    sha256: b0747f9b1bc03d1932b4d8c586f39a35ac97e7e72fe6e63f2b2a2472d466f3c1
-  category: dev
-  optional: true
-- name: attr
-  version: 2.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
-  hash:
-    md5: d9c69a24ad678ffce24c6543a0176b00
-    sha256: 82c13b1772c21fc4a17441734de471d3aabf82b61db9b11f4a1bd04a9c4ac324
-  category: main
-  optional: false
 - name: attrs
   version: 25.1.0
   manager: conda
@@ -680,8 +311,8 @@ package:
   hash:
     md5: 2cc3f588512f04f3a0c64b4e9bedc02d
     sha256: 1f267886522dfb9ae4e5ebbc3135b5eb13cff27bdbfe8d881a4d893459166ab4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: attrs
   version: 25.1.0
   manager: conda
@@ -692,8 +323,8 @@ package:
   hash:
     md5: 2cc3f588512f04f3a0c64b4e9bedc02d
     sha256: 1f267886522dfb9ae4e5ebbc3135b5eb13cff27bdbfe8d881a4d893459166ab4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: attrs
   version: 25.1.0
   manager: conda
@@ -704,138 +335,138 @@ package:
   hash:
     md5: 2cc3f588512f04f3a0c64b4e9bedc02d
     sha256: 1f267886522dfb9ae4e5ebbc3135b5eb13cff27bdbfe8d881a4d893459166ab4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: aws-c-auth
-  version: 0.8.0
+  version: 0.8.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-    aws-c-http: '>=0.9.0,<0.9.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
-    aws-c-sdkutils: '>=0.2.1,<0.2.2.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-c-sdkutils: '>=0.2.2,<0.2.3.0a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.0-hcd8ed7f_7.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.1-h205f482_0.conda
   hash:
-    md5: b8725d87357c876b0458dee554c39b28
-    sha256: 35a8c73e750af3096170bba6a3a834b43b2241df6f57dd2d479e8eece1f2c526
+    md5: 9c500858e88df50af3cc883d194de78a
+    sha256: ebe5e33249f37f6bb481de99581ebdc92dbfcf1b6915609bcf3c9e78661d6352
   category: main
   optional: false
 - name: aws-c-auth
-  version: 0.8.0
+  version: 0.8.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-    aws-c-http: '>=0.9.0,<0.9.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
-    aws-c-sdkutils: '>=0.2.1,<0.2.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.8.0-h69e5304_7.conda
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-c-sdkutils: '>=0.2.2,<0.2.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.8.1-h6661f4c_0.conda
   hash:
-    md5: 2242fb13381c1025354a51848ac324e5
-    sha256: 397684aee5ccb2ace5d57ee1a9137fd7cde89657a8543825267abc9beccf7ad9
+    md5: 7045b0456fbf3620bcefa120f0bd6b96
+    sha256: 276a68de081c8fb9aa6fc4b6bafe5f3488aaa9e20ee0f680ac329190f8483789
   category: main
   optional: false
 - name: aws-c-auth
-  version: 0.8.0
+  version: 0.8.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-    aws-c-http: '>=0.9.0,<0.9.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
-    aws-c-sdkutils: '>=0.2.1,<0.2.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.0-h6935006_7.conda
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-c-sdkutils: '>=0.2.2,<0.2.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.1-hfc2798a_0.conda
   hash:
-    md5: c1181b45af5bb8867ee9edf2e85ecc91
-    sha256: 1b2d103607232935425565d929eb704924f72c41abbf7ad55ccbaa7a4c4ef832
+    md5: 0abd67c0f7b60d50348fbb32fef50b65
+    sha256: 5a60d196a585b25d1446fb973009e4e648e8d70beaa2793787243ede6da0fd9a
   category: main
   optional: false
 - name: aws-c-cal
-  version: 0.8.0
+  version: 0.8.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     libgcc: '>=13'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.0-he70792b_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.1-h1a47875_3.conda
   hash:
-    md5: 9b81a9d9395fb2abd60984fcfe7eb01a
-    sha256: 83724251e3d8a98c8236d478a9ea9d164b55c4031dbdf45f728fa1bdbc43d6ef
+    md5: 55a8561fdbbbd34f50f57d9be12ed084
+    sha256: 095ac824ea9303eff67e04090ae531d9eb33d2bf8f82eaade39b839c421e16e8
   category: main
   optional: false
 - name: aws-c-cal
-  version: 0.8.0
+  version: 0.8.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.8.0-h814e318_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.8.1-hc0df2db_3.conda
   hash:
-    md5: 532f048c811213cf7f9c0c280ed5b760
-    sha256: 004de52b7d7abca21d28f81408983f1cebd0f9b379842e89c69b4e3a617a8aea
+    md5: a9d2198575baadd2211190358a2a6b3e
+    sha256: 11db519ebf28a11b0e5ebc14ef15afff64763f6d1df181831f1660605423a0f8
   category: main
   optional: false
 - name: aws-c-cal
-  version: 0.8.0
+  version: 0.8.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.0-h8a8b6a7_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.8.1-hc8a0bd2_3.conda
   hash:
-    md5: 107fcd20e67df3945a34129098f3da4a
-    sha256: 0f8ad4bd6067ca35ef89834b8f11ed391bec122afa4f4df2c087b7c2934c4743
+    md5: 8b0ce61384e5a33d2b301a64f3d22ac5
+    sha256: 1f44be36e1daa17b4b081debb8aee492d13571084f38b503ad13e869fef24fe4
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.10.0
+  version: 0.10.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.0-hb9d3cd8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.10.6-hb9d3cd8_0.conda
   hash:
-    md5: f6495bc3a19a4400d3407052d22bef13
-    sha256: cf825c991332f4803fbc552bee92e46d2d5e2919a5521fa55043207f39882e3c
+    md5: d7d4680337a14001b0e043e96529409b
+    sha256: 496e92f2150fdc351eacf6e236015deedb3d0d3114f8e5954341cbf9f3dda257
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.10.0
+  version: 0.10.6
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.10.0-ha44c9a9_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.10.6-h6e16a3a_0.conda
   hash:
-    md5: 49cfcde38ade26d72fc6a103bede21f5
-    sha256: 797fa5eac65ad3f95795a88aef23f938cc31cd1e365b6537147dea50ba28d7e8
+    md5: 9f0bbd4a339c01ec81d7e19cbb9ad2ed
+    sha256: fd38587825ade82ddbf4752136679e5cb9700bd3520aafc2db950a28ec4ecfa8
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.10.0
+  version: 0.10.6
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.0-h7ab814d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.10.6-h5505292_0.conda
   hash:
-    md5: d4a98098dac19b54459855c1eb4a689a
-    sha256: 4ac33b0ec0d8a3b8af462d51e0e5e9095d9726860eb9b711ab6c6f84ba6b6b5e
+    md5: 145e5b4c9702ed279d7d68aaf096f77d
+    sha256: 3bde135c8e74987c0f79ecd4fa17ec9cff0d658b3090168727ca1af3815ae57a
   category: main
   optional: false
 - name: aws-c-compression
@@ -844,12 +475,12 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-hba2fe39_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.0-h4e1184b_5.conda
   hash:
-    md5: c6133966058e553727f0afe21ab38cd2
-    sha256: c7930aa52911ddc01de6ff92e5c93f1c71ecf3fc36d85ffe920b5dc422f6de4a
+    md5: 3f4c1197462a6df2be6dc8241828fe93
+    sha256: 62ca84da83585e7814a40240a1e750b1563b2680b032a471464eccc001c3309b
   category: main
   optional: false
 - name: aws-c-compression
@@ -858,11 +489,11 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.0-h814e318_1.conda
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.0-hc0df2db_5.conda
   hash:
-    md5: ec975f9c7d27591f84dd4da0957ec1a0
-    sha256: 16d388ad30be1b338507a19088a2022b9c9a6bb5e1f5171ac686093b61007364
+    md5: a9c8558d5bfcc336c83ae7ea91593c18
+    sha256: e3aa29e79c45ea80e7eb575c461bede53a9d82905da36f4a9e0379825cc5475e
   category: main
   optional: false
 - name: aws-c-compression
@@ -871,11 +502,11 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-h8a8b6a7_1.conda
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.0-hc8a0bd2_5.conda
   hash:
-    md5: e3306612c4561cbea6d0216b3dd85338
-    sha256: 701d2b269ce3d58f298d79a76e4a6537b2b9df32745584a3d012253dc49dd9d9
+    md5: a8b6c17732d14ed49d0e9b59c43186bc
+    sha256: 47b2813f652ce7e64ac442f771b2a5f7d4af4ad0d07ff51f6075ea80ed2e3f09
   category: main
   optional: false
 - name: aws-c-event-stream
@@ -884,15 +515,15 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
-    aws-checksums: '>=0.2.0,<0.2.1.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-checksums: '>=0.2.2,<0.2.3.0a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h127f702_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.0-h7959bf6_11.conda
   hash:
-    md5: 81d250bca40c7907ece5f5dd00de51d0
-    sha256: 5da248465f9e271c9fbbdb3090d5aa19c7f1d7017aa18a47ce69466339fe8c20
+    md5: 9b3fb60fe57925a92f399bc3fc42eccf
+    sha256: 10d7240c7db0c941fb1a59c4f8ea6689a434b03309ee7b766fa15a809c553c02
   category: main
   optional: false
 - name: aws-c-event-stream
@@ -901,14 +532,14 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
-    aws-checksums: '>=0.2.0,<0.2.1.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-checksums: '>=0.2.2,<0.2.3.0a0'
     libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.5.0-hbfe8335_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.5.0-h8236443_11.conda
   hash:
-    md5: 2a772340b744718fa73710e84cc74ff6
-    sha256: 96b25601b9a882d066238903234a4e4e27356338f754011d7d189482e07406e4
+    md5: b310a8a7c25dd982af1ad491b3705418
+    sha256: e8403a2afca0b1f584f5b98e18a82e5b05292fb66cc24bb83c219b0ff23b814f
   category: main
   optional: false
 - name: aws-c-event-stream
@@ -917,107 +548,107 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
-    aws-checksums: '>=0.2.0,<0.2.1.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-checksums: '>=0.2.2,<0.2.3.0a0'
     libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h53a7d5e_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.0-h54f970a_11.conda
   hash:
-    md5: ee6ab18e57b915a8680bbbc583c04f0b
-    sha256: c0302836312b1755d47cd9a6dac6de21a98846a9a23d0208d772f450942e0c0e
+    md5: ba41238f8e653998d7d2f42e3a8db054
+    sha256: f0667935f4e0d4c25e0e51da035640310b5ceeb8f723156734439bde8b848d7d
   category: main
   optional: false
 - name: aws-c-http
-  version: 0.9.0
+  version: 0.9.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     aws-c-compression: '>=0.3.0,<0.3.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.0-h8a7d7e2_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.9.2-hefd7a92_4.conda
   hash:
-    md5: c40bb8a9f3936ebeea804e97c5adf179
-    sha256: 9f2751a0f23561789b7d0df996755b135e90dd00d319d2ae07dd1128bd203748
+    md5: 5ce4df662d32d3123ea8da15571b6f51
+    sha256: 4a330206bd51148f6c13ca0b7a4db40f29a46f090642ebacdeb88b8a4abd7f99
   category: main
   optional: false
 - name: aws-c-http
-  version: 0.9.0
+  version: 0.9.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     aws-c-compression: '>=0.3.0,<0.3.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.9.0-h8316fcd_5.conda
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.9.2-h5492b4a_4.conda
   hash:
-    md5: 0bdc212b67bc378fbbf25b848ffb6c35
-    sha256: 7b988431d13bc7ee055f4d19be8b2784d21fb8d3e100b98d02d6a857644ac6ea
+    md5: 4a93c133064fca271b5a8ea42daa5a96
+    sha256: bf613d96f1c71f38c93c39522f2ef8ede58571302c797316ada933a566a86ef6
   category: main
   optional: false
 - name: aws-c-http
-  version: 0.9.0
+  version: 0.9.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     aws-c-compression: '>=0.3.0,<0.3.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.0-h007639a_5.conda
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.2-h96aa502_4.conda
   hash:
-    md5: e8be780c203c54a620f70dd2b15263ce
-    sha256: 50e506e55e491c1560324e73de001af21dcdbd1c5c4d2a46984588fb87813ecc
+    md5: 495c93a4f08b17deb3c04894512330e6
+    sha256: 22e4737c8a885995b7c1ae1d79c1f6e78d489e16ec079615980fdde067aeaf76
   category: main
   optional: false
 - name: aws-c-io
-  version: 0.15.1
+  version: 0.15.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     libgcc: '>=13'
-    s2n: '>=1.5.7,<1.5.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.1-h2a50c78_1.conda
+    s2n: '>=1.5.11,<1.5.12.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.15.3-h173a860_6.conda
   hash:
-    md5: 67dfecff4c4253cfe33c3c8e428f1767
-    sha256: 598f75e63aff93eec7f284f1bafdb808b79a7f57acd4442169f1b5f35caab914
+    md5: 9a063178f1af0a898526cc24ba7be486
+    sha256: 335d822eead0a097ffd23677a288e1f18ea22f47a92d4f877419debb93af0e81
   category: main
   optional: false
 - name: aws-c-io
-  version: 0.15.1
+  version: 0.15.3
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.15.1-h33d4847_1.conda
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.15.3-h7bd4489_6.conda
   hash:
-    md5: 4fed3d69593030e575d098a3dffa5b00
-    sha256: 98001055b5f2f5be0a93484ed95ea6fcba42a887eabdc8d9d78b4bc4d1c715ba
+    md5: 9c6f2cabd18b4778bf2b9a69bcbc3621
+    sha256: 46e46465a839a8bb22fe4cb37d64afd1df5ecb32ec864bca65fb14d6bca0c1fa
   category: main
   optional: false
 - name: aws-c-io
-  version: 0.15.1
+  version: 0.15.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.1-hb495e35_1.conda
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.15.3-haba67d1_6.conda
   hash:
-    md5: d6d283e3ba890b8386b54ca8f571f616
-    sha256: 3dabe80b2fe7965e05debcb6e28a622e95c411a37d2695b9a09bec612307337d
+    md5: d02e8f40ff69562903e70a1c6c48b009
+    sha256: 73722dd175af78b6cbfa033066f0933351f5382a1a737f6c6d9b8cfa84022161
   category: main
   optional: false
 - name: aws-c-mqtt
@@ -1026,14 +657,14 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-    aws-c-http: '>=0.9.0,<0.9.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-hd25e75f_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.11.0-h11f4f37_12.conda
   hash:
-    md5: 277dae7174fd2bc81c01411039ac2173
-    sha256: 88d3f42dc37d6718e93b21b26eadd97207191b7bce6bd8e29f9f7ab36fd99b7d
+    md5: 96c3e0221fa2da97619ee82faa341a73
+    sha256: 512d3969426152d9d5fd886e27b13706122dc3fa90eb08c37b0d51a33d7bb14a
   category: main
   optional: false
 - name: aws-c-mqtt
@@ -1042,13 +673,13 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-    aws-c-http: '>=0.9.0,<0.9.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.11.0-hec7e333_5.conda
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.11.0-h3488609_12.conda
   hash:
-    md5: 9d91c9c8c61d1ea2fb5b6d3bab4b795d
-    sha256: 51b036110e1a216cb4652434d9697512f341e8196ea0b5af635d25a7bc2d9360
+    md5: 5028bbe899aaf6f760d1b67967d9fe58
+    sha256: f740c56238c096dceeab635324ca9ea8a6a80bcd89a09d69616f08d0aa9f8d42
   category: main
   optional: false
 - name: aws-c-mqtt
@@ -1057,325 +688,277 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-    aws-c-http: '>=0.9.0,<0.9.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h6850007_5.conda
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.11.0-h24f418c_12.conda
   hash:
-    md5: bec16e1070d9ebfc27bde490c68fe9d9
-    sha256: 9cfcea2aa6020e6af635ab3390eeee6949461ca65565fa7d08d599fdeebcf2af
+    md5: c072045a6206f88015d02fcba1705ea1
+    sha256: 96575ea1dd2a9ea94763882e40a66dcbff9c41f702bf37c9514c4c719b3c11dd
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.7.0
+  version: 0.7.9
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-auth: '>=0.8.0,<0.8.1.0a0'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-    aws-c-http: '>=0.9.0,<0.9.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
-    aws-checksums: '>=0.2.0,<0.2.1.0a0'
+    aws-c-auth: '>=0.8.1,<0.8.2.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-checksums: '>=0.2.2,<0.2.3.0a0'
     libgcc: '>=13'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.0-h858c4ad_7.conda
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.7.9-he1b24dc_1.conda
   hash:
-    md5: 1698a4867ecd97931d1bb743428686ec
-    sha256: d24980ca81e08bf7196f3ee21df73b4aef7d860818594a88920cdba41d75e522
+    md5: caafc32928a5f7f3f7ef67d287689144
+    sha256: 15fbdedc56850f8be5be7a5bcaea1af09c97590e631c024ae089737fc932fc42
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.7.0
+  version: 0.7.9
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-auth: '>=0.8.0,<0.8.1.0a0'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-    aws-c-http: '>=0.9.0,<0.9.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
-    aws-checksums: '>=0.2.0,<0.2.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.7.0-hdbd2099_7.conda
+    aws-c-auth: '>=0.8.1,<0.8.2.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-checksums: '>=0.2.2,<0.2.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.7.9-h702e2dd_1.conda
   hash:
-    md5: 8d93a49485ce40fa6765e2cbc6df560e
-    sha256: 7e21aa519a588364c0fa49573a83dacce994a7b07e8ada5a5e1abab35613bb0d
+    md5: 79314d2e176c003d7b2bb78d338ae77f
+    sha256: 6c37af382dcc99cdbdad37f5a1368ef3cb6c5a977714693d362cdc2742dc8024
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.7.0
+  version: 0.7.9
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-auth: '>=0.8.0,<0.8.1.0a0'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-    aws-c-http: '>=0.9.0,<0.9.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
-    aws-checksums: '>=0.2.0,<0.2.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.0-h2bee52d_7.conda
+    aws-c-auth: '>=0.8.1,<0.8.2.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
+    aws-checksums: '>=0.2.2,<0.2.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.9-hf37e03c_1.conda
   hash:
-    md5: 651d54a474bf4663cd4acbb9c63ba261
-    sha256: b5203bfe36cc18ffb7c6270d1334c5525ba4dea6a86a2130dba80a8d4df64621
+    md5: de65f5e4ab5020103fe70a0eba9432a0
+    sha256: 92e8ca4eefcbbdf4189584c9410382884a06ed3030e5ecaac656dab8c95e6a80
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.1
+  version: 0.2.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.1-hba2fe39_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.2-h4e1184b_0.conda
   hash:
-    md5: f0b3524e47ed870bb8304a8d6fa67c7f
-    sha256: 8f11ec96e5a81e35b166b98b5c481568e5df18618d4de9dec00cace3a674c9bb
+    md5: dcd498d493818b776a77fbc242fbf8e4
+    sha256: 0424e380c435ba03b5948d02e8c958866c4eee50ed29e57f99473a5f795a4cfc
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.1
+  version: 0.2.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.1-hc280b33_0.conda
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.2-hc0df2db_0.conda
   hash:
-    md5: ea1bec6200d75ab9cd3a879f407a4310
-    sha256: b12b4b455f8e66e260b2bbd69259cdb6b5b5f8d80f83521f1fcd4a23c190a91a
+    md5: d30609a69cb865c31a967447cb845fc0
+    sha256: 0f8c22d4df2f9550e877d40df5a239cff6674e115405e88ee4cee6ae1969dfec
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.1
+  version: 0.2.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.1-h0b63f77_0.conda
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.2-hc8a0bd2_0.conda
   hash:
-    md5: c399890eb4c3c3fb1b4b4838cd7d7208
-    sha256: 1f17f70ada62bbfd900fb051f8a3988c7436e45fe69d5e9aa69bf0154983d1f9
+    md5: e7b5498ac7b7ab921a907be38f3a8080
+    sha256: ea4f0f1e99056293c69615f581a997d65ba7e229e296e402e0d8ef750648a5b5
   category: main
   optional: false
 - name: aws-checksums
-  version: 0.2.0
+  version: 0.2.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.0-hba2fe39_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.2-h4e1184b_4.conda
   hash:
-    md5: ac8d58d81bdcefa5bce4e883c6b88c42
-    sha256: 6c87c69df9dc2293d7159cb56b265da0a5bd12521ff4c664c6e57c24b1cfcc90
+    md5: 74e8c3e4df4ceae34aa2959df4b28101
+    sha256: 1ed9a332d06ad595694907fad2d6d801082916c27cd5076096fda4061e6d24a8
   category: main
   optional: false
 - name: aws-checksums
-  version: 0.2.0
+  version: 0.2.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.0-h814e318_1.conda
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.2-hc0df2db_4.conda
   hash:
-    md5: 40d2ba11f708ec9beccf99a4387a0a25
-    sha256: 13bdf44125c9be9c3e92d96bfe696562412187454a565d8c438e0bef01e7ae29
+    md5: 7575377b784344407b89a469e077ffa2
+    sha256: b7dd703e9ca92f4e64d0d9f7dd1a4e87528959b3d37876a2836172f684d904bd
   category: main
   optional: false
 - name: aws-checksums
-  version: 0.2.0
+  version: 0.2.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.0-h8a8b6a7_1.conda
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.2-hc8a0bd2_4.conda
   hash:
-    md5: d9db2bb8ced62ee3d6bfc32b46c5af1f
-    sha256: 1297ef83c67e9b0cb2bf80abf7ff1c05d62d485dd9eda963318d338e18cb89bd
+    md5: e70e88a357a3749b67679c0788c5b08a
+    sha256: 215086d95e8ff1d3fcb0197ada116cc9d7db1fdae7573f5e810d20fa9215b47c
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.29.3
+  version: 0.29.9
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-auth: '>=0.8.0,<0.8.1.0a0'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-auth: '>=0.8.1,<0.8.2.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
-    aws-c-http: '>=0.9.0,<0.9.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
     aws-c-mqtt: '>=0.11.0,<0.11.1.0a0'
-    aws-c-s3: '>=0.7.0,<0.7.1.0a0'
-    aws-c-sdkutils: '>=0.2.1,<0.2.2.0a0'
+    aws-c-s3: '>=0.7.9,<0.7.10.0a0'
+    aws-c-sdkutils: '>=0.2.2,<0.2.3.0a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.3-hbc793f2_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.29.9-he0e7f3f_2.conda
   hash:
-    md5: 3ac9933695a731e6507eef6c3704c10f
-    sha256: 19c213c62bfe60aba9c48140d1a921c351df96548d50ffa16d8c03d24f8a1e5b
+    md5: 8a4e6fc8a3b285536202b5456a74a940
+    sha256: c1930569713bd5231d48d885a5e3707ac917b428e8f08189d14064a2bb128adc
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.29.3
+  version: 0.29.9
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-auth: '>=0.8.0,<0.8.1.0a0'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-auth: '>=0.8.1,<0.8.2.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
-    aws-c-http: '>=0.9.0,<0.9.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
     aws-c-mqtt: '>=0.11.0,<0.11.1.0a0'
-    aws-c-s3: '>=0.7.0,<0.7.1.0a0'
-    aws-c-sdkutils: '>=0.2.1,<0.2.2.0a0'
+    aws-c-s3: '>=0.7.9,<0.7.10.0a0'
+    aws-c-sdkutils: '>=0.2.2,<0.2.3.0a0'
     libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.29.3-h9d5f034_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.29.9-h5c43303_2.conda
   hash:
-    md5: 5d627f1d988c07ca8a3f49739f9413e3
-    sha256: 78110457920217e59bb74700b5a4caf082966bff1c7c3171255fe75fce5c7a9f
+    md5: b2e8729ac755ec676e07e41e6f456c17
+    sha256: a0bcfc6c1a6dc90519f2b832cab35825a59e2bc49143faca23923b3958fdd176
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.29.3
+  version: 0.29.9
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-auth: '>=0.8.0,<0.8.1.0a0'
-    aws-c-cal: '>=0.8.0,<0.8.1.0a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-auth: '>=0.8.1,<0.8.2.0a0'
+    aws-c-cal: '>=0.8.1,<0.8.2.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
-    aws-c-http: '>=0.9.0,<0.9.1.0a0'
-    aws-c-io: '>=0.15.1,<0.15.2.0a0'
+    aws-c-http: '>=0.9.2,<0.9.3.0a0'
+    aws-c-io: '>=0.15.3,<0.15.4.0a0'
     aws-c-mqtt: '>=0.11.0,<0.11.1.0a0'
-    aws-c-s3: '>=0.7.0,<0.7.1.0a0'
-    aws-c-sdkutils: '>=0.2.1,<0.2.2.0a0'
+    aws-c-s3: '>=0.7.9,<0.7.10.0a0'
+    aws-c-sdkutils: '>=0.2.2,<0.2.3.0a0'
     libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.3-h7abc90e_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.29.9-ha81f72f_2.conda
   hash:
-    md5: 38a65640b8885238fb6155718d7c52b0
-    sha256: c187663950bad364957cf490c0a380312ac018852eeaaa996750149d80fe90f0
+    md5: c9c034d3239bf25687ca4dd985007ecd
+    sha256: ed5f1d19aad53787fdebe13db4709c97eae2092536cc55d3536eba320c4286e1
   category: main
   optional: false
-- name: aws-sam-translator
-  version: 1.94.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    boto3: '>=1.19.5,<2'
-    jsonschema: <5,>=3.2
-    pydantic: '>=1.8,<3,!=1.10.15,!=1.10.17'
-    python: '>=3.9,<4.0'
-    typing-extensions: '>=4.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/aws-sam-translator-1.94.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: f517c0c8063484928324bc7049f58c3c
-    sha256: 16a1715ccdc73a12cb855152c79350bc4c012af8cab88426506955cde037aa2b
-  category: dev
-  optional: true
-- name: aws-sam-translator
-  version: 1.94.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9,<4.0'
-    typing-extensions: '>=4.4'
-    boto3: '>=1.19.5,<2'
-    jsonschema: <5,>=3.2
-    pydantic: '>=1.8,<3,!=1.10.15,!=1.10.17'
-  url: https://conda.anaconda.org/conda-forge/noarch/aws-sam-translator-1.94.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: f517c0c8063484928324bc7049f58c3c
-    sha256: 16a1715ccdc73a12cb855152c79350bc4c012af8cab88426506955cde037aa2b
-  category: dev
-  optional: true
-- name: aws-sam-translator
-  version: 1.94.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9,<4.0'
-    typing-extensions: '>=4.4'
-    boto3: '>=1.19.5,<2'
-    jsonschema: <5,>=3.2
-    pydantic: '>=1.8,<3,!=1.10.15,!=1.10.17'
-  url: https://conda.anaconda.org/conda-forge/noarch/aws-sam-translator-1.94.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: f517c0c8063484928324bc7049f58c3c
-    sha256: 16a1715ccdc73a12cb855152c79350bc4c012af8cab88426506955cde037aa2b
-  category: dev
-  optional: true
 - name: aws-sdk-cpp
-  version: 1.11.407
+  version: 1.11.489
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
-    aws-checksums: '>=0.2.0,<0.2.1.0a0'
-    aws-crt-cpp: '>=0.29.3,<0.29.4.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
+    aws-checksums: '>=0.2.2,<0.2.3.0a0'
+    aws-crt-cpp: '>=0.29.9,<0.29.10.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.407-h5cd358a_9.conda
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.489-h4d475cb_0.conda
   hash:
-    md5: 1bba87c0e95867ad8ef2932d603ce7ee
-    sha256: 844fc29c66cad653c54d2a8a5edd62a01d3b02195dc11eed54060a24ad8911f5
+    md5: b775e9f46dfa94b228a81d8e8c6d8b1d
+    sha256: 08d6b7d2ed17bfcc7deb903c7751278ee434abdb27e3be0dceb561f30f030c75
   category: main
   optional: false
 - name: aws-sdk-cpp
-  version: 1.11.407
+  version: 1.11.489
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
-    aws-checksums: '>=0.2.0,<0.2.1.0a0'
-    aws-crt-cpp: '>=0.29.3,<0.29.4.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
+    aws-checksums: '>=0.2.2,<0.2.3.0a0'
+    aws-crt-cpp: '>=0.29.9,<0.29.10.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
     libcxx: '>=18'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.407-hd94a03e_9.conda
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.489-h904bc55_0.conda
   hash:
-    md5: c7f63181f02906d4f2f1634e251b4a1b
-    sha256: d5554dcbcb89d8951b5c39359be544daa0c9e8ab6a2ea690cd6c73a331964319
+    md5: b860858f5b5d146af55a3ae58574e7f6
+    sha256: 06476455d8cd32c2f701ee609b6368b54a5e7bd8f5fd0c8b9a9240f68848703c
   category: main
   optional: false
 - name: aws-sdk-cpp
-  version: 1.11.407
+  version: 1.11.489
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.10.0,<0.10.1.0a0'
+    aws-c-common: '>=0.10.6,<0.10.7.0a0'
     aws-c-event-stream: '>=0.5.0,<0.5.1.0a0'
-    aws-checksums: '>=0.2.0,<0.2.1.0a0'
-    aws-crt-cpp: '>=0.29.3,<0.29.4.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
+    aws-checksums: '>=0.2.2,<0.2.3.0a0'
+    aws-crt-cpp: '>=0.29.9,<0.29.10.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
     libcxx: '>=18'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.407-h124cfea_9.conda
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.489-h0e5014b_0.conda
   hash:
-    md5: 08c1305729417bd80910219c37eef1e8
-    sha256: 52260e96642a44db84e38cb01dfc99d8c134e2676fafc90dc38c82453f7751d5
+    md5: 156cfb45a1bb8cffc81e59047bb34f51
+    sha256: d82451530ddf363d8bb31a8a7391bb9699f745e940ace91d78c0e6170deef03c
   category: main
   optional: false
 - name: aws-xray-sdk
@@ -1420,6 +1003,242 @@ package:
     sha256: cee9764c5a75f28af403891161517066be30cb1819034958e490479c62317dc0
   category: dev
   optional: true
+- name: azure-core-cpp
+  version: 1.14.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
+  hash:
+    md5: 0a8838771cc2e985cd295e01ae83baf1
+    sha256: fe07debdb089a3db17f40a7f20d283d75284bb4fc269ef727b8ba6fc93f7cb5a
+  category: main
+  optional: false
+- name: azure-core-cpp
+  version: 1.14.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=17'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.14.0-h9a36307_0.conda
+  hash:
+    md5: 1082a031824b12a2be731d600cfa5ccb
+    sha256: c7694fc16b9aebeb6ee5e4f80019b477a181d961a3e4d9b6a66b77777eb754fe
+  category: main
+  optional: false
+- name: azure-core-cpp
+  version: 1.14.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=17'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.14.0-hd50102c_0.conda
+  hash:
+    md5: f093a11dcf3cdcca010b20a818fcc6dc
+    sha256: f5b91329ed59ffc0be8747784c6e4cc7e56250c54032883a83bc11808ef6a87e
+  category: main
+  optional: false
+- name: azure-identity-cpp
+  version: 1.10.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
+  hash:
+    md5: 73f73f60854f325a55f1d31459f2ab73
+    sha256: 286b31616c191486626cb49e9ceb5920d29394b9e913c23adb7eb637629ba4de
+  category: main
+  optional: false
+- name: azure-identity-cpp
+  version: 1.10.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    libcxx: '>=17'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.10.0-ha4e2ba9_0.conda
+  hash:
+    md5: ad56b6a4b8931d37a2cf5bc724a46f01
+    sha256: b9899b9698a6c7353fc5078c449105aae58635d217befbc8ca9d5a527198019b
+  category: main
+  optional: false
+- name: azure-identity-cpp
+  version: 1.10.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    libcxx: '>=17'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.10.0-hc602bab_0.conda
+  hash:
+    md5: d7b71593a937459f2d4b67e1a4727dc2
+    sha256: bde446b916fff5150606f8ed3e6058ffc55a3aa72381e46f1ab346590b1ae40a
+  category: main
+  optional: false
+- name: azure-storage-blobs-cpp
+  version: 12.13.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    azure-storage-common-cpp: '>=12.8.0,<12.8.1.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
+  hash:
+    md5: 7eb66060455c7a47d9dcdbfa9f46579b
+    sha256: 2606260e5379eed255bcdc6adc39b93fb31477337bcd911c121fc43cd29bf394
+  category: main
+  optional: false
+- name: azure-storage-blobs-cpp
+  version: 12.13.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    azure-storage-common-cpp: '>=12.8.0,<12.8.1.0a0'
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.13.0-h3d2f5f1_1.conda
+  hash:
+    md5: 3df4fb5d6d0e7b3fb28e071aff23787e
+    sha256: 31984e52450230d04ca98d5232dbe256e5ef6e32b15d46124135c6e64790010d
+  category: main
+  optional: false
+- name: azure-storage-blobs-cpp
+  version: 12.13.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    azure-storage-common-cpp: '>=12.8.0,<12.8.1.0a0'
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.13.0-h7585a09_1.conda
+  hash:
+    md5: 704238ef05d46144dae2e6b5853df8bc
+    sha256: 08d52d130addc0fb55d5ba10d9fa483e39be25d69bac7f4c676c2c3069207590
+  category: main
+  optional: false
+- name: azure-storage-common-cpp
+  version: 12.8.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libxml2: '>=2.12.7,<3.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
+  hash:
+    md5: 13de36be8de3ae3f05ba127631599213
+    sha256: 273475f002b091b66ce7366da04bf164c3732c03f8692ab2ee2d23335b6a82ba
+  category: main
+  optional: false
+- name: azure-storage-common-cpp
+  version: 12.8.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    libcxx: '>=17'
+    libxml2: '>=2.12.7,<3.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.8.0-h1ccc5ac_1.conda
+  hash:
+    md5: 5b3e79eb148d6e30d6c697788bad9960
+    sha256: 51fb67d2991d105b8f7b97b4810cd63bac4dc421a4a9c83c15a98ca520a42e1e
+  category: main
+  optional: false
+- name: azure-storage-common-cpp
+  version: 12.8.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    libcxx: '>=17'
+    libxml2: '>=2.12.7,<3.0a0'
+    openssl: '>=3.3.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.8.0-h9ca1f76_1.conda
+  hash:
+    md5: 7a187cd7b1445afc80253bb186a607cc
+    sha256: 77ab04e8fe5636a2de9c718f72a43645f7502cd208868c8a91ffba385547d585
+  category: main
+  optional: false
+- name: azure-storage-files-datalake-cpp
+  version: 12.12.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    azure-storage-blobs-cpp: '>=12.13.0,<12.13.1.0a0'
+    azure-storage-common-cpp: '>=12.8.0,<12.8.1.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+  hash:
+    md5: 7c1980f89dd41b097549782121a73490
+    sha256: 5371e4f3f920933bb89b926a85a67f24388227419abd6e99f6086481e5e8d5f2
+  category: main
+  optional: false
+- name: azure-storage-files-datalake-cpp
+  version: 12.12.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    azure-storage-blobs-cpp: '>=12.13.0,<12.13.1.0a0'
+    azure-storage-common-cpp: '>=12.8.0,<12.8.1.0a0'
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
+  hash:
+    md5: 60452336e7f61f6fdaaff69264ee112e
+    sha256: 12d95251a8793ea2e78f494e69353a930e9ea06bbaaaa4ccb6e5b3e35ee0744f
+  category: main
+  optional: false
+- name: azure-storage-files-datalake-cpp
+  version: 12.12.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    azure-storage-blobs-cpp: '>=12.13.0,<12.13.1.0a0'
+    azure-storage-common-cpp: '>=12.8.0,<12.8.1.0a0'
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-hcdd55da_1.conda
+  hash:
+    md5: c49fbc5233fcbaa86391162ff1adef38
+    sha256: f48523f8aa0b5b80f45a92f0556b388dd96f44ac2dc2f44a01d08c1822eec97d
+  category: main
+  optional: false
 - name: backoff
   version: 2.2.1
   manager: conda
@@ -1430,8 +1249,8 @@ package:
   hash:
     md5: a38b801f2bcc12af80c2e02a9e4ce7d9
     sha256: f334115c6b0c6c2cd0d28595365f205ec7eaa60bcc5ff91a75d7245f728be820
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: backoff
   version: 2.2.1
   manager: conda
@@ -1442,8 +1261,8 @@ package:
   hash:
     md5: a38b801f2bcc12af80c2e02a9e4ce7d9
     sha256: f334115c6b0c6c2cd0d28595365f205ec7eaa60bcc5ff91a75d7245f728be820
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: backoff
   version: 2.2.1
   manager: conda
@@ -1454,8 +1273,8 @@ package:
   hash:
     md5: a38b801f2bcc12af80c2e02a9e4ce7d9
     sha256: f334115c6b0c6c2cd0d28595365f205ec7eaa60bcc5ff91a75d7245f728be820
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: backports
   version: '1.0'
   manager: conda
@@ -1531,154 +1350,112 @@ package:
     sha256: a0f41db6d7580cec3c850e5d1b82cb03197dd49a3179b1cee59c62cd2c761b36
   category: main
   optional: false
-- name: bcrypt
-  version: 4.2.1
+- name: black
+  version: 25.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    click: '>=8.0.0'
+    mypy_extensions: '>=0.4.3'
+    packaging: '>=22.0'
+    pathspec: '>=0.9'
+    platformdirs: '>=2'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/black-25.1.0-py312h7900ff3_0.conda
+  hash:
+    md5: 986a60de52eec10b36c61bb3890858ff
+    sha256: a115a0984455ee031ac90fc533ab719fd5f5e3803930ccf0a934fb7416d568ef
+  category: dev
+  optional: true
+- name: black
+  version: 25.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    click: '>=8.0.0'
+    mypy_extensions: '>=0.4.3'
+    packaging: '>=22.0'
+    pathspec: '>=0.9'
+    platformdirs: '>=2'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/black-25.1.0-py312hb401068_0.conda
+  hash:
+    md5: d37d5213fcf23a33d946e40937578a02
+    sha256: e937f18e36e23ecf0ec9ab89fc3ef5263308e88b645c4278fe8807fd95bef4c1
+  category: dev
+  optional: true
+- name: black
+  version: 25.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    click: '>=8.0.0'
+    mypy_extensions: '>=0.4.3'
+    packaging: '>=22.0'
+    pathspec: '>=0.9'
+    platformdirs: '>=2'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-25.1.0-py312h81bd7bf_0.conda
+  hash:
+    md5: 98fa266dc77c8fe02795acf493d92af2
+    sha256: 9e35cb45a48b0a860a79bdf460698c01b9411c45bbfbf4cac33522fb83c1a2a4
+  category: dev
+  optional: true
+- name: blinker
+  version: 1.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+  hash:
+    md5: 42834439227a4551b939beeeb8a4b085
+    sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
+  category: dev
+  optional: true
+- name: blinker
+  version: 1.9.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+  hash:
+    md5: 42834439227a4551b939beeeb8a4b085
+    sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
+  category: dev
+  optional: true
+- name: blinker
+  version: 1.9.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+  hash:
+    md5: 42834439227a4551b939beeeb8a4b085
+    sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
+  category: dev
+  optional: true
+- name: blosc
+  version: 1.21.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/bcrypt-4.2.1-py312h12e396e_0.conda
-  hash:
-    md5: fbfaa371b5f14cb89756483bb4e030be
-    sha256: 6f2b82c69893ef33d24975572a03c031a889c0a0e8406ae1d3a09c7f1608bf4b
-  category: dev
-  optional: true
-- name: bcrypt
-  version: 4.2.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/bcrypt-4.2.1-py312h0d0de52_0.conda
-  hash:
-    md5: 6ed8319cec2be2818ce6270645a57d22
-    sha256: ed6adbba5e892a5165401c2513b77b570692cc311b8a0d6bb4a2edac353ebdd7
-  category: dev
-  optional: true
-- name: bcrypt
-  version: 4.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bcrypt-4.2.1-py312hcd83bfe_0.conda
-  hash:
-    md5: 527903e14dd5572f8e076c6ad6954d67
-    sha256: eec3209348e156e7879c20e7f49afe603460889dccac1263d07a6239c086b134
-  category: dev
-  optional: true
-- name: black
-  version: 24.10.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: '>=8.0.0'
-    mypy_extensions: '>=0.4.3'
-    packaging: '>=22.0'
-    pathspec: '>=0.9'
-    platformdirs: '>=2'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/black-24.10.0-py312h7900ff3_0.conda
-  hash:
-    md5: 2daba153b913b1b901cf61440ad5e019
-    sha256: 2b4344d18328b3e8fd9b5356f4ee15556779766db8cb21ecf2ff818809773df6
-  category: dev
-  optional: true
-- name: black
-  version: 24.10.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    click: '>=8.0.0'
-    mypy_extensions: '>=0.4.3'
-    packaging: '>=22.0'
-    pathspec: '>=0.9'
-    platformdirs: '>=2'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/black-24.10.0-py312hb401068_0.conda
-  hash:
-    md5: e832f4c2afb84e85718008b600944bc0
-    sha256: a1397d32f6d40ff19107bab8c1570f3934ad91a601d1d973b129eabe08b943e6
-  category: dev
-  optional: true
-- name: black
-  version: 24.10.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    click: '>=8.0.0'
-    mypy_extensions: '>=0.4.3'
-    packaging: '>=22.0'
-    pathspec: '>=0.9'
-    platformdirs: '>=2'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-24.10.0-py312h81bd7bf_0.conda
-  hash:
-    md5: 702d7bf6d22135d3e30811ed9c62bb07
-    sha256: 7e0cd77935e68717506469463546365637abf3f73aa597a890cb5f5ef3c75caf
-  category: dev
-  optional: true
-- name: blinker
-  version: 1.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
-  hash:
-    md5: 42834439227a4551b939beeeb8a4b085
-    sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
-  category: dev
-  optional: true
-- name: blinker
-  version: 1.9.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
-  hash:
-    md5: 42834439227a4551b939beeeb8a4b085
-    sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
-  category: dev
-  optional: true
-- name: blinker
-  version: 1.9.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
-  hash:
-    md5: 42834439227a4551b939beeeb8a4b085
-    sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
-  category: dev
-  optional: true
-- name: blosc
-  version: 1.21.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.2.0,<1.3.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
+    snappy: '>=1.2.1,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
   hash:
-    md5: 54fe76ab3d0189acaef95156874db7f9
-    sha256: 6cc260f9c6d32c5e728a2099a52fdd7ee69a782fff7b400d0606fcd32e0f5fd1
+    md5: 2c2fae981fd2afd00812c92ac47d023d
+    sha256: e7af5d1183b06a206192ff440e08db1c4e8b2ca1f8376ee45fb2f3a85d4ee45d
   category: main
   optional: false
 - name: blosc
@@ -1687,15 +1464,15 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcxx: '>=16'
+    libcxx: '>=18'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.2.0,<1.3.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
+    snappy: '>=1.2.1,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-h7d75f6d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-hd145fbb_1.conda
   hash:
-    md5: 3e5669e51737d04f4806dd3e8c424663
-    sha256: 65e5f5dd3d68ed0d9d35e79d64f8141283cad2b55dcd9a04480ceea0e436aca8
+    md5: 717852102c68a082992ce13a53403f9d
+    sha256: 876bdb1947644b4408f498ac91c61f1f4987d2c57eb47c0aba0d5ee822cd7da9
   category: main
   optional: false
 - name: blosc
@@ -1704,15 +1481,15 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
+    libcxx: '>=18'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.2.0,<1.3.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
+    snappy: '>=1.2.1,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h7dd00d9_1.conda
   hash:
-    md5: e94ca7aec8544f700d45b24aff2dd4d7
-    sha256: 5a1e635a371449a750b776cab64ad83f5218b58b3f137ebd33ad3ec17f1ce92e
+    md5: 925acfb50a750aa178f7a0aced77f351
+    sha256: c3fe902114b9a3ac837e1a32408cc2142c147ec054c1038d37aec6814343f48a
   category: main
   optional: false
 - name: boltons
@@ -1752,48 +1529,48 @@ package:
   category: main
   optional: false
 - name: boto3
-  version: 1.36.3
+  version: 1.36.14
   manager: conda
   platform: linux-64
   dependencies:
-    botocore: '>=1.36.3,<1.37.0'
+    botocore: '>=1.36.14,<1.37.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.9'
     s3transfer: '>=0.11.0,<0.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 2ce714023bbdc1a381ec55505da2e113
-    sha256: 7d649962da531389e078b93459b668fc132238ac977e84c6bfa399a224edc3bf
+    md5: 8594f2e4a0840816b02b4589fa3a0fd0
+    sha256: 60be8c80c92b87154fc434b0f65aa6ab49cb64b7e67af388cf49a9fc447ee301
   category: main
   optional: false
 - name: boto3
-  version: 1.36.3
+  version: 1.36.14
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.9'
     jmespath: '>=0.7.1,<2.0.0'
     s3transfer: '>=0.11.0,<0.12.0'
-    botocore: '>=1.36.3,<1.37.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.3-pyhd8ed1ab_0.conda
+    botocore: '>=1.36.14,<1.37.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 2ce714023bbdc1a381ec55505da2e113
-    sha256: 7d649962da531389e078b93459b668fc132238ac977e84c6bfa399a224edc3bf
+    md5: 8594f2e4a0840816b02b4589fa3a0fd0
+    sha256: 60be8c80c92b87154fc434b0f65aa6ab49cb64b7e67af388cf49a9fc447ee301
   category: main
   optional: false
 - name: boto3
-  version: 1.36.3
+  version: 1.36.14
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9'
     jmespath: '>=0.7.1,<2.0.0'
     s3transfer: '>=0.11.0,<0.12.0'
-    botocore: '>=1.36.3,<1.37.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.3-pyhd8ed1ab_0.conda
+    botocore: '>=1.36.14,<1.37.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.36.14-pyhd8ed1ab_0.conda
   hash:
-    md5: 2ce714023bbdc1a381ec55505da2e113
-    sha256: 7d649962da531389e078b93459b668fc132238ac977e84c6bfa399a224edc3bf
+    md5: 8594f2e4a0840816b02b4589fa3a0fd0
+    sha256: 60be8c80c92b87154fc434b0f65aa6ab49cb64b7e67af388cf49a9fc447ee301
   category: main
   optional: false
 - name: boto3-stubs
@@ -1899,7 +1676,7 @@ package:
   category: dev
   optional: true
 - name: botocore
-  version: 1.36.3
+  version: 1.36.14
   manager: conda
   platform: linux-64
   dependencies:
@@ -1907,14 +1684,14 @@ package:
     python: '>=3.10'
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.3-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.14-pyge310_1234567_0.conda
   hash:
-    md5: d21b74ea6fe0795af13a62f00f5258f3
-    sha256: 3d41462f9f40d0e15b665ad0123693877b9445eca3ed1f16fa698fc5c2e66948
+    md5: e6688d833f6cb38c3d4e18fe62d19f08
+    sha256: 64e14a80462ea95bb55bb2d019c8fded4e7f17978d96d43349577f72da5a6115
   category: main
   optional: false
 - name: botocore
-  version: 1.36.3
+  version: 1.36.14
   manager: conda
   platform: osx-64
   dependencies:
@@ -1922,14 +1699,14 @@ package:
     python-dateutil: '>=2.1,<3.0.0'
     jmespath: '>=0.7.1,<2.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.3-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.14-pyge310_1234567_0.conda
   hash:
-    md5: d21b74ea6fe0795af13a62f00f5258f3
-    sha256: 3d41462f9f40d0e15b665ad0123693877b9445eca3ed1f16fa698fc5c2e66948
+    md5: e6688d833f6cb38c3d4e18fe62d19f08
+    sha256: 64e14a80462ea95bb55bb2d019c8fded4e7f17978d96d43349577f72da5a6115
   category: main
   optional: false
 - name: botocore
-  version: 1.36.3
+  version: 1.36.14
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1937,10 +1714,10 @@ package:
     python-dateutil: '>=2.1,<3.0.0'
     jmespath: '>=0.7.1,<2.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.3-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.36.14-pyge310_1234567_0.conda
   hash:
-    md5: d21b74ea6fe0795af13a62f00f5258f3
-    sha256: 3d41462f9f40d0e15b665ad0123693877b9445eca3ed1f16fa698fc5c2e66948
+    md5: e6688d833f6cb38c3d4e18fe62d19f08
+    sha256: 64e14a80462ea95bb55bb2d019c8fded4e7f17978d96d43349577f72da5a6115
   category: main
   optional: false
 - name: botocore-stubs
@@ -2504,79 +2281,6 @@ package:
     sha256: 2560a98e3dc0ff4ff408a199d05922ae10fab2629417c4c4309e4226267cef8c
   category: main
   optional: false
-- name: cairo
-  version: 1.18.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    fontconfig: '>=2.15.0,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=75.1,<76.0a0'
-    libexpat: '>=2.6.4,<3.0a0'
-    libgcc: '>=13'
-    libglib: '>=2.82.2,<3.0a0'
-    libpng: '>=1.6.44,<1.7.0a0'
-    libstdcxx: '>=13'
-    libxcb: '>=1.17.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pixman: '>=0.44.2,<1.0a0'
-    xorg-libice: '>=1.1.1,<2.0a0'
-    xorg-libsm: '>=1.2.4,<2.0a0'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-    xorg-libxext: '>=1.3.6,<2.0a0'
-    xorg-libxrender: '>=0.9.11,<0.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.2-h3394656_1.conda
-  hash:
-    md5: b34c2833a1f56db610aeb27f206d800d
-    sha256: de7d0d094e53decc005cb13e527be2635b8f604978da497d4c0d282c7dc08385
-  category: dev
-  optional: true
-- name: cairo
-  version: 1.18.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    fontconfig: '>=2.15.0,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=75.1,<76.0a0'
-    libcxx: '>=18'
-    libexpat: '>=2.6.4,<3.0a0'
-    libglib: '>=2.82.2,<3.0a0'
-    libpng: '>=1.6.44,<1.7.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pixman: '>=0.44.2,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.2-h950ec3b_1.conda
-  hash:
-    md5: ae293443dff77ba14eab9e9ee68ec833
-    sha256: ad8c41650e5a10d9177e9d92652d2bd5fe9eefa095ebd4805835c3f067c0202b
-  category: dev
-  optional: true
-- name: cairo
-  version: 1.18.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    fontconfig: '>=2.15.0,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=75.1,<76.0a0'
-    libcxx: '>=18'
-    libexpat: '>=2.6.4,<3.0a0'
-    libglib: '>=2.82.2,<3.0a0'
-    libpng: '>=1.6.44,<1.7.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pixman: '>=0.44.2,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.2-h6a3b0d2_1.conda
-  hash:
-    md5: 8e3666c3f6e2c3e57aa261ab103a3600
-    sha256: 9a28344e806b89c87fda0cdabd2fb961e5d2ff97107dba25bac9f5dc57220cc3
-  category: dev
-  optional: true
 - name: certifi
   version: 2024.12.14
   manager: conda
@@ -2698,78 +2402,6 @@ package:
     sha256: d5696636733b3c301054b948cdd793f118efacce361d9bd4afb57d5980a9064f
   category: dev
   optional: true
-- name: cfn-lint
-  version: 1.24.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-sam-translator: '>=1.94.0'
-    jschema-to-python: '>=1.2.3,<1.3.dev0'
-    jsonpatch: ''
-    junit-xml: '>=1.9,<2.dev0'
-    networkx: '>=2.4,<4'
-    pydot: ''
-    python: '>=3.9,<4.0'
-    pyyaml: '>5.4'
-    regex: ''
-    sarif-om: '>=1.0.4,<1.1.dev0'
-    sympy: '>=1.0.0'
-    typing-extensions: ''
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/cfn-lint-1.24.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ea4081d2415fbcf0715fb46ca52610d8
-    sha256: 1f5a49315ab6bd0f925fdbf0ca9e5858d5f03d34c0c2a0e5258c111ee312f150
-  category: dev
-  optional: true
-- name: cfn-lint
-  version: 1.24.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    typing_extensions: ''
-    typing-extensions: ''
-    regex: ''
-    pydot: ''
-    jsonpatch: ''
-    python: '>=3.9,<4.0'
-    pyyaml: '>5.4'
-    sympy: '>=1.0.0'
-    jschema-to-python: '>=1.2.3,<1.3.dev0'
-    junit-xml: '>=1.9,<2.dev0'
-    networkx: '>=2.4,<4'
-    sarif-om: '>=1.0.4,<1.1.dev0'
-    aws-sam-translator: '>=1.94.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cfn-lint-1.24.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ea4081d2415fbcf0715fb46ca52610d8
-    sha256: 1f5a49315ab6bd0f925fdbf0ca9e5858d5f03d34c0c2a0e5258c111ee312f150
-  category: dev
-  optional: true
-- name: cfn-lint
-  version: 1.24.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    typing_extensions: ''
-    typing-extensions: ''
-    regex: ''
-    pydot: ''
-    jsonpatch: ''
-    python: '>=3.9,<4.0'
-    pyyaml: '>5.4'
-    sympy: '>=1.0.0'
-    jschema-to-python: '>=1.2.3,<1.3.dev0'
-    junit-xml: '>=1.9,<2.dev0'
-    networkx: '>=2.4,<4'
-    sarif-om: '>=1.0.4,<1.1.dev0'
-    aws-sam-translator: '>=1.94.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cfn-lint-1.24.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ea4081d2415fbcf0715fb46ca52610d8
-    sha256: 1f5a49315ab6bd0f925fdbf0ca9e5858d5f03d34c0c2a0e5258c111ee312f150
-  category: dev
-  optional: true
 - name: charset-normalizer
   version: 3.4.1
   manager: conda
@@ -3116,7 +2748,7 @@ package:
   category: dev
   optional: true
 - name: conda
-  version: 24.11.3
+  version: 25.1.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -3141,14 +2773,14 @@ package:
     tqdm: '>=4'
     truststore: '>=0.8.0'
     zstandard: '>=0.19.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/conda-24.11.3-py312h7900ff3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/conda-25.1.1-py312h7900ff3_0.conda
   hash:
-    md5: bdaca5d82db98d8b5639f058a818ff03
-    sha256: dbf0b37da0cd3eb2ee5535467c13c16fc2c2a1bc959d68fde89c60b3fec78763
+    md5: cd2912e82cd83aeaba54e17dbc2802cb
+    sha256: a8a6ddf6b579bf7f8c3858389187910242a9fb09ac9e5146ef284d2e11fb1e5d
   category: main
   optional: false
 - name: conda
-  version: 24.11.3
+  version: 25.1.1
   manager: conda
   platform: osx-64
   dependencies:
@@ -3173,14 +2805,14 @@ package:
     tqdm: '>=4'
     truststore: '>=0.8.0'
     zstandard: '>=0.19.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/conda-24.11.3-py312hb401068_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/conda-25.1.1-py312hb401068_0.conda
   hash:
-    md5: b19d45d499a4249ef39db67162f4be7b
-    sha256: 393d8a2109d551a3fb03a69d32c4f48b57aeec61f59c582f861fcc59f62e2940
+    md5: 9bf30346238544016b082e0198fc97fa
+    sha256: 9e336511f06080d081fe3b0ec884826783915016ecd7d17a8b873107570b69dd
   category: main
   optional: false
 - name: conda
-  version: 24.11.3
+  version: 25.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3205,10 +2837,10 @@ package:
     tqdm: '>=4'
     truststore: '>=0.8.0'
     zstandard: '>=0.19.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/conda-24.11.3-py312h81bd7bf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/conda-25.1.1-py312h81bd7bf_0.conda
   hash:
-    md5: 18fa2b450241200ac0e9f3ce77efa839
-    sha256: 5204b7e937d08597c0d7ab14591d71a3f42d46eff40b36a7568e7dbd0ecf8d1d
+    md5: 5bd0a8303bb7fb50da00a16ce8beb10f
+    sha256: 029cd5fd0818b3c694b49a51854230d5df5cb0b703fca73f555400c961d0fd47
   category: main
   optional: false
 - name: conda-libmamba-solver
@@ -3594,45 +3226,6 @@ package:
     sha256: 9af3323963a059681eb848218c11ba2208f12bc5416ee357b0d4f9f8bef5ebca
   category: main
   optional: false
-- name: cpython
-  version: 3.12.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: 3.12.8.*
-    python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.8-py312hd8ed1ab_1.conda
-  hash:
-    md5: caa04d37126e82822468d6bdf50f5ebd
-    sha256: 05413d84485086301e5bd7c03fca2caae91f75474d99d9fc815cec912332452b
-  category: dev
-  optional: true
-- name: cpython
-  version: 3.12.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python_abi: '*'
-    python: 3.12.8.*
-  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.8-py312hd8ed1ab_1.conda
-  hash:
-    md5: caa04d37126e82822468d6bdf50f5ebd
-    sha256: 05413d84485086301e5bd7c03fca2caae91f75474d99d9fc815cec912332452b
-  category: dev
-  optional: true
-- name: cpython
-  version: 3.12.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python_abi: '*'
-    python: 3.12.8.*
-  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.8-py312hd8ed1ab_1.conda
-  hash:
-    md5: caa04d37126e82822468d6bdf50f5ebd
-    sha256: 05413d84485086301e5bd7c03fca2caae91f75474d99d9fc815cec912332452b
-  category: dev
-  optional: true
 - name: crashtest
   version: 0.4.1
   manager: conda
@@ -4002,99 +3595,6 @@ package:
     sha256: 5603c7d0321963bb9b4030eadabc3fd7ca6103a38475b4e0ed13ed6d97c86f4e
   category: main
   optional: false
-- name: docker-py
-  version: 7.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    paramiko: '>=2.4.3'
-    python: '>=3.9'
-    pywin32-on-windows: ''
-    requests: '>=2.26.0'
-    urllib3: '>=1.26.0'
-    websocket-client: '>=0.32.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-7.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 07ce73ca6f6c1a1df5d498679fc52d9e
-    sha256: 909bad7898ef2933a7efe69a48200e2331a362b0a1edd2d592942cde1f130979
-  category: dev
-  optional: true
-- name: docker-py
-  version: 7.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    pywin32-on-windows: ''
-    python: '>=3.9'
-    requests: '>=2.26.0'
-    urllib3: '>=1.26.0'
-    websocket-client: '>=0.32.0'
-    paramiko: '>=2.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-7.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 07ce73ca6f6c1a1df5d498679fc52d9e
-    sha256: 909bad7898ef2933a7efe69a48200e2331a362b0a1edd2d592942cde1f130979
-  category: dev
-  optional: true
-- name: docker-py
-  version: 7.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    pywin32-on-windows: ''
-    python: '>=3.9'
-    requests: '>=2.26.0'
-    urllib3: '>=1.26.0'
-    websocket-client: '>=0.32.0'
-    paramiko: '>=2.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-7.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 07ce73ca6f6c1a1df5d498679fc52d9e
-    sha256: 909bad7898ef2933a7efe69a48200e2331a362b0a1edd2d592942cde1f130979
-  category: dev
-  optional: true
-- name: ecdsa
-  version: 0.19.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gmpy2: ''
-    python: '>=3.9'
-    six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ecdsa-0.19.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 3b5baf4fb277368a6e79f2bf7c97a401
-    sha256: a78f5c45a940e4f91ea45972695f57a6c4f77982acac47b1f5dc3467d8be01b6
-  category: dev
-  optional: true
-- name: ecdsa
-  version: 0.19.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    gmpy2: ''
-    python: '>=3.9'
-    six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ecdsa-0.19.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 3b5baf4fb277368a6e79f2bf7c97a401
-    sha256: a78f5c45a940e4f91ea45972695f57a6c4f77982acac47b1f5dc3467d8be01b6
-  category: dev
-  optional: true
-- name: ecdsa
-  version: 0.19.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    gmpy2: ''
-    python: '>=3.9'
-    six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ecdsa-0.19.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 3b5baf4fb277368a6e79f2bf7c97a401
-    sha256: a78f5c45a940e4f91ea45972695f57a6c4f77982acac47b1f5dc3467d8be01b6
-  category: dev
-  optional: true
 - name: ensureconda
   version: 1.4.4
   manager: conda
@@ -4146,40 +3646,6 @@ package:
     sha256: 4efc864d9245a30f15bbc6eb12d06a5cf7a11d91d3e2c84630df1ce83f8b9878
   category: main
   optional: false
-- name: epoxy
-  version: 1.5.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=10.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-h166bdaf_1.tar.bz2
-  hash:
-    md5: a089d06164afd2d511347d3f87214e0b
-    sha256: 1e58ee2ed0f4699be202f23d49b9644b499836230da7dd5b2f63e6766acff89e
-  category: dev
-  optional: true
-- name: epoxy
-  version: 1.5.10
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/epoxy-1.5.10-h5eb16cf_1.tar.bz2
-  hash:
-    md5: 721a46794b9ad1301115068189acb750
-    sha256: 0e344e8490237565a5685736421e06b47a1b46dee7151c0973dd48130f8e583a
-  category: dev
-  optional: true
-- name: epoxy
-  version: 1.5.10
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/epoxy-1.5.10-h1c322ee_1.tar.bz2
-  hash:
-    md5: 20dd7359a6052120d52e1e13b4c818b9
-    sha256: 8b93dbebab0fe12ece4767e6a2dc53a6600319ece0b8ba5121715f28c7b0f8d1
-  category: dev
-  optional: true
 - name: exceptiongroup
   version: 1.2.2
   manager: conda
@@ -4401,46 +3867,43 @@ package:
     sha256: 5eb604e7993c519d8ac5bfe9ce0a50709d4c502bafda4d38f0d4d54da2411a36
   category: dev
   optional: true
-- name: flask_cors
-  version: 4.0.0
+- name: flask-cors
+  version: 5.0.0
   manager: conda
   platform: linux-64
   dependencies:
     flask: '>=0.9'
-    python: '>=3.6'
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/flask_cors-4.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-cors-5.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ee54b19f948680ed98645b3e5bee6e47
-    sha256: f7316ced92b144244c9a4e29cf18f4fc3cb2269c12f1e715905c91bb279f1c64
+    md5: 00417f00eb4fad0b01474a0987e2a8c3
+    sha256: b1f8e4cb32319a9a94e265ae9c34e34d3a1704bab7b19716c89681bacab56ad9
   category: dev
   optional: true
-- name: flask_cors
-  version: 4.0.0
+- name: flask-cors
+  version: 5.0.0
   manager: conda
   platform: osx-64
   dependencies:
-    six: ''
-    python: '>=3.6'
+    python: '>=3.9'
     flask: '>=0.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/flask_cors-4.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-cors-5.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ee54b19f948680ed98645b3e5bee6e47
-    sha256: f7316ced92b144244c9a4e29cf18f4fc3cb2269c12f1e715905c91bb279f1c64
+    md5: 00417f00eb4fad0b01474a0987e2a8c3
+    sha256: b1f8e4cb32319a9a94e265ae9c34e34d3a1704bab7b19716c89681bacab56ad9
   category: dev
   optional: true
-- name: flask_cors
-  version: 4.0.0
+- name: flask-cors
+  version: 5.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    six: ''
-    python: '>=3.6'
+    python: '>=3.9'
     flask: '>=0.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/flask_cors-4.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-cors-5.0.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ee54b19f948680ed98645b3e5bee6e47
-    sha256: f7316ced92b144244c9a4e29cf18f4fc3cb2269c12f1e715905c91bb279f1c64
+    md5: 00417f00eb4fad0b01474a0987e2a8c3
+    sha256: b1f8e4cb32319a9a94e265ae9c34e34d3a1704bab7b19716c89681bacab56ad9
   category: dev
   optional: true
 - name: fmt
@@ -4534,266 +3997,6 @@ package:
     sha256: 5db2c83bf48c2f1ea758e17a68cfb2ec691ad4a9bc4b196058917461be24b313
   category: main
   optional: false
-- name: font-ttf-dejavu-sans-mono
-  version: '2.37'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  hash:
-    md5: 0c96522c6bdaed4b1566d11387caaf45
-    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  category: dev
-  optional: true
-- name: font-ttf-dejavu-sans-mono
-  version: '2.37'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  hash:
-    md5: 0c96522c6bdaed4b1566d11387caaf45
-    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  category: dev
-  optional: true
-- name: font-ttf-dejavu-sans-mono
-  version: '2.37'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  hash:
-    md5: 0c96522c6bdaed4b1566d11387caaf45
-    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  category: dev
-  optional: true
-- name: font-ttf-inconsolata
-  version: '3.000'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  hash:
-    md5: 34893075a5c9e55cdafac56607368fc6
-    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  category: dev
-  optional: true
-- name: font-ttf-inconsolata
-  version: '3.000'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  hash:
-    md5: 34893075a5c9e55cdafac56607368fc6
-    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  category: dev
-  optional: true
-- name: font-ttf-inconsolata
-  version: '3.000'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  hash:
-    md5: 34893075a5c9e55cdafac56607368fc6
-    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  category: dev
-  optional: true
-- name: font-ttf-source-code-pro
-  version: '2.038'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  hash:
-    md5: 4d59c254e01d9cde7957100457e2d5fb
-    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  category: dev
-  optional: true
-- name: font-ttf-source-code-pro
-  version: '2.038'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  hash:
-    md5: 4d59c254e01d9cde7957100457e2d5fb
-    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  category: dev
-  optional: true
-- name: font-ttf-source-code-pro
-  version: '2.038'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  hash:
-    md5: 4d59c254e01d9cde7957100457e2d5fb
-    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  category: dev
-  optional: true
-- name: font-ttf-ubuntu
-  version: '0.83'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-  hash:
-    md5: 49023d73832ef61042f6a237cb2687e7
-    sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
-  category: dev
-  optional: true
-- name: font-ttf-ubuntu
-  version: '0.83'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-  hash:
-    md5: 49023d73832ef61042f6a237cb2687e7
-    sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
-  category: dev
-  optional: true
-- name: font-ttf-ubuntu
-  version: '0.83'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-  hash:
-    md5: 49023d73832ef61042f6a237cb2687e7
-    sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
-  category: dev
-  optional: true
-- name: fontconfig
-  version: 2.15.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    freetype: '>=2.12.1,<3.0a0'
-    libexpat: '>=2.6.3,<3.0a0'
-    libgcc: '>=13'
-    libuuid: '>=2.38.1,<3.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
-  hash:
-    md5: 8f5b0b297b59e1ac160ad4beec99dbee
-    sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
-  category: dev
-  optional: true
-- name: fontconfig
-  version: 2.15.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    freetype: '>=2.12.1,<3.0a0'
-    libexpat: '>=2.6.3,<3.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.15.0-h37eeddb_1.conda
-  hash:
-    md5: 84ccec5ee37eb03dd352db0a3f89ada3
-    sha256: 61a9aa1d2dd115ffc1ab372966dc8b1ac7b69870e6b1744641da276b31ea5c0b
-  category: dev
-  optional: true
-- name: fontconfig
-  version: 2.15.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    freetype: '>=2.12.1,<3.0a0'
-    libexpat: '>=2.6.3,<3.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.15.0-h1383a14_1.conda
-  hash:
-    md5: 7b29f48742cea5d1ccb5edd839cb5621
-    sha256: f79d3d816fafbd6a2b0f75ebc3251a30d3294b08af9bb747194121f5efa364bc
-  category: dev
-  optional: true
-- name: fonts-conda-ecosystem
-  version: '1'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    fonts-conda-forge: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  hash:
-    md5: fee5683a3f04bd15cbd8318b096a27ab
-    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  category: dev
-  optional: true
-- name: fonts-conda-ecosystem
-  version: '1'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    fonts-conda-forge: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  hash:
-    md5: fee5683a3f04bd15cbd8318b096a27ab
-    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  category: dev
-  optional: true
-- name: fonts-conda-ecosystem
-  version: '1'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    fonts-conda-forge: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  hash:
-    md5: fee5683a3f04bd15cbd8318b096a27ab
-    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  category: dev
-  optional: true
-- name: fonts-conda-forge
-  version: '1'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    font-ttf-dejavu-sans-mono: ''
-    font-ttf-inconsolata: ''
-    font-ttf-source-code-pro: ''
-    font-ttf-ubuntu: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-  hash:
-    md5: f766549260d6815b0c52253f1fb1bb29
-    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  category: dev
-  optional: true
-- name: fonts-conda-forge
-  version: '1'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    font-ttf-ubuntu: ''
-    font-ttf-inconsolata: ''
-    font-ttf-source-code-pro: ''
-    font-ttf-dejavu-sans-mono: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-  hash:
-    md5: f766549260d6815b0c52253f1fb1bb29
-    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  category: dev
-  optional: true
-- name: fonts-conda-forge
-  version: '1'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    font-ttf-ubuntu: ''
-    font-ttf-inconsolata: ''
-    font-ttf-source-code-pro: ''
-    font-ttf-dejavu-sans-mono: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-  hash:
-    md5: f766549260d6815b0c52253f1fb1bb29
-    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  category: dev
-  optional: true
 - name: fonttools
   version: 4.55.8
   manager: conda
@@ -4932,40 +4135,6 @@ package:
     sha256: b4146ac9ba1676494e3d812ca39664dd7dd454e4d0984f3665fd6feec318c71c
   category: main
   optional: false
-- name: fribidi
-  version: 1.0.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
-  hash:
-    md5: ac7bc6a654f8f41b352b38f4051135f8
-    sha256: 5d7b6c0ee7743ba41399e9e05a58ccc1cfc903942e49ff6f677f6e423ea7a627
-  category: dev
-  optional: true
-- name: fribidi
-  version: 1.0.10
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
-  hash:
-    md5: f1c6b41e0f56998ecd9a3e210faa1dc0
-    sha256: 4f6db86ecc4984cd4ac88ca52030726c3cfd11a64dfb15c8602025ee3001a2b5
-  category: dev
-  optional: true
-- name: fribidi
-  version: 1.0.10
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
-  hash:
-    md5: c64443234ff91d70cb9c7dc926c58834
-    sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
-  category: dev
-  optional: true
 - name: frozendict
   version: 2.4.6
   manager: conda
@@ -5009,135 +4178,42 @@ package:
     sha256: 357cef10885bd2fb5d5d3197a8565d0c0b86fffd0dbaff58acee29f7d897a935
   category: main
   optional: false
-- name: frozenlist
-  version: 1.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.5.0-py312h178313f_1.conda
-  hash:
-    md5: fb986e1c089021979dc79606af78ef8f
-    sha256: 501e20626798b6d7f130f4db0fb02c0385d8f4c11ca525925602a4208afb343f
-  category: main
-  optional: false
-- name: frozenlist
-  version: 1.5.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.5.0-py312h3520af0_1.conda
-  hash:
-    md5: 887a4fa613758220fff7641b9d3ead95
-    sha256: 332d78beaec0ab79f176656e71b819d75bb72a9a9c99bb1dc0387c7f0c34f016
-  category: main
-  optional: false
-- name: frozenlist
-  version: 1.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.5.0-py312h998013c_1.conda
-  hash:
-    md5: 5eb3715c7e3fa9b533361375bfefe6ee
-    sha256: d503ac8c050abdbd129253973f23be34944978d510de78ef5a3e6aa1e3d9552d
-  category: main
-  optional: false
 - name: fsspec
-  version: 2024.12.0
+  version: 2025.2.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.12.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: e041ad4c43ab5e10c74587f95378ebc7
-    sha256: 3320970c4604989eadf908397a9475f9e6a96a773c185915111399cbfbe47817
+    md5: d9ea16b71920b03beafc17fcca16df90
+    sha256: 7433b8469074985b651693778ec6f03d2a23fad9919a515e3b8545996b5e721a
   category: main
   optional: false
 - name: fsspec
-  version: 2024.12.0
+  version: 2025.2.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.12.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: e041ad4c43ab5e10c74587f95378ebc7
-    sha256: 3320970c4604989eadf908397a9475f9e6a96a773c185915111399cbfbe47817
+    md5: d9ea16b71920b03beafc17fcca16df90
+    sha256: 7433b8469074985b651693778ec6f03d2a23fad9919a515e3b8545996b5e721a
   category: main
   optional: false
 - name: fsspec
-  version: 2024.12.0
+  version: 2025.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.12.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: e041ad4c43ab5e10c74587f95378ebc7
-    sha256: 3320970c4604989eadf908397a9475f9e6a96a773c185915111399cbfbe47817
+    md5: d9ea16b71920b03beafc17fcca16df90
+    sha256: 7433b8469074985b651693778ec6f03d2a23fad9919a515e3b8545996b5e721a
   category: main
   optional: false
-- name: gdk-pixbuf
-  version: 2.42.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.2,<3.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
-  hash:
-    md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
-    sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
-  category: dev
-  optional: true
-- name: gdk-pixbuf
-  version: 2.42.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libglib: '>=2.80.2,<3.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gdk-pixbuf-2.42.12-ha587570_0.conda
-  hash:
-    md5: ee186d2e8db4605030753dc05025d4a0
-    sha256: 92cb602ef86feb35252ee909e19536fa043bd85b8507450ad8264cfa518a5881
-  category: dev
-  optional: true
-- name: gdk-pixbuf
-  version: 2.42.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libglib: '>=2.80.2,<3.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.42.12-h7ddc832_0.conda
-  hash:
-    md5: 151309a7e1eb57a3c2ab8088a1d74f3e
-    sha256: 72bcf0a4d3f9aa6d99d7d1d224d19f76ccdb3a4fa85e60f77d17e17985c81bd2
-  category: dev
-  optional: true
 - name: geographiclib
   version: '2.0'
   manager: conda
@@ -5568,48 +4644,6 @@ package:
     sha256: b996e717ca693e4e831d3d3143aca3abb47536561306195002b226fe4dde53c3
   category: main
   optional: false
-- name: glib-tools
-  version: 2.82.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libglib: 2.82.2
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.82.2-h4833e2c_1.conda
-  hash:
-    md5: e2e44caeaef6e4b107577aa46c95eb12
-    sha256: 5d8a48abdb1bc2b54f1380d2805cb9cd6cd9609ed0e5c3ed272aef92ab53b190
-  category: dev
-  optional: true
-- name: glib-tools
-  version: 2.82.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libglib: 2.82.2
-    libintl: '>=0.22.5,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.82.2-hf8faeaf_1.conda
-  hash:
-    md5: 9c64be7c2dbbdde429d12a84c538ef1e
-    sha256: d626c650d320ca14c259a7aa12283c452b3ca1e58191c29b820001725822285e
-  category: dev
-  optional: true
-- name: glib-tools
-  version: 2.82.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libglib: 2.82.2
-    libintl: '>=0.22.5,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.82.2-h1dc7a0c_1.conda
-  hash:
-    md5: bdc35b7b75b7cd2bcfd288e399333f29
-    sha256: b6874fea5674855149f929899126e4298d020945f3d9c6a7955d14ede1855e3a
-  category: dev
-  optional: true
 - name: glog
   version: 0.7.1
   manager: conda
@@ -5655,19 +4689,6 @@ package:
 - name: gmp
   version: 6.3.0
   manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
-  hash:
-    md5: c94a5994ef49749880a8139cf9afcbe1
-    sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
-  category: dev
-  optional: true
-- name: gmp
-  version: 6.3.0
-  manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
@@ -5689,351 +4710,6 @@ package:
   hash:
     md5: eed7278dfbab727b56f2c0b64330814b
     sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
-  category: dev
-  optional: true
-- name: gmpy2
-  version: 2.1.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    gmp: '>=6.3.0,<7.0a0'
-    libgcc: '>=13'
-    mpc: '>=1.3.1,<2.0a0'
-    mpfr: '>=4.2.1,<5.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.1.5-py312h7201bc8_3.conda
-  hash:
-    md5: 673ef4d6611f5b4ca7b5c1f8c65a38dc
-    sha256: addd0bc226ca86c11f1223ab322d12b67501c2b3d93749bdab2068ccaedd8ef0
-  category: dev
-  optional: true
-- name: gmpy2
-  version: 2.1.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    gmp: '>=6.3.0,<7.0a0'
-    mpc: '>=1.3.1,<2.0a0'
-    mpfr: '>=4.2.1,<5.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/gmpy2-2.1.5-py312h068713c_3.conda
-  hash:
-    md5: 02d900885f1af6fcf7646fdf847cad3b
-    sha256: 5f3411b2520ec3a27e6047a0fae057d37cb9caf035e196f85c888320d473ce1e
-  category: dev
-  optional: true
-- name: gmpy2
-  version: 2.1.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    gmp: '>=6.3.0,<7.0a0'
-    mpc: '>=1.3.1,<2.0a0'
-    mpfr: '>=4.2.1,<5.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.1.5-py312h524cf62_3.conda
-  hash:
-    md5: ab7a5d10c7b4e249a9fe7bc280909803
-    sha256: 0ea196e4b706321951af1eebdb6a4eb9307faa1fd5361bcf49acb150e71774f7
-  category: dev
-  optional: true
-- name: graphite2
-  version: 1.3.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
-  hash:
-    md5: f87c7b7c2cb45f323ffbce941c78ab7c
-    sha256: 0595b009f20f8f60f13a6398e7cdcbd2acea5f986633adcf85f5a2283c992add
-  category: dev
-  optional: true
-- name: graphite2
-  version: 1.3.13
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.13-h73e2aa4_1003.conda
-  hash:
-    md5: fc7124f86e1d359fc5d878accd9e814c
-    sha256: b71db966e47cd83b16bfcc2099b8fa87c07286f24a0742078fede4c84314f91a
-  category: dev
-  optional: true
-- name: graphite2
-  version: 1.3.13
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-hebf3989_1003.conda
-  hash:
-    md5: 339991336eeddb70076d8ca826dac625
-    sha256: 2eadafbfc52f5e7df3da3c3b7e5bbe34d970bea1d645ffe60b0b1c3a216657f5
-  category: dev
-  optional: true
-- name: graphql-core
-  version: 3.2.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-    typing_extensions: '>=4.1,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/graphql-core-3.2.6-pyh29332c3_0.conda
-  hash:
-    md5: dc604341f71b370f8a4a0a3b2996cd99
-    sha256: 6395a2a9964f044d891b54a984993c703327129374c0fdf20d88b4506830bc2a
-  category: dev
-  optional: true
-- name: graphql-core
-  version: 3.2.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-    typing_extensions: '>=4.1,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/graphql-core-3.2.6-pyh29332c3_0.conda
-  hash:
-    md5: dc604341f71b370f8a4a0a3b2996cd99
-    sha256: 6395a2a9964f044d891b54a984993c703327129374c0fdf20d88b4506830bc2a
-  category: dev
-  optional: true
-- name: graphql-core
-  version: 3.2.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-    typing_extensions: '>=4.1,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/graphql-core-3.2.6-pyh29332c3_0.conda
-  hash:
-    md5: dc604341f71b370f8a4a0a3b2996cd99
-    sha256: 6395a2a9964f044d891b54a984993c703327129374c0fdf20d88b4506830bc2a
-  category: dev
-  optional: true
-- name: graphviz
-  version: 12.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    adwaita-icon-theme: ''
-    cairo: '>=1.18.2,<2.0a0'
-    fonts-conda-ecosystem: ''
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    gtk3: '>=3.24.43,<4.0a0'
-    gts: '>=0.7.6,<0.8.0a0'
-    libexpat: '>=2.6.4,<3.0a0'
-    libgcc: '>=13'
-    libgd: '>=2.3.3,<2.4.0a0'
-    libglib: '>=2.82.2,<3.0a0'
-    librsvg: '>=2.58.4,<3.0a0'
-    libstdcxx: '>=13'
-    libwebp-base: '>=1.5.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pango: '>=1.56.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphviz-12.2.1-h5ae0cbf_1.conda
-  hash:
-    md5: df7835d2c73cd1889d377cfd6694ada4
-    sha256: e6866409ba03df392ac5ec6f0d6ff9751a685ed917bfbcd8a73f550c5fe83c2b
-  category: dev
-  optional: true
-- name: graphviz
-  version: 12.2.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    adwaita-icon-theme: ''
-    cairo: '>=1.18.2,<2.0a0'
-    fonts-conda-ecosystem: ''
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    gtk3: '>=3.24.43,<4.0a0'
-    gts: '>=0.7.6,<0.8.0a0'
-    libcxx: '>=18'
-    libexpat: '>=2.6.4,<3.0a0'
-    libgd: '>=2.3.3,<2.4.0a0'
-    libglib: '>=2.82.2,<3.0a0'
-    librsvg: '>=2.58.4,<3.0a0'
-    libwebp-base: '>=1.5.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pango: '>=1.56.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/graphviz-12.2.1-h44a0556_1.conda
-  hash:
-    md5: f1e519616cb1c137cff9849cfa1beb93
-    sha256: 3a8eef238000e8fcb8f4f31a035869d7b5ad0466f69c72e9064786b54d1812cc
-  category: dev
-  optional: true
-- name: graphviz
-  version: 12.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    adwaita-icon-theme: ''
-    cairo: '>=1.18.2,<2.0a0'
-    fonts-conda-ecosystem: ''
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    gtk3: '>=3.24.43,<4.0a0'
-    gts: '>=0.7.6,<0.8.0a0'
-    libcxx: '>=18'
-    libexpat: '>=2.6.4,<3.0a0'
-    libgd: '>=2.3.3,<2.4.0a0'
-    libglib: '>=2.82.2,<3.0a0'
-    librsvg: '>=2.58.4,<3.0a0'
-    libwebp-base: '>=1.5.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pango: '>=1.56.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphviz-12.2.1-hff64154_1.conda
-  hash:
-    md5: b0b656550a16dfba7efa1479756c5b63
-    sha256: 54e3ce5668b17ea41fed515e57fbd9e805969df468eaf7ff65389d7f53b46d54
-  category: dev
-  optional: true
-- name: gtk3
-  version: 3.24.43
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    at-spi2-atk: '>=2.38.0,<3.0a0'
-    atk-1.0: '>=2.38.0'
-    cairo: '>=1.18.2,<2.0a0'
-    epoxy: '>=1.5.10,<1.6.0a0'
-    fontconfig: '>=2.15.0,<3.0a0'
-    fonts-conda-ecosystem: ''
-    fribidi: '>=1.0.10,<2.0a0'
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    glib-tools: ''
-    harfbuzz: '>=10.2.0,<11.0a0'
-    hicolor-icon-theme: ''
-    libcups: '>=2.3.3,<3.0a0'
-    libexpat: '>=2.6.4,<3.0a0'
-    libgcc: '>=13'
-    libglib: '>=2.82.2,<3.0a0'
-    liblzma: '>=5.6.3,<6.0a0'
-    libxkbcommon: '>=1.7.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pango: '>=1.56.0,<2.0a0'
-    wayland: '>=1.23.1,<2.0a0'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-    xorg-libxcomposite: '>=0.4.6,<1.0a0'
-    xorg-libxcursor: '>=1.2.3,<2.0a0'
-    xorg-libxdamage: '>=1.1.6,<2.0a0'
-    xorg-libxext: '>=1.3.6,<2.0a0'
-    xorg-libxfixes: '>=6.0.1,<7.0a0'
-    xorg-libxi: '>=1.8.2,<2.0a0'
-    xorg-libxinerama: '>=1.1.5,<1.2.0a0'
-    xorg-libxrandr: '>=1.5.4,<2.0a0'
-    xorg-libxrender: '>=0.9.12,<0.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_3.conda
-  hash:
-    md5: 56c679bcdb8c1d824e927088725862cb
-    sha256: c8f939497b43d90fa2ac9d99b44ed25759a798c305237300508e526de5e78de7
-  category: dev
-  optional: true
-- name: gtk3
-  version: 3.24.43
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    atk-1.0: '>=2.38.0'
-    cairo: '>=1.18.2,<2.0a0'
-    epoxy: '>=1.5.10,<1.6.0a0'
-    fribidi: '>=1.0.10,<2.0a0'
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    glib-tools: ''
-    harfbuzz: '>=10.2.0,<11.0a0'
-    hicolor-icon-theme: ''
-    libasprintf: '>=0.22.5,<1.0a0'
-    libexpat: '>=2.6.4,<3.0a0'
-    libgettextpo: '>=0.22.5,<1.0a0'
-    libglib: '>=2.82.2,<3.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-    liblzma: '>=5.6.3,<6.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pango: '>=1.56.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gtk3-3.24.43-h82a860e_3.conda
-  hash:
-    md5: fc1a95f558be54a6e8445373dd19fd0a
-    sha256: ebf180c29a34d4a317df75c6e32e90845149387716cbc556c5615856bb9e23d3
-  category: dev
-  optional: true
-- name: gtk3
-  version: 3.24.43
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    atk-1.0: '>=2.38.0'
-    cairo: '>=1.18.2,<2.0a0'
-    epoxy: '>=1.5.10,<1.6.0a0'
-    fribidi: '>=1.0.10,<2.0a0'
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    glib-tools: ''
-    harfbuzz: '>=10.2.0,<11.0a0'
-    hicolor-icon-theme: ''
-    libasprintf: '>=0.22.5,<1.0a0'
-    libexpat: '>=2.6.4,<3.0a0'
-    libgettextpo: '>=0.22.5,<1.0a0'
-    libglib: '>=2.82.2,<3.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-    liblzma: '>=5.6.3,<6.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pango: '>=1.56.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gtk3-3.24.43-he7bb075_3.conda
-  hash:
-    md5: bf683088766bb687f27d39f5e128d2b0
-    sha256: 5f52152c0af1953c220e9faf8132f010c4eb85a749319889abc2e17e6c430651
-  category: dev
-  optional: true
-- name: gts
-  version: 0.7.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libglib: '>=2.76.3,<3.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
-  hash:
-    md5: 4d8df0b0db060d33c9a702ada998a8fe
-    sha256: b5cd16262fefb836f69dc26d879b6508d29f8a5c5948a966c47fe99e2e19c99b
-  category: dev
-  optional: true
-- name: gts
-  version: 0.7.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libcxx: '>=15.0.7'
-    libglib: '>=2.76.3,<3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gts-0.7.6-h53e17e3_4.conda
-  hash:
-    md5: 848cc963fcfbd063c7a023024aa3bec0
-    sha256: d5b82a36f7e9d7636b854e56d1b4fe01c4d895128a7b73e2ec6945b691ff3314
-  category: dev
-  optional: true
-- name: gts
-  version: 0.7.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=15.0.7'
-    libglib: '>=2.76.3,<3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
-  hash:
-    md5: 21b4dd3098f63a74cf2aa9159cbef57d
-    sha256: e0f8c7bc1b9ea62ded78ffa848e37771eeaaaf55b3146580513c7266862043ba
   category: dev
   optional: true
 - name: h5py
@@ -6088,67 +4764,6 @@ package:
     sha256: 8d1441742c14e7e989e3845d9251717882d8ae8c49769830fa3e12b94170fe9a
   category: main
   optional: false
-- name: harfbuzz
-  version: 10.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cairo: '>=1.18.2,<2.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    graphite2: ''
-    icu: '>=75.1,<76.0a0'
-    libexpat: '>=2.6.4,<3.0a0'
-    libgcc: '>=13'
-    libglib: '>=2.82.2,<3.0a0'
-    libstdcxx: '>=13'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-10.2.0-h4bba637_0.conda
-  hash:
-    md5: 9e38e86167e8b1ea0094747d12944ce4
-    sha256: 94426eca8c60b43f57beb3338d3298dda09452c7a42314bbbb4ebfa552542a84
-  category: dev
-  optional: true
-- name: harfbuzz
-  version: 10.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    cairo: '>=1.18.2,<2.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    graphite2: ''
-    icu: '>=75.1,<76.0a0'
-    libcxx: '>=18'
-    libexpat: '>=2.6.4,<3.0a0'
-    libglib: '>=2.82.2,<3.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-10.2.0-h5b25545_0.conda
-  hash:
-    md5: 61e64e76917a6c7f62a405f3c8569592
-    sha256: 06253714b6b1541b5e5f695b89d145d60c73968360905aecd312e083f6b9ec6c
-  category: dev
-  optional: true
-- name: harfbuzz
-  version: 10.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    cairo: '>=1.18.2,<2.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    graphite2: ''
-    icu: '>=75.1,<76.0a0'
-    libcxx: '>=18'
-    libexpat: '>=2.6.4,<3.0a0'
-    libglib: '>=2.82.2,<3.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-10.2.0-ha0dd535_0.conda
-  hash:
-    md5: 30377b8ff7d4e8a2c08be6957999c100
-    sha256: e9d148870adbe8efd9913fb036461d337609359b5d4474d0963d8ebe6b9789b2
-  category: dev
-  optional: true
 - name: hdf5
   version: 1.14.4
   manager: conda
@@ -6207,39 +4822,6 @@ package:
     sha256: 1746cd2465832bf23d1e91b680935655dea9053d51e526deea86b0afb0b9d6a3
   category: main
   optional: false
-- name: hicolor-icon-theme
-  version: '0.17'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
-  hash:
-    md5: bbf6f174dcd3254e19a2f5d2295ce808
-    sha256: 336f29ceea9594f15cc8ec4c45fdc29e10796573c697ee0d57ebb7edd7e92043
-  category: dev
-  optional: true
-- name: hicolor-icon-theme
-  version: '0.17'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/hicolor-icon-theme-0.17-h694c41f_2.tar.bz2
-  hash:
-    md5: f64218f19d9a441e80343cea13be1afb
-    sha256: a5cb0c03d731bfb09b4262a3afdeae33bef98bc73972f1bd6b7e3fcd240bea41
-  category: dev
-  optional: true
-- name: hicolor-icon-theme
-  version: '0.17'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_2.tar.bz2
-  hash:
-    md5: 237b05b7eb284d7eebc3c5d93f5e4bca
-    sha256: 286e33fb452f61133a3a61d002890235d1d1378554218ab063d6870416440281
-  category: dev
-  optional: true
 - name: html5lib
   version: '1.1'
   manager: conda
@@ -6434,42 +5016,6 @@ package:
     sha256: 598951ebdb23e25e4cec4bbff0ae369cec65ead80b50bc08b441d8e54de5cf03
   category: main
   optional: false
-- name: importlib_metadata
-  version: 8.6.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    importlib-metadata: '>=8.6.1,<8.6.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.6.1-hd8ed1ab_0.conda
-  hash:
-    md5: 7f46575a91b1307441abc235d01cab66
-    sha256: 1e3eb9d65c4d7b87c7347553ef9eef6f994996f90a2299e19b35f5997d3a3e79
-  category: dev
-  optional: true
-- name: importlib_metadata
-  version: 8.6.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    importlib-metadata: '>=8.6.1,<8.6.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.6.1-hd8ed1ab_0.conda
-  hash:
-    md5: 7f46575a91b1307441abc235d01cab66
-    sha256: 1e3eb9d65c4d7b87c7347553ef9eef6f994996f90a2299e19b35f5997d3a3e79
-  category: dev
-  optional: true
-- name: importlib_metadata
-  version: 8.6.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    importlib-metadata: '>=8.6.1,<8.6.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.6.1-hd8ed1ab_0.conda
-  hash:
-    md5: 7f46575a91b1307441abc235d01cab66
-    sha256: 1e3eb9d65c4d7b87c7347553ef9eef6f994996f90a2299e19b35f5997d3a3e79
-  category: dev
-  optional: true
 - name: importlib_resources
   version: 6.5.2
   manager: conda
@@ -6644,8 +5190,8 @@ package:
   hash:
     md5: 9de86472b8f207fb098c69daaad50e67
     sha256: b1b940cfe85d5f0aaed83ef8c9f07ee80daa68acb05feeb5142d620472b01e0d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: ipython
   version: 8.32.0
   manager: conda
@@ -6668,8 +5214,8 @@ package:
   hash:
     md5: 9de86472b8f207fb098c69daaad50e67
     sha256: b1b940cfe85d5f0aaed83ef8c9f07ee80daa68acb05feeb5142d620472b01e0d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: ipython
   version: 8.32.0
   manager: conda
@@ -6692,45 +5238,45 @@ package:
   hash:
     md5: 9de86472b8f207fb098c69daaad50e67
     sha256: b1b940cfe85d5f0aaed83ef8c9f07ee80daa68acb05feeb5142d620472b01e0d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: isort
-  version: 5.13.2
+  version: 6.0.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.9,<4.0'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/isort-6.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ef7dc847f19fe4859d5aaa33385bf509
-    sha256: 6ebf6e83c2d449760ad5c5cc344711d6404f9e3cf6952811b8678aca5a4ab01f
+    md5: 5e4f9eef5749c5ce6457321a3f8bd405
+    sha256: 6cd5e7e86ec3d674311cbcdd5943a1c1508ff12b0e28006d919f69391f18dd15
   category: dev
   optional: true
 - name: isort
-  version: 5.13.2
+  version: 6.0.0
   manager: conda
   platform: osx-64
   dependencies:
     setuptools: ''
     python: '>=3.9,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/isort-6.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ef7dc847f19fe4859d5aaa33385bf509
-    sha256: 6ebf6e83c2d449760ad5c5cc344711d6404f9e3cf6952811b8678aca5a4ab01f
+    md5: 5e4f9eef5749c5ce6457321a3f8bd405
+    sha256: 6cd5e7e86ec3d674311cbcdd5943a1c1508ff12b0e28006d919f69391f18dd15
   category: dev
   optional: true
 - name: isort
-  version: 5.13.2
+  version: 6.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     setuptools: ''
     python: '>=3.9,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/isort-6.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ef7dc847f19fe4859d5aaa33385bf509
-    sha256: 6ebf6e83c2d449760ad5c5cc344711d6404f9e3cf6952811b8678aca5a4ab01f
+    md5: 5e4f9eef5749c5ce6457321a3f8bd405
+    sha256: 6cd5e7e86ec3d674311cbcdd5943a1c1508ff12b0e28006d919f69391f18dd15
   category: dev
   optional: true
 - name: itsdangerous
@@ -7051,49 +5597,43 @@ package:
     sha256: 51cc2dc491668af0c4d9299b0ab750f16ccf413ec5e2391b924108c1fbacae9b
   category: main
   optional: false
-- name: jschema-to-python
-  version: 1.2.3
+- name: joserfc
+  version: 1.0.3
   manager: conda
   platform: linux-64
   dependencies:
-    attrs: ''
-    jsonpickle: ''
-    pbr: ''
+    cryptography: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jschema-to-python-1.2.3-pyhff2d567_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.0.3-pyhd8ed1ab_0.conda
   hash:
-    md5: b2f293e5b388bb05ea0b10d5597a9cd2
-    sha256: 30df2e45143e0ee194df754083f38c44278788653f74696a39ddf238d6cbce73
+    md5: c319f63251683d48fade0ac355b60e11
+    sha256: b404c8ca33812e22ee1202a5ac29c2c6a971189a2e42bf25bea2623028d583c8
   category: dev
   optional: true
-- name: jschema-to-python
-  version: 1.2.3
+- name: joserfc
+  version: 1.0.3
   manager: conda
   platform: osx-64
   dependencies:
-    attrs: ''
-    jsonpickle: ''
-    pbr: ''
+    cryptography: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jschema-to-python-1.2.3-pyhff2d567_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.0.3-pyhd8ed1ab_0.conda
   hash:
-    md5: b2f293e5b388bb05ea0b10d5597a9cd2
-    sha256: 30df2e45143e0ee194df754083f38c44278788653f74696a39ddf238d6cbce73
+    md5: c319f63251683d48fade0ac355b60e11
+    sha256: b404c8ca33812e22ee1202a5ac29c2c6a971189a2e42bf25bea2623028d583c8
   category: dev
   optional: true
-- name: jschema-to-python
-  version: 1.2.3
+- name: joserfc
+  version: 1.0.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    attrs: ''
-    jsonpickle: ''
-    pbr: ''
+    cryptography: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/jschema-to-python-1.2.3-pyhff2d567_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.0.3-pyhd8ed1ab_0.conda
   hash:
-    md5: b2f293e5b388bb05ea0b10d5597a9cd2
-    sha256: 30df2e45143e0ee194df754083f38c44278788653f74696a39ddf238d6cbce73
+    md5: c319f63251683d48fade0ac355b60e11
+    sha256: b404c8ca33812e22ee1202a5ac29c2c6a971189a2e42bf25bea2623028d583c8
   category: dev
   optional: true
 - name: json-c
@@ -7211,42 +5751,6 @@ package:
     sha256: 304955757d1fedbe344af43b12b5467cca072f83cce6109361ba942e186b3993
   category: main
   optional: false
-- name: jsonpickle
-  version: 4.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-4.0.0-pyh29332c3_0.conda
-  hash:
-    md5: 326318b423a787eec6cb842fac0158c0
-    sha256: f0b69d1c43ae01c7494020bd800b4791909690b2b12b92c1d9760f2c9af1d5c8
-  category: dev
-  optional: true
-- name: jsonpickle
-  version: 4.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-4.0.0-pyh29332c3_0.conda
-  hash:
-    md5: 326318b423a787eec6cb842fac0158c0
-    sha256: f0b69d1c43ae01c7494020bd800b4791909690b2b12b92c1d9760f2c9af1d5c8
-  category: dev
-  optional: true
-- name: jsonpickle
-  version: 4.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonpickle-4.0.0-pyh29332c3_0.conda
-  hash:
-    md5: 326318b423a787eec6cb842fac0158c0
-    sha256: f0b69d1c43ae01c7494020bd800b4791909690b2b12b92c1d9760f2c9af1d5c8
-  category: dev
-  optional: true
 - name: jsonpointer
   version: 3.0.0
   manager: conda
@@ -7425,45 +5929,6 @@ package:
   hash:
     md5: 3b519bc21bc80e60b456f1e62962a766
     sha256: 37127133837444cf0e6d1a95ff5a505f8214ed4e89e8e9343284840e674c6891
-  category: dev
-  optional: true
-- name: junit-xml
-  version: '1.9'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/junit-xml-1.9-pyhd8ed1ab_1.conda
-  hash:
-    md5: 770ac65c221b65dd0c7b6678d15a6969
-    sha256: b744e6885e5c4d87163cda1465c8ee9a16122b4b3d3f38d3b5206e13832ce972
-  category: dev
-  optional: true
-- name: junit-xml
-  version: '1.9'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    six: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/junit-xml-1.9-pyhd8ed1ab_1.conda
-  hash:
-    md5: 770ac65c221b65dd0c7b6678d15a6969
-    sha256: b744e6885e5c4d87163cda1465c8ee9a16122b4b3d3f38d3b5206e13832ce972
-  category: dev
-  optional: true
-- name: junit-xml
-  version: '1.9'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    six: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/junit-xml-1.9-pyhd8ed1ab_1.conda
-  hash:
-    md5: 770ac65c221b65dd0c7b6678d15a6969
-    sha256: b744e6885e5c4d87163cda1465c8ee9a16122b4b3d3f38d3b5206e13832ce972
   category: dev
   optional: true
 - name: jupyter_client
@@ -7942,17 +6407,17 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
     libgcc: '>=13'
+    liblzma: '>=5.6.3,<6.0a0'
     libxml2: '>=2.13.5,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
     lzo: '>=2.10,<3.0a0'
     openssl: '>=3.4.0,<4.0a0'
-    xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.7-hadbb8c3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.7-h4585015_3.conda
   hash:
-    md5: 4a099677417658748239616b6ca96bb6
-    sha256: 68afcb4519d08cebf71845aff6038e7273f021efc04ef48246f8d41e4e462a61
+    md5: a28808eae584c7f519943719b2a2b386
+    sha256: 2466803e26ae9dbd2263de3a102b572b741c056549875c04b6ec10830bd5d338
   category: main
   optional: false
 - name: libarchive
@@ -7963,17 +6428,17 @@ package:
     __osx: '>=10.13'
     bzip2: '>=1.0.8,<2.0a0'
     libiconv: '>=1.17,<2.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
     libxml2: '>=2.13.5,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
     lzo: '>=2.10,<3.0a0'
     openssl: '>=3.4.0,<4.0a0'
-    xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.7-h7988bea_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.7-h1a33361_3.conda
   hash:
-    md5: 5af9f38826ccc57545a5c55c54cbfd92
-    sha256: 50a5ffeeef306c9f29e2872aa011c28f546a364a8e50350bd05ff0055ad8c599
+    md5: 5cc55f063de099a537a56c4db2e8d58d
+    sha256: fd1f0d23787057fce1c9b7e598e91bde3868cfed02a0c3c666f720bab71b136e
   category: main
   optional: false
 - name: libarchive
@@ -7984,447 +6449,275 @@ package:
     __osx: '>=11.0'
     bzip2: '>=1.0.8,<2.0a0'
     libiconv: '>=1.17,<2.0a0'
+    liblzma: '>=5.6.3,<6.0a0'
     libxml2: '>=2.13.5,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
     lzo: '>=2.10,<3.0a0'
     openssl: '>=3.4.0,<4.0a0'
-    xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.7-h7c07d2a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.7-h3b16cec_3.conda
   hash:
-    md5: 49b28e291693b70cf8a7e70f290834d8
-    sha256: 10d5c755761c6823d20c6ddbd42292ef91f34e271b6ba3e78d0c5fa81c22b3ed
+    md5: 1c2eda2163510220b9f9d56a85c8da9d
+    sha256: cbce64423e72bcd3576b5cfe0e4edd255900100f72467d5b4ea1d77449ac1ce9
   category: main
   optional: false
 - name: libarrow
-  version: 14.0.2
+  version: 19.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-crt-cpp: '>=0.29.3,<0.29.4.0a0'
-    aws-sdk-cpp: '>=1.11.407,<1.11.408.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    gflags: '>=2.2.2,<2.3.0a0'
-    glog: '>=0.7.1,<0.8.0a0'
-    libabseil: '>=20240722.0,<20240723.0a0'
-    libbrotlidec: '>=1.1.0,<1.2.0a0'
-    libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libgcc: '>=13'
-    libgoogle-cloud: '>=2.30.0,<2.31.0a0'
-    libgoogle-cloud-storage: '>=2.30.0,<2.31.0a0'
-    libre2-11: '>=2024.7.2'
-    libstdcxx: '>=13'
-    libutf8proc: <2.9
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=2.0.2,<2.0.3.0a0'
-    re2: ''
-    snappy: '>=1.2.1,<1.3.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.2-hccc8d3c_52_cpu.conda
-  hash:
-    md5: 1f8dfe438d4806e3c8ccafac367ac851
-    sha256: df99f327ee1032e0c3582f9527c3ed965fe2bea042ee3cc5769a5568a3606e79
-  category: main
-  optional: false
-- name: libarrow
-  version: 14.0.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    aws-crt-cpp: '>=0.29.3,<0.29.4.0a0'
-    aws-sdk-cpp: '>=1.11.407,<1.11.408.0a0'
+    aws-crt-cpp: '>=0.29.9,<0.29.10.0a0'
+    aws-sdk-cpp: '>=1.11.489,<1.11.490.0a0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    azure-identity-cpp: '>=1.10.0,<1.10.1.0a0'
+    azure-storage-blobs-cpp: '>=12.13.0,<12.13.1.0a0'
+    azure-storage-files-datalake-cpp: '>=12.12.0,<12.12.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     glog: '>=0.7.1,<0.8.0a0'
     libabseil: '>=20240722.0,<20240723.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libcxx: '>=17'
-    libgoogle-cloud: '>=2.30.0,<2.31.0a0'
-    libgoogle-cloud-storage: '>=2.30.0,<2.31.0a0'
+    libgcc: '>=13'
+    libgoogle-cloud: '>=2.34.0,<2.35.0a0'
+    libgoogle-cloud-storage: '>=2.34.0,<2.35.0a0'
+    libopentelemetry-cpp: '>=1.18.0,<1.19.0a0'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libre2-11: '>=2024.7.2'
-    libutf8proc: <2.9
+    libstdcxx: '>=13'
+    libutf8proc: '>=2.10.0,<2.11.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=2.0.2,<2.0.3.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
+    orc: '>=2.0.3,<2.0.4.0a0'
     re2: ''
     snappy: '>=1.2.1,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.2-hff4c71d_52_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-19.0.0-h00a82cf_8_cpu.conda
   hash:
-    md5: 9b3e790cd4df47ed85fe10d89f4ae2ad
-    sha256: d26011347953c6a12826de1021ddabb37cfcf4db21d3146a6c8e63dec9e647dc
+    md5: 51e31b59290c09b58d290f66b908999b
+    sha256: dcac39be95b9afe42bc9b7bfcfa258e31e413a4cb79c49f6707edf2838e8d64c
   category: main
   optional: false
 - name: libarrow
-  version: 14.0.2
+  version: 19.0.0
   manager: conda
-  platform: osx-arm64
+  platform: osx-64
   dependencies:
-    __osx: '>=11.0'
-    aws-crt-cpp: '>=0.29.3,<0.29.4.0a0'
-    aws-sdk-cpp: '>=1.11.407,<1.11.408.0a0'
+    __osx: '>=10.13'
+    aws-crt-cpp: '>=0.29.9,<0.29.10.0a0'
+    aws-sdk-cpp: '>=1.11.489,<1.11.490.0a0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    azure-identity-cpp: '>=1.10.0,<1.10.1.0a0'
+    azure-storage-blobs-cpp: '>=12.13.0,<12.13.1.0a0'
+    azure-storage-files-datalake-cpp: '>=12.12.0,<12.12.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     glog: '>=0.7.1,<0.8.0a0'
     libabseil: '>=20240722.0,<20240723.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libcxx: '>=17'
-    libgoogle-cloud: '>=2.30.0,<2.31.0a0'
-    libgoogle-cloud-storage: '>=2.30.0,<2.31.0a0'
+    libcxx: '>=18'
+    libgoogle-cloud: '>=2.34.0,<2.35.0a0'
+    libgoogle-cloud-storage: '>=2.34.0,<2.35.0a0'
+    libopentelemetry-cpp: '>=1.18.0,<1.19.0a0'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libre2-11: '>=2024.7.2'
-    libutf8proc: <2.9
+    libutf8proc: '>=2.10.0,<2.11.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=2.0.2,<2.0.3.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
+    orc: '>=2.0.3,<2.0.4.0a0'
     re2: ''
     snappy: '>=1.2.1,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.2-h97e12a9_52_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-19.0.0-h3deb67b_8_cpu.conda
   hash:
-    md5: 93eced965c69854014546ae88ca49cc8
-    sha256: d20ee2b31e7360d687960b7c8ecf667cc7fef66babb4c2f88f3251a62c1159cc
+    md5: cc7d99241b8abad046954434c9ac35fa
+    sha256: 06664fac75a8ebde134eb3f43a8ffdc4c973fce9cebb565d4205f6e4aebcc7da
+  category: main
+  optional: false
+- name: libarrow
+  version: 19.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    aws-crt-cpp: '>=0.29.9,<0.29.10.0a0'
+    aws-sdk-cpp: '>=1.11.489,<1.11.490.0a0'
+    azure-core-cpp: '>=1.14.0,<1.14.1.0a0'
+    azure-identity-cpp: '>=1.10.0,<1.10.1.0a0'
+    azure-storage-blobs-cpp: '>=12.13.0,<12.13.1.0a0'
+    azure-storage-files-datalake-cpp: '>=12.12.0,<12.12.1.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    glog: '>=0.7.1,<0.8.0a0'
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libbrotlidec: '>=1.1.0,<1.2.0a0'
+    libbrotlienc: '>=1.1.0,<1.2.0a0'
+    libcxx: '>=18'
+    libgoogle-cloud: '>=2.34.0,<2.35.0a0'
+    libgoogle-cloud-storage: '>=2.34.0,<2.35.0a0'
+    libopentelemetry-cpp: '>=1.18.0,<1.19.0a0'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
+    libre2-11: '>=2024.7.2'
+    libutf8proc: '>=2.10.0,<2.11.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
+    orc: '>=2.0.3,<2.0.4.0a0'
+    re2: ''
+    snappy: '>=1.2.1,<1.3.0a0'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-19.0.0-h819e3af_8_cpu.conda
+  hash:
+    md5: fbe0ce0ef6d386ab832ee5cca2ab3048
+    sha256: 825afabd1c998dfddce9600584c492296a15219d441c6e3029e6c6228200d695
   category: main
   optional: false
 - name: libarrow-acero
-  version: 14.0.2
+  version: 19.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    gflags: '>=2.2.2,<2.3.0a0'
-    libarrow: 14.0.2
+    libarrow: 19.0.0
     libgcc: '>=13'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.2-h5d0bfc1_52_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-19.0.0-hcb10f89_8_cpu.conda
   hash:
-    md5: 9279fa5a3b12d65a3fdfd1f24830aa26
-    sha256: f17ec704eeb22c5efe73ddc312ecfcd0e4b338d62e8d3af008eb19966a9f8ade
+    md5: dafba09929a58e10bb8231ff7966e623
+    sha256: bf8f64403685eb3ab6ebc5a25cc3a70431a1f822469bf96b0ee80c169deec0ac
   category: main
   optional: false
 - name: libarrow-acero
-  version: 14.0.2
+  version: 19.0.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libarrow: 14.0.2
-    libcxx: '>=17'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.2-h97d8b74_52_cpu.conda
+    libarrow: 19.0.0
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-19.0.0-ha6338a2_8_cpu.conda
   hash:
-    md5: fb0bc2ff1cf8ca362fc0199a52ae1af1
-    sha256: d691f756d5c326380cc2852b51cdcaf5dc103849bc44598d95829b8c89d294d7
+    md5: 3f444e96a620c571b5534c8b11853deb
+    sha256: 662a89ede1ac3bea7bc16f9ea41bdda2c86107899e90ed8049f8fa048d597cbd
   category: main
   optional: false
 - name: libarrow-acero
-  version: 14.0.2
+  version: 19.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libarrow: 14.0.2
-    libcxx: '>=17'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.2-h5833ebf_52_cpu.conda
+    libarrow: 19.0.0
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-19.0.0-hf07054f_8_cpu.conda
   hash:
-    md5: 3eb545dd1cf8cc6159508fca783ea54d
-    sha256: edccf5e1aebe159ead1d733e798f02e7ef86f3d71e6b55e6c62563345ecd962a
+    md5: 68cd272eccf7b4fcb0a3bab95e89e71e
+    sha256: 66ce35077dae435cd34644d53159af14afd62452eeec8f63cd55adb11e7f2780
   category: main
   optional: false
 - name: libarrow-dataset
-  version: 14.0.2
+  version: 19.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    gflags: '>=2.2.2,<2.3.0a0'
-    libarrow: 14.0.2
-    libarrow-acero: 14.0.2
+    libarrow: 19.0.0
+    libarrow-acero: 19.0.0
     libgcc: '>=13'
-    libparquet: 14.0.2
+    libparquet: 19.0.0
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.2-h5d0bfc1_52_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-19.0.0-hcb10f89_8_cpu.conda
   hash:
-    md5: 430c5c0c381b6329972d02464339c496
-    sha256: ac6a9e351d860838ebe131e1a843bf2bf19f649f14654f1f083d2326b0141073
+    md5: 66e19108e4597b9a35d0886607c2d8a8
+    sha256: dc4a0f13428c9bd9781e25b67f5f52a92b8c4beafa2435fe5127e9fac7969218
   category: main
   optional: false
 - name: libarrow-dataset
-  version: 14.0.2
+  version: 19.0.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libarrow: 14.0.2
-    libarrow-acero: 14.0.2
-    libcxx: '>=17'
-    libparquet: 14.0.2
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.2-h97d8b74_52_cpu.conda
+    libarrow: 19.0.0
+    libarrow-acero: 19.0.0
+    libcxx: '>=18'
+    libparquet: 19.0.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-19.0.0-ha6338a2_8_cpu.conda
   hash:
-    md5: 5262b5872182745387ed883f12dc1161
-    sha256: 410b0d3eff94471296057c96e10617b499f1531e33ee2ff6708b02c90c37f11f
+    md5: 9b5fdcfc89f011086aa40d7128f433c0
+    sha256: 843656272be9a5ce0519a487600a3b751599361e2b547cae604038de4324201a
   category: main
   optional: false
 - name: libarrow-dataset
-  version: 14.0.2
+  version: 19.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libarrow: 14.0.2
-    libarrow-acero: 14.0.2
-    libcxx: '>=17'
-    libparquet: 14.0.2
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.2-h5833ebf_52_cpu.conda
+    libarrow: 19.0.0
+    libarrow-acero: 19.0.0
+    libcxx: '>=18'
+    libparquet: 19.0.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-19.0.0-hf07054f_8_cpu.conda
   hash:
-    md5: f784986633a174ce2961ac636e9efea2
-    sha256: defd6b86699f96d7003d26ebd206c5bc887945480812b8f4a81f6402317924a2
+    md5: 1a941d1ddc16b532790781a4becdc881
+    sha256: 6934ce0503472f002695d45ae12a8f2948e10e7a0b7430330a4d0d83f3e5ca27
   category: main
   optional: false
-- name: libarrow-flight
-  version: 14.0.2
+- name: libarrow-substrait
+  version: 19.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    gflags: '>=2.2.2,<2.3.0a0'
     libabseil: '>=20240722.0,<20240723.0a0'
-    libarrow: 14.0.2
+    libarrow: 19.0.0
+    libarrow-acero: 19.0.0
+    libarrow-dataset: 19.0.0
     libgcc: '>=13'
-    libgrpc: '>=1.67.1,<1.68.0a0'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libstdcxx: '>=13'
-    ucx: '>=1.17.0,<1.18.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.2-he7f0889_52_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-19.0.0-h08228c5_8_cpu.conda
   hash:
-    md5: 7f9cbce1e819c5eb0f80f80751ca5458
-    sha256: 6f4c9a0a86da645f6f8e6c4ff8a8674a4d108529ba3d58d5524238246f1cd8e6
+    md5: e5dd1926e5a4b23de8ba4eacc8eb9b2d
+    sha256: e370ee738d3963120f715343a27cf041c62a3ee8bb19e25da9115ec4bae5f2de
   category: main
   optional: false
-- name: libarrow-flight
-  version: 14.0.2
+- name: libarrow-substrait
+  version: 19.0.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libabseil: '>=20240722.0,<20240723.0a0'
-    libarrow: 14.0.2
-    libcxx: '>=17'
-    libgrpc: '>=1.67.1,<1.68.0a0'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.2-hadc88be_52_cpu.conda
+    libarrow: 19.0.0
+    libarrow-acero: 19.0.0
+    libarrow-dataset: 19.0.0
+    libcxx: '>=18'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-19.0.0-h5c2345d_8_cpu.conda
   hash:
-    md5: 2c351b1f5753a46b318aa6bc2d65d73c
-    sha256: 8217bc043d0b1a9c6d37384cf3f974ade6f8df5ac94d99344794f375881be028
+    md5: 2719966ac35ed31dd99ea32874b1d132
+    sha256: 55f0f7849d05f87c1c8ca68900bec8c111e55a68337b3ddae621ef5b51940a04
   category: main
   optional: false
-- name: libarrow-flight
-  version: 14.0.2
+- name: libarrow-substrait
+  version: 19.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libabseil: '>=20240722.0,<20240723.0a0'
-    libarrow: 14.0.2
-    libcxx: '>=17'
-    libgrpc: '>=1.67.1,<1.68.0a0'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.2-hf98a671_52_cpu.conda
+    libarrow: 19.0.0
+    libarrow-acero: 19.0.0
+    libarrow-dataset: 19.0.0
+    libcxx: '>=18'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-19.0.0-h4239455_8_cpu.conda
   hash:
-    md5: 099f9167b6aaf3f27538bc7ced57d704
-    sha256: 0249a77e0c6f18a69fbed5fc62cc94e2f69a346c44c43f426ba15e8ce30c0768
+    md5: a39953d9b03b0463f4ccc187a8bcfcca
+    sha256: 445d2ca20b07e57270f3b07b62c09794369413e5ff3716d9c73d0ad360969583
   category: main
   optional: false
-- name: libarrow-flight-sql
-  version: 14.0.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    gflags: '>=2.2.2,<2.3.0a0'
-    libarrow: 14.0.2
-    libarrow-flight: 14.0.2
-    libgcc: '>=13'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.2-he7b089f_52_cpu.conda
-  hash:
-    md5: 39d6fd40fd33a3402865e378d5184053
-    sha256: 7d4213d8024f88fa3c95ba1c1ea2c4ea80211d3dd333576dc7a0214bb492fe2a
-  category: main
-  optional: false
-- name: libarrow-flight-sql
-  version: 14.0.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libarrow: 14.0.2
-    libarrow-flight: 14.0.2
-    libcxx: '>=17'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.2-heffbc13_52_cpu.conda
-  hash:
-    md5: c0339c0b736a721807d2390c1ab8b7dc
-    sha256: 1d3f3e6f36e22eef1eafe535bbfc006b13d87cdcb8abde6b943f636b7d39da04
-  category: main
-  optional: false
-- name: libarrow-flight-sql
-  version: 14.0.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libarrow: 14.0.2
-    libarrow-flight: 14.0.2
-    libcxx: '>=17'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.2-h0f5b584_52_cpu.conda
-  hash:
-    md5: 51b47cbeae6806d0c2d1711078adbee6
-    sha256: f6a2c37f17f09c9ec6a68318ec0d65b94727d0fe87baf4a64429257e335cb3e4
-  category: main
-  optional: false
-- name: libarrow-gandiva
-  version: 14.0.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    gflags: '>=2.2.2,<2.3.0a0'
-    libarrow: 14.0.2
-    libgcc: '>=13'
-    libllvm17: '>=17.0.6,<17.1.0a0'
-    libre2-11: '>=2024.7.2'
-    libstdcxx: '>=13'
-    libutf8proc: <2.9
-    openssl: '>=3.3.2,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.2-h18fa613_52_cpu.conda
-  hash:
-    md5: 29ea30d64ac9114516f4c4c0823dc783
-    sha256: 6b6f310ef28b805b84f64629760c718f9c67ca32e2b4cf600cb8a2a54ee72fd7
-  category: main
-  optional: false
-- name: libarrow-gandiva
-  version: 14.0.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libarrow: 14.0.2
-    libcxx: '>=17'
-    libllvm17: '>=17.0.6,<17.1.0a0'
-    libre2-11: '>=2024.7.2'
-    libutf8proc: <2.9
-    openssl: '>=3.3.2,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.2-h13f1c6c_52_cpu.conda
-  hash:
-    md5: 099acb8f06d017983edcdfcba6c30186
-    sha256: 5d9e0ab9c537037dac3aa62a4b35dade7a73031e4e5f20e8fb23cc58857d0148
-  category: main
-  optional: false
-- name: libarrow-gandiva
-  version: 14.0.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libarrow: 14.0.2
-    libcxx: '>=17'
-    libllvm17: '>=17.0.6,<17.1.0a0'
-    libre2-11: '>=2024.7.2'
-    libutf8proc: <2.9
-    openssl: '>=3.3.2,<4.0a0'
-    re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.2-h6d50e30_52_cpu.conda
-  hash:
-    md5: 43c0d9fb72bfb28263199616aa0411c3
-    sha256: aab297810e06641817f246da43e909581bc7161ecdedc6ecfb513c19aa385a43
-  category: main
-  optional: false
-- name: libarrow-substrait
-  version: 14.0.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    gflags: '>=2.2.2,<2.3.0a0'
-    libarrow: 14.0.2
-    libarrow-acero: 14.0.2
-    libarrow-dataset: 14.0.2
-    libgcc: '>=13'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.2-he7b089f_52_cpu.conda
-  hash:
-    md5: c336ae13e9a0da1f9ddab96620931fae
-    sha256: 289ae886fc9658120f08fd290d67400c8f08a5ad08f224a44c54dbbbe792bd8a
-  category: main
-  optional: false
-- name: libarrow-substrait
-  version: 14.0.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libarrow: 14.0.2
-    libarrow-acero: 14.0.2
-    libarrow-dataset: 14.0.2
-    libcxx: '>=17'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.2-heffbc13_52_cpu.conda
-  hash:
-    md5: 49e74fe7f996e054afcbfdda6ed2a3d4
-    sha256: 4033d1702f3f8ba675c80ad23461e8f2864d821e28547ed5d43212619ebd7c96
-  category: main
-  optional: false
-- name: libarrow-substrait
-  version: 14.0.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libarrow: 14.0.2
-    libarrow-acero: 14.0.2
-    libarrow-dataset: 14.0.2
-    libcxx: '>=17'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.2-h8cfa146_52_cpu.conda
-  hash:
-    md5: 79ac56f353f2fc18564ea4e19fc67101
-    sha256: 0478d1e098fa55c34c064e9e6da36b1f3026228bdfcab5fae87c81e1182a2be6
-  category: main
-  optional: false
-- name: libasprintf
-  version: 0.22.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-hdfe23c8_3.conda
-  hash:
-    md5: 55363e1d53635b3497cdf753ab0690c1
-    sha256: 9c6f3e2558e098dbbc63c9884b4af368ea6cc4185ea027563ac4f5ee8571b143
-  category: dev
-  optional: true
-- name: libasprintf
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8414b35_3.conda
-  hash:
-    md5: 472b673c083175195965a48f2f4808f8
-    sha256: 819bf95543470658f48db53a267a3fabe1616797c4031cf88e63f451c5029e6f
-  category: dev
-  optional: true
 - name: libavif16
   version: 1.1.1
   manager: conda
@@ -8627,20 +6920,6 @@ package:
     sha256: eeb1eb0d58b9d02bc1b98dc0a058f104ab168eb2f7d1c7bfa0570a12cfcdb7b7
   category: main
   optional: false
-- name: libcap
-  version: '2.71'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    attr: '>=2.5.1,<2.6.0a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.71-h39aace5_0.conda
-  hash:
-    md5: dd19e4e3043f6948bd7454b946ee0983
-    sha256: 2bbefac94f4ab8ff7c64dc843238b6c8edcc9ff1f2b5a0a48407a904dc7ccfb2
-  category: main
-  optional: false
 - name: libcblas
   version: 3.9.0
   manager: conda
@@ -8714,21 +6993,6 @@ package:
     sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
   category: main
   optional: false
-- name: libcups
-  version: 2.3.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    krb5: '>=1.21.1,<1.22.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
-  hash:
-    md5: d4529f4dff3057982a7617c7ac58fde3
-    sha256: bc67b9b21078c99c6bd8595fe7e1ed6da1f721007726e717f0449de7032798c4
-  category: dev
-  optional: true
 - name: libcurl
   version: 8.11.1
   manager: conda
@@ -8846,40 +7110,40 @@ package:
   category: main
   optional: false
 - name: libdeflate
-  version: '1.22'
+  version: '1.23'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.23-h4ddbbb0_0.conda
   hash:
-    md5: b422943d5d772b7cc858b36ad2a92db5
-    sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
+    md5: 8dfae1d2e74767e9ce36d5fa0d8605db
+    sha256: 511d801626d02f4247a04fff957cc6e9ec4cc7e8622bd9acd076bcdc5de5fe66
   category: main
   optional: false
 - name: libdeflate
-  version: '1.22'
+  version: '1.23'
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.22-h00291cd_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.23-he65b83e_0.conda
   hash:
-    md5: a15785ccc62ae2a8febd299424081efb
-    sha256: 681035346974c3315685dc40898e26f65f1c00cbb0b5fd80cc2599e207a34b31
+    md5: 120f8f7ba6a8defb59f4253447db4bb4
+    sha256: 20c1e685e7409bb82c819ba55b9f7d9a654e8e6d597081581493badb7464520e
   category: main
   optional: false
 - name: libdeflate
-  version: '1.22'
+  version: '1.23'
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.23-hec38601_0.conda
   hash:
-    md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
-    sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
+    md5: 1d8b9588be14e71df38c525767a1ac30
+    sha256: 887c02deaed6d583459eba6367023e36d8761085b2f7126e389424f57155da53
   category: main
   optional: false
 - name: libedit
@@ -9089,91 +7353,8 @@ package:
     sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
   category: main
   optional: false
-- name: libgcrypt-lib
-  version: 1.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libgpg-error: '>=1.51,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.0-hb9d3cd8_2.conda
-  hash:
-    md5: e55712ff40a054134d51b89afca57dbc
-    sha256: ffc3602f9298da248786f46b00d0594d26a18feeb1b07ce88f3d7d61075e39e6
-  category: main
-  optional: false
-- name: libgd
-  version: 2.3.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    fontconfig: '>=2.15.0,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=75.1,<76.0a0'
-    libexpat: '>=2.6.4,<3.0a0'
-    libgcc: '>=13'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.45,<1.7.0a0'
-    libtiff: '>=4.7.0,<4.8.0a0'
-    libwebp-base: '>=1.5.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
-  hash:
-    md5: 68fc66282364981589ef36868b1a7c78
-    sha256: 19e5be91445db119152217e8e8eec4fd0499d854acc7d8062044fb55a70971cd
-  category: dev
-  optional: true
-- name: libgd
-  version: 2.3.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    fontconfig: '>=2.15.0,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=75.1,<76.0a0'
-    libexpat: '>=2.6.4,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.45,<1.7.0a0'
-    libtiff: '>=4.7.0,<4.8.0a0'
-    libwebp-base: '>=1.5.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgd-2.3.3-h8555400_11.conda
-  hash:
-    md5: 0eea404372aa41cf95e71c604534b2a2
-    sha256: af8ca696b229236e4a692220a26421a4f3d28a6ceff16723cd1fe12bc7e6517c
-  category: dev
-  optional: true
-- name: libgd
-  version: 2.3.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    fontconfig: '>=2.15.0,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=75.1,<76.0a0'
-    libexpat: '>=2.6.4,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.45,<1.7.0a0'
-    libtiff: '>=4.7.0,<4.8.0a0'
-    libwebp-base: '>=1.5.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgd-2.3.3-hb2c3a21_11.conda
-  hash:
-    md5: 4581aa3cfcd1a90967ed02d4a9f3db4b
-    sha256: be038eb8dfe296509aee2df21184c72cb76285b0340448525664bc396aa6146d
-  category: dev
-  optional: true
 - name: libgdal-core
-  version: 3.10.0
+  version: 3.10.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -9185,38 +7366,38 @@ package:
     json-c: '>=0.18,<0.19.0a0'
     lerc: '>=4.0.0,<5.0a0'
     libarchive: '>=3.7.7,<3.8.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
-    libdeflate: '>=1.22,<1.23.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
+    libdeflate: '>=1.23,<1.24.0a0'
     libexpat: '>=2.6.4,<3.0a0'
     libgcc: '>=13'
-    libheif: '>=1.18.2,<1.19.0a0'
+    libheif: '>=1.19.5,<1.20.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
     liblzma: '>=5.6.3,<6.0a0'
-    libpng: '>=1.6.44,<1.7.0a0'
+    libpng: '>=1.6.45,<1.7.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.47.2,<4.0a0'
+    libsqlite: '>=3.48.0,<4.0a0'
     libstdcxx: '>=13'
     libtiff: '>=4.7.0,<4.8.0a0'
     libuuid: '>=2.38.1,<3.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
     libxml2: '>=2.13.5,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
     openssl: '>=3.4.0,<4.0a0'
     pcre2: '>=10.44,<10.45.0a0'
     proj: '>=9.5.1,<9.6.0a0'
     xerces-c: '>=3.2.5,<3.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.0-h7250d82_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.1-h3359108_2.conda
   hash:
-    md5: 4e14dd6eef7e961a54258cab6482a656
-    sha256: 9de9ffb786deb0addb0d00e7b24b6b98e20cf366bb0318f80844c730554952f6
+    md5: 35b2030c99c4bbf72bd8f5d35245b7e4
+    sha256: e97cc5496a28b6f1c18ae84b1c2a3f91f5643101115c9453bf7b102b71f8a567
   category: main
   optional: false
 - name: libgdal-core
-  version: 3.10.0
+  version: 3.10.1
   manager: conda
   platform: osx-64
   dependencies:
@@ -9228,36 +7409,36 @@ package:
     json-c: '>=0.18,<0.19.0a0'
     lerc: '>=4.0.0,<5.0a0'
     libarchive: '>=3.7.7,<3.8.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
     libcxx: '>=18'
-    libdeflate: '>=1.22,<1.23.0a0'
+    libdeflate: '>=1.23,<1.24.0a0'
     libexpat: '>=2.6.4,<3.0a0'
-    libheif: '>=1.18.2,<1.19.0a0'
+    libheif: '>=1.19.5,<1.20.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
     liblzma: '>=5.6.3,<6.0a0'
-    libpng: '>=1.6.44,<1.7.0a0'
+    libpng: '>=1.6.45,<1.7.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.47.2,<4.0a0'
+    libsqlite: '>=3.48.0,<4.0a0'
     libtiff: '>=4.7.0,<4.8.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
     libxml2: '>=2.13.5,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
     openssl: '>=3.4.0,<4.0a0'
     pcre2: '>=10.44,<10.45.0a0'
     proj: '>=9.5.1,<9.6.0a0'
     xerces-c: '>=3.2.5,<3.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.10.0-h04043bc_6.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.10.1-ha746336_2.conda
   hash:
-    md5: 0fdc13a5e28a7150d2ded1a3c7334625
-    sha256: 1082353a1f37c334ddeca585cb5d8cc4a86ba074e29ac24ce81da16dcf47fbfb
+    md5: af21f99c36eca114257730116c53b96d
+    sha256: 6a4022ad4f0c98f71c36407f528bddf615b76c81a2356d3f9fc467ec7c44b619
   category: main
   optional: false
 - name: libgdal-core
-  version: 3.10.0
+  version: 3.10.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -9269,62 +7450,34 @@ package:
     json-c: '>=0.18,<0.19.0a0'
     lerc: '>=4.0.0,<5.0a0'
     libarchive: '>=3.7.7,<3.8.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
     libcxx: '>=18'
-    libdeflate: '>=1.22,<1.23.0a0'
+    libdeflate: '>=1.23,<1.24.0a0'
     libexpat: '>=2.6.4,<3.0a0'
-    libheif: '>=1.18.2,<1.19.0a0'
+    libheif: '>=1.19.5,<1.20.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
     liblzma: '>=5.6.3,<6.0a0'
-    libpng: '>=1.6.44,<1.7.0a0'
+    libpng: '>=1.6.45,<1.7.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.47.2,<4.0a0'
+    libsqlite: '>=3.48.0,<4.0a0'
     libtiff: '>=4.7.0,<4.8.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
+    libwebp-base: '>=1.5.0,<2.0a0'
     libxml2: '>=2.13.5,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
     openssl: '>=3.4.0,<4.0a0'
     pcre2: '>=10.44,<10.45.0a0'
     proj: '>=9.5.1,<9.6.0a0'
     xerces-c: '>=3.2.5,<3.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.10.0-h9ccd308_6.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.10.1-h9ef0d2d_2.conda
   hash:
-    md5: cd753bb7543fc897ceaedcdabe8d580f
-    sha256: d44ed8fa3feff35d7f8213046b686942e087dc026dfb5d8dc2484d968d0843df
+    md5: f0ea5524380b2c76156589e6aa0998a9
+    sha256: 891e4fc19846b99e5c2232c4e04c72d5eb55cd9702e70416283adf65e0598048
   category: main
   optional: false
-- name: libgettextpo
-  version: 0.22.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-hdfe23c8_3.conda
-  hash:
-    md5: ba6eeccaee150e24a544be8ae71aeca1
-    sha256: 8f7631d03a093272a5a8423181ac2c66514503e082e5494a2e942737af8a34ad
-  category: dev
-  optional: true
-- name: libgettextpo
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8414b35_3.conda
-  hash:
-    md5: c8cd7295cfb7bda5cbabea4fef904349
-    sha256: bc446fad58155e96a01b28e99254415c2151bdddf57f9a2c00c44e6f0298bb62
-  category: dev
-  optional: true
 - name: libgfortran
   version: 14.2.0
   manager: conda
@@ -9414,40 +7567,6 @@ package:
     sha256: f0804a9e46ae7b32ca698d26c1c95aa82a91f71b6051883d4a46bea725be9ea4
   category: main
   optional: false
-- name: libglib
-  version: 2.82.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libffi: '>=3.4,<4.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pcre2: '>=10.44,<10.45.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.82.2-h5c976ab_1.conda
-  hash:
-    md5: 05e05255a2e9c5e9c1b6322d84b4999b
-    sha256: 78fab559eefc52856331462304a4c55c054fa8f0b0feb31ff5496d06c08342ba
-  category: dev
-  optional: true
-- name: libglib
-  version: 2.82.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libffi: '>=3.4,<4.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pcre2: '>=10.44,<10.45.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.82.2-hdff4504_1.conda
-  hash:
-    md5: 849da57c370384ce48bef2e050488882
-    sha256: d002aeaa51424e331f8504a54b6ba4388a6011a0ebcac29296f3d14282bf733b
-  category: dev
-  optional: true
 - name: libgomp
   version: 14.2.0
   manager: conda
@@ -9461,62 +7580,62 @@ package:
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 2.30.0
+  version: 2.34.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libabseil: '>=20240722.0,<20240723.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
     libgcc: '>=13'
     libgrpc: '>=1.67.1,<1.68.0a0'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libstdcxx: '>=13'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.30.0-h804f50b_1.conda
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.34.0-h2b5623c_0.conda
   hash:
-    md5: 0a1c61bdbf27a966bbb0c8bf9df37b02
-    sha256: 2766d13648adf974638a016c258890de1eaecf79186f67ca2d43b2687d27d5c4
+    md5: 2a5142c88dd6132eaa8079f99476e922
+    sha256: 348ee1dddd82dcef5a185c86e65dda8acfc9b583acc425ccb9b661f2d433b2cc
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 2.30.0
+  version: 2.34.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libabseil: '>=20240722.0,<20240723.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
     libcxx: '>=18'
     libgrpc: '>=1.67.1,<1.68.0a0'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.30.0-hd00c612_1.conda
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.34.0-h7000a09_0.conda
   hash:
-    md5: 5abc1fd3e6b08617d090a03ac6dcf961
-    sha256: 886a2b1595bb2fa95f013e142f03eddd468486707d76165ad5a341b656ab1a9f
+    md5: b99d040fc4dda99775e786d7cd591b2d
+    sha256: b033640af758362d9022611cca388c6a88c72bedbadeeacaf0009035027df088
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 2.30.0
+  version: 2.34.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libabseil: '>=20240722.0,<20240723.0a0'
-    libcurl: '>=8.10.1,<9.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
     libcxx: '>=18'
     libgrpc: '>=1.67.1,<1.68.0a0'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.30.0-h8d8be31_1.conda
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.34.0-hdbe95d5_0.conda
   hash:
-    md5: 69843fcf53962f47205996fc284ec29e
-    sha256: 9e2c138ccf300d909b4bc2487dfcda779bf9c3307948ce1d72c385008e0862fd
+    md5: 69826544e7978fcaa6bc8c1962d96ad6
+    sha256: 919d8cbcd47d5bd2244c55b2bb87e2bd2eed8215996aab8435cb7123ffd9d20e
   category: main
   optional: false
 - name: libgoogle-cloud-storage
-  version: 2.30.0
+  version: 2.34.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -9525,18 +7644,18 @@ package:
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libcurl: ''
     libgcc: '>=13'
-    libgoogle-cloud: 2.30.0
+    libgoogle-cloud: 2.34.0
     libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
     openssl: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.30.0-h0121fbd_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.34.0-h0121fbd_0.conda
   hash:
-    md5: afbbf507f8c96faa95a2efa376ad484c
-    sha256: b171fc442de5ee010f515c4cb913cabc916619953188cb8d54fc38b8915e4cf3
+    md5: 9f0c43225243c81c6991733edcaafff5
+    sha256: aa1b3b30ae6b2eab7c9e6a8e2fd8ec3776f25d2e3f0b6f9dc547ff8083bf25fa
   category: main
   optional: false
 - name: libgoogle-cloud-storage
-  version: 2.30.0
+  version: 2.34.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -9545,17 +7664,17 @@ package:
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libcurl: ''
     libcxx: '>=18'
-    libgoogle-cloud: 2.30.0
+    libgoogle-cloud: 2.34.0
     libzlib: '>=1.3.1,<2.0a0'
     openssl: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.30.0-h3f2b517_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.34.0-h3f2b517_0.conda
   hash:
-    md5: a2d97c91e722e844449e77c46189b064
-    sha256: e90836e026b3eb3750cb698560005f698705e830768bc549332ac4ad942b890d
+    md5: c6962e0181e6edca75e236f8e0c1ea53
+    sha256: e4d78f5226cc319d578731b7736680c2b4c0c18663d6fb48ddf132d6c3913394
   category: main
   optional: false
 - name: libgoogle-cloud-storage
-  version: 2.30.0
+  version: 2.34.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -9564,27 +7683,13 @@ package:
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libcurl: ''
     libcxx: '>=18'
-    libgoogle-cloud: 2.30.0
+    libgoogle-cloud: 2.34.0
     libzlib: '>=1.3.1,<2.0a0'
     openssl: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.30.0-h7081f7f_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.34.0-h7081f7f_0.conda
   hash:
-    md5: 66517c46cacd189a6dae3f17fc030d36
-    sha256: 2bada39ddba63e6f6f5dba708f8fc6570b8f9ba20fe0e2bdda2dd24538c7ae3b
-  category: main
-  optional: false
-- name: libgpg-error
-  version: '1.51'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.51-hbd13f7d_1.conda
-  hash:
-    md5: 168cc19c031482f83b23c4eebbb94e26
-    sha256: 9e0c09c1faf2151ade3ccb64e52d3c1f2dde85c00e37c6a3e6a8bced2aba68be
+    md5: f09cb03f9cf847f1dc41b4c1f65c97c2
+    sha256: 79f6b93fb330728530036b2b38764e9d42e0eedd3ae7e549ac7eae49acd1e52b
   category: main
   optional: false
 - name: libgrpc
@@ -9593,19 +7698,19 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.32.3,<2.0a0'
+    c-ares: '>=1.34.4,<2.0a0'
     libabseil: '>=20240722.0,<20240723.0a0'
     libgcc: '>=13'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libre2-11: '>=2024.7.2'
     libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.2,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-h25350d4_1.conda
   hash:
-    md5: 4606a4647bfe857e3cfe21ca12ac3afb
-    sha256: 870550c1faf524e9a695262cd4c31441b18ad542f16893bd3c5dbc93106705f7
+    md5: 0c6497a760b99a926c7c12b74951a39c
+    sha256: 014627485b3cf0ea18e04c0bab07be7fb98722a3aeeb58477acc7e1c3d2f911e
   category: main
   optional: false
 - name: libgrpc
@@ -9614,18 +7719,18 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    c-ares: '>=1.34.2,<2.0a0'
+    c-ares: '>=1.34.4,<2.0a0'
     libabseil: '>=20240722.0,<20240723.0a0'
-    libcxx: '>=17'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libcxx: '>=18'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libre2-11: '>=2024.7.2'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.2,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.67.1-he6e0b18_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.67.1-h4896ac0_1.conda
   hash:
-    md5: 05ea1754e8da5d0e8faf9ec599505834
-    sha256: 0884aaa894617fac40c0e0d03a03d2ea6ea486fe9692a0ff854cbe4b080e4c6a
+    md5: e6f9b94b637c659257d7ea8508748905
+    sha256: 7d70fb44315e58d31f3bd07319ea61db7348e51d35a7e2127908db76edccc247
   category: main
   optional: false
 - name: libgrpc
@@ -9634,22 +7739,22 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    c-ares: '>=1.34.2,<2.0a0'
+    c-ares: '>=1.34.4,<2.0a0'
     libabseil: '>=20240722.0,<20240723.0a0'
-    libcxx: '>=17'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libcxx: '>=18'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libre2-11: '>=2024.7.2'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.2,<4.0a0'
+    openssl: '>=3.4.0,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-hc70892a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.67.1-h0a426d6_1.conda
   hash:
-    md5: 624e27571fde34f8acc2afec840ac435
-    sha256: d2393fcd3c3584e5d58da4122f48bcf297567d2f6f14b3d1fcbd34fdd5040694
+    md5: 8a3cba079d6ac985e7d73c76a678fbb4
+    sha256: 630edf63981818ff590367cb95fddbed0f5a390464d0952c90ec81de899e84a6
   category: main
   optional: false
 - name: libheif
-  version: 1.18.2
+  version: 1.19.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -9658,17 +7763,17 @@ package:
     dav1d: '>=1.2.1,<1.2.2.0a0'
     libavif16: '>=1.1.1,<2.0a0'
     libde265: '>=1.0.15,<1.0.16.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
     x265: '>=3.5,<3.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.18.2-gpl_hffcb242_100.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.19.5-gpl_hc21c24c_100.conda
   hash:
-    md5: 76ac2c07b62d45c192940f010eea11fa
-    sha256: 82af131dc112f4f36ca9226f30a7b1b3e05ed4fb3f85003e8f1af72b6a8e44bc
+    md5: 3b57852666eaacc13414ac811dde3f8a
+    sha256: d814dd9203d5ba2f38b4682f53ac02ddd17578324d715a101d29c057610c6545
   category: main
   optional: false
 - name: libheif
-  version: 1.18.2
+  version: 1.19.5
   manager: conda
   platform: osx-64
   dependencies:
@@ -9676,17 +7781,17 @@ package:
     aom: '>=3.9.1,<3.10.0a0'
     dav1d: '>=1.2.1,<1.2.2.0a0'
     libavif16: '>=1.1.1,<2.0a0'
-    libcxx: '>=16'
+    libcxx: '>=18'
     libde265: '>=1.0.15,<1.0.16.0a0'
     x265: '>=3.5,<3.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libheif-1.18.2-gpl_h57a3ca0_100.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libheif-1.19.5-gpl_hc62a4a2_100.conda
   hash:
-    md5: b08c6fdf99e131e906935a01b63e113c
-    sha256: e3aaa419f3d7ff2e21710991c1dd4484ed301942dcbcb5052e6835ddfd08abed
+    md5: 8fe3273539e2f4d0b8dc3d9aa960f2bf
+    sha256: 2c37ca00e28623ddb1e86e443f6aacc2c5c4f78353a33714475c20160a40aa53
   category: main
   optional: false
 - name: libheif
-  version: 1.18.2
+  version: 1.19.5
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -9694,13 +7799,13 @@ package:
     aom: '>=3.9.1,<3.10.0a0'
     dav1d: '>=1.2.1,<1.2.2.0a0'
     libavif16: '>=1.1.1,<2.0a0'
-    libcxx: '>=16'
+    libcxx: '>=18'
     libde265: '>=1.0.15,<1.0.16.0a0'
     x265: '>=3.5,<3.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.18.2-gpl_he913df3_100.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.19.5-gpl_h297b2c4_100.conda
   hash:
-    md5: 29911afbc2ec42a42914d5255dea52e6
-    sha256: 34a70c5889989013b199c6266a30362539af9e24211a6963a0cb0d7ba786f12d
+    md5: 5e457131dd237050dbfe6b141592f3ea
+    sha256: f340e8e51519bcf885da9dd12602f19f76f3206347701accb28034dd0112b1a1
   category: main
   optional: false
 - name: libiconv
@@ -9737,32 +7842,6 @@ package:
     sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
   category: main
   optional: false
-- name: libintl
-  version: 0.22.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libiconv: '>=1.17,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-hdfe23c8_3.conda
-  hash:
-    md5: 52d4d643ed26c07599736326c46bf12f
-    sha256: 0dbb662440a73e20742f12d88e51785a5a5117b8b150783a032b8818a8c043af
-  category: dev
-  optional: true
-- name: libintl
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libiconv: '>=1.17,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8414b35_3.conda
-  hash:
-    md5: 3b98ec32e91b3b59ad53dbb9c96dd334
-    sha256: 7c1d238d4333af385e594c89ebcb520caad7ed83a735c901099ec0970a87a891
-  category: dev
-  optional: true
 - name: libjpeg-turbo
   version: 3.0.0
   manager: conda
@@ -9927,54 +8006,6 @@ package:
     sha256: 63e22ccd4c1b80dfc7da169c65c62a878a46ef0e5771c3b0c091071e718ae1b1
   category: main
   optional: false
-- name: libllvm17
-  version: 17.0.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-    libxml2: '>=2.13.5,<3.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm17-17.0.6-ha7bfdaf_3.conda
-  hash:
-    md5: ed3e154faccbf6393bf0bc9ea0423dce
-    sha256: 4fb1d91048b7714c65b01dc8fd5e9ed3fdf7e48c0b2ed390c75dd376cf682316
-  category: main
-  optional: false
-- name: libllvm17
-  version: 17.0.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libcxx: '>=16'
-    libxml2: '>=2.12.1,<3.0.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm17-17.0.6-hbedff68_1.conda
-  hash:
-    md5: fcd38f0553a99fa279fb66a5bfc2fb28
-    sha256: 605460ecc4ccc04163d0b06c99693864e5bcba7a9f014a5263c9856195282265
-  category: main
-  optional: false
-- name: libllvm17
-  version: 17.0.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=18'
-    libxml2: '>=2.13.5,<3.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-hc4b4ae8_3.conda
-  hash:
-    md5: 2a75227e917a3ec0a064155f1ed11b06
-    sha256: 9b4da9f025bc946f5e1c8c104d7790b1af0c6e87eb03f29dea97fa1639ff83f2
-  category: main
-  optional: false
 - name: liblzma
   version: 5.6.4
   manager: conda
@@ -10010,46 +8041,6 @@ package:
   hash:
     md5: e3fd1f8320a100f2b210e690a57cd615
     sha256: 560c59d3834cc652a84fb45531bd335ad06e271b34ebc216e380a89798fe8e2c
-  category: main
-  optional: false
-- name: liblzma-devel
-  version: 5.6.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    liblzma: 5.6.4
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.6.4-hb9d3cd8_0.conda
-  hash:
-    md5: 5ab1a0df19c8f3ec00d5e63458e0a420
-    sha256: 34928b36a3946902196a6786db80c8a4a97f6c9418838d67be90a1388479a682
-  category: main
-  optional: false
-- name: liblzma-devel
-  version: 5.6.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    liblzma: 5.6.4
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-devel-5.6.4-hd471939_0.conda
-  hash:
-    md5: 06eccf9183d7bfeb45888e07804e6297
-    sha256: 0f8c5679cce617a3c45f58a4e984cf2ec920a9b98f4e522fc3e0e6a69a31bf26
-  category: main
-  optional: false
-- name: liblzma-devel
-  version: 5.6.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    liblzma: 5.6.4
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.6.4-h39f12f2_0.conda
-  hash:
-    md5: 5789af7c91332d5d5693d3afd499b9eb
-    sha256: b5585156354258a85c7739039b6793e42324d29a24952fac8a9311cf2b6fff7a
   category: main
   optional: false
 - name: libmamba
@@ -10244,19 +8235,6 @@ package:
     sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
   category: main
   optional: false
-- name: libnl
-  version: 3.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
-  hash:
-    md5: db63358239cbe1ff86242406d440e44a
-    sha256: ba7c5d294e3d80f08ac5a39564217702d1a752e352e486210faff794ac5001b4
-  category: main
-  optional: false
 - name: libnsl
   version: 2.0.1
   manager: conda
@@ -10314,54 +8292,143 @@ package:
     sha256: 62bb669c37a845129096f73d446cdb6bb170e4927f2fea2b661329680dbbc373
   category: main
   optional: false
+- name: libopentelemetry-cpp
+  version: 1.18.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
+    libgrpc: '>=1.67.1,<1.68.0a0'
+    libopentelemetry-cpp-headers: 1.18.0
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    nlohmann_json: ''
+    prometheus-cpp: '>=1.3.0,<1.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.18.0-hfcad708_1.conda
+  hash:
+    md5: 1f5a5d66e77a39dc5bd639ec953705cf
+    sha256: 4ea235e08676f16b0d3c3380befe1478c0fa0141512ee709b011005c55c9619f
+  category: main
+  optional: false
+- name: libopentelemetry-cpp
+  version: 1.18.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
+    libgrpc: '>=1.67.1,<1.68.0a0'
+    libopentelemetry-cpp-headers: 1.18.0
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    nlohmann_json: ''
+    prometheus-cpp: '>=1.3.0,<1.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-1.18.0-h739dec3_1.conda
+  hash:
+    md5: f567067f39b8577939373d8b4bef8863
+    sha256: 3e5c194e503087a40fa8a316ff56afe3a4be936136ca185c35f5e39dd6bba0f8
+  category: main
+  optional: false
+- name: libopentelemetry-cpp
+  version: 1.18.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libabseil: '>=20240722.0,<20240723.0a0'
+    libcurl: '>=8.11.1,<9.0a0'
+    libgrpc: '>=1.67.1,<1.68.0a0'
+    libopentelemetry-cpp-headers: 1.18.0
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    nlohmann_json: ''
+    prometheus-cpp: '>=1.3.0,<1.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.18.0-h0c05b2d_1.conda
+  hash:
+    md5: 19c46cc18825f3924251c39ec1b0d983
+    sha256: c6bcbd53d62a9e0d8c667e560db0ca2ecb7679277cbb3c23457aabe74fcb8cba
+  category: main
+  optional: false
+- name: libopentelemetry-cpp-headers
+  version: 1.18.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.18.0-ha770c72_1.conda
+  hash:
+    md5: 4fb055f57404920a43b147031471e03b
+    sha256: aa1f7dea79ea8513ff77339ba7c6e9cf10dfa537143e7718b1cfb3af52b649f2
+  category: main
+  optional: false
+- name: libopentelemetry-cpp-headers
+  version: 1.18.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-headers-1.18.0-h694c41f_1.conda
+  hash:
+    md5: 4c996e9294dd750e824e15f6a05ba247
+    sha256: 5e51b72cb76da505595059ca36378571ed1a75f5fe8ae292b16e6b1927c7cbcb
+  category: main
+  optional: false
+- name: libopentelemetry-cpp-headers
+  version: 1.18.0
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.18.0-hce30654_1.conda
+  hash:
+    md5: e965dad955841507549fdacd8f7f94c0
+    sha256: 82e5f5ba64debbaab3c601b265dfc0cdb4d2880feba9bada5fd2e67b9f91ada5
+  category: main
+  optional: false
 - name: libparquet
-  version: 14.0.2
+  version: 19.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    gflags: '>=2.2.2,<2.3.0a0'
-    libarrow: 14.0.2
+    libarrow: 19.0.0
     libgcc: '>=13'
     libstdcxx: '>=13'
     libthrift: '>=0.21.0,<0.21.1.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.2-hd082c85_52_cpu.conda
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-19.0.0-h081d1f1_8_cpu.conda
   hash:
-    md5: 2ef3c2382ef37b72fe2e48082c24d29e
-    sha256: 2b52c433d47bd213e334b634c1dfd830857dd6a968a3e2d209e5f1d42add89aa
+    md5: bef810a8da683aa11c644066a87f71c3
+    sha256: b2e1bf8634efb643a9f15fe19f9bc0877482c509eff7cee6136278a2c2fa5842
   category: main
   optional: false
 - name: libparquet
-  version: 14.0.2
+  version: 19.0.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libarrow: 14.0.2
-    libcxx: '>=17'
+    libarrow: 19.0.0
+    libcxx: '>=18'
     libthrift: '>=0.21.0,<0.21.1.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.2-h2be9fba_52_cpu.conda
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-19.0.0-h3e22b07_8_cpu.conda
   hash:
-    md5: 9ccc0631f3ce06c50203c3b4ec881954
-    sha256: 10956f2dc8a89915f515b58240651525325004ff2d39de7828565eecde6c35e6
+    md5: cbaae00b9e1f488554aa8222bb132a4a
+    sha256: 65827c217fcbabb349a05b7bc365f163dbae38c3113572a356d140df96fe8744
   category: main
   optional: false
 - name: libparquet
-  version: 14.0.2
+  version: 19.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libarrow: 14.0.2
-    libcxx: '>=17'
+    libarrow: 19.0.0
+    libcxx: '>=18'
     libthrift: '>=0.21.0,<0.21.1.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.2-h8aa6169_52_cpu.conda
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-19.0.0-h636d7b7_8_cpu.conda
   hash:
-    md5: 42cac887efa238b90c80447f9297e1b6
-    sha256: 772211cf489e8a4d322cabdb2ba4a673effc8dae888cc1670bd376380a4eab9d
+    md5: c1ff2e71a289fb76146591c9d3f9de0a
+    sha256: da04e6bd7ed2ca64aadf0ad12d9752e8423e85c37e0db80e27c7ff334fcbd2b6
   category: main
   optional: false
 - name: libpng
@@ -10405,7 +8472,7 @@ package:
   category: main
   optional: false
 - name: libprotobuf
-  version: 5.28.2
+  version: 5.28.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -10414,40 +8481,40 @@ package:
     libgcc: '>=13'
     libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.3-h6128344_1.conda
   hash:
-    md5: ab0bff36363bec94720275a681af8b83
-    sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
+    md5: d8703f1ffe5a06356f06467f1d0b9464
+    sha256: 51125ebb8b7152e4a4e69fd2398489c4ec8473195c27cde3cbdf1cb6d18c5493
   category: main
   optional: false
 - name: libprotobuf
-  version: 5.28.2
+  version: 5.28.3
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libabseil: '>=20240722.0,<20240723.0a0'
-    libcxx: '>=17'
+    libcxx: '>=18'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.28.2-h8b30cf6_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-5.28.3-h6401091_1.conda
   hash:
-    md5: 2302089e5bcb04ce891ce765c963befb
-    sha256: e240c2003e301ede0a0f4af7688adb8456559ffaa4af2eed3fce879c22c80a0e
+    md5: 5601e7ce099eb72741e9cd6413f42a07
+    sha256: 7bd8467402040312cf1030d98427b6bdce9905e519a1979cd7aa5f0fb0902cad
   category: main
   optional: false
 - name: libprotobuf
-  version: 5.28.2
+  version: 5.28.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libabseil: '>=20240722.0,<20240723.0a0'
-    libcxx: '>=17'
+    libcxx: '>=18'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.3-h3bd63a1_1.conda
   hash:
-    md5: d2cb5991f2fb8eb079c80084435e9ce6
-    sha256: f732a6fa918428e2d5ba61e78fe11bb44a002cc8f6bb74c94ee5b1297fefcfd8
+    md5: bdbfea4cf45ae36652c6bbcc2e7ebe91
+    sha256: f58a16b13ad53346903c833e266f83c3d770a43a432659b98710aed85ca885e7
   category: main
   optional: false
 - name: libre2-11
@@ -10493,61 +8560,6 @@ package:
     sha256: 112a73ad483353751d4c5d63648c69a4d6fcebf5e1b698a860a3f5124fc3db96
   category: main
   optional: false
-- name: librsvg
-  version: 2.58.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cairo: '>=1.18.2,<2.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    harfbuzz: '>=10.1.0,<11.0a0'
-    libgcc: '>=13'
-    libglib: '>=2.82.2,<3.0a0'
-    libpng: '>=1.6.44,<1.7.0a0'
-    libxml2: '>=2.13.5,<3.0a0'
-    pango: '>=1.54.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-h49af25d_2.conda
-  hash:
-    md5: b9846db0abffb09847e2cb0fec4b4db6
-    sha256: 475013475a3209c24a82f9e80c545d56ccca2fa04df85952852f3d73caa38ff9
-  category: dev
-  optional: true
-- name: librsvg
-  version: 2.58.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    cairo: '>=1.18.2,<2.0a0'
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    libglib: '>=2.82.2,<3.0a0'
-    libxml2: '>=2.13.5,<3.0a0'
-    pango: '>=1.54.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/librsvg-2.58.4-h21a6cfa_2.conda
-  hash:
-    md5: 0aa68f5a6ebfd2254daae40170439f03
-    sha256: 482cde0a3828935edc31c529e15c2686425f64b07a7e52551b6ed672360f2a15
-  category: dev
-  optional: true
-- name: librsvg
-  version: 2.58.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    cairo: '>=1.18.2,<2.0a0'
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    libglib: '>=2.82.2,<3.0a0'
-    libxml2: '>=2.13.5,<3.0a0'
-    pango: '>=1.54.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.4-h266df6f_2.conda
-  hash:
-    md5: 82c31ce77bac095b5700b1fdaad9a628
-    sha256: c1ef2c5855166001967952d7525aa2f29707214495c74c2bbb60e691aee45ef0
-  category: dev
-  optional: true
 - name: librttopo
   version: 1.1.0
   manager: conda
@@ -10845,24 +8857,6 @@ package:
     sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
   category: main
   optional: false
-- name: libsystemd0
-  version: '256.9'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libcap: '>=2.71,<2.72.0a0'
-    libgcc: '>=13'
-    libgcrypt-lib: '>=1.11.0,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-256.9-h2774228_0.conda
-  hash:
-    md5: 7b283ff97a87409a884bc11283855c17
-    sha256: a93e45c12c2954942a994ff3ffc8b9a144261288032da834ed80a6210708ad49
-  category: main
-  optional: false
 - name: libthrift
   version: 0.21.0
   manager: conda
@@ -10919,7 +8913,7 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.22,<1.23.0a0'
+    libdeflate: '>=1.23,<1.24.0a0'
     libgcc: '>=13'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     liblzma: '>=5.6.3,<6.0a0'
@@ -10927,10 +8921,10 @@ package:
     libwebp-base: '>=1.4.0,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hc4654cb_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hd9ff511_3.conda
   hash:
-    md5: be54fb40ea32e8fe9dbaa94d4528b57e
-    sha256: 18653b4a5c73e19c5e86ff72dab9bf59f5cc43d7f404a6be705d152dfd5e0660
+    md5: 0ea6510969e1296cc19966fad481f6de
+    sha256: b224e16b88d76ea95e4af56e2bc638c603bd26a770b98d117d04541d3aafa002
   category: main
   optional: false
 - name: libtiff
@@ -10941,16 +8935,16 @@ package:
     __osx: '>=10.13'
     lerc: '>=4.0.0,<5.0a0'
     libcxx: '>=18'
-    libdeflate: '>=1.22,<1.23.0a0'
+    libdeflate: '>=1.23,<1.24.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     liblzma: '>=5.6.3,<6.0a0'
     libwebp-base: '>=1.4.0,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-hf4bdac2_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.0-hb77a491_3.conda
   hash:
-    md5: 99a4153a4ee19d4902c0c08bfae4cdb4
-    sha256: dba23d6c9c1df6092e894b69d53fcdb78cdd10eab8e1b57f040de91a8beed908
+    md5: 6f2f9df7b093d6b33bc0c334acc7d2d9
+    sha256: bb50df7cfc1acb11eae63c5f4fdc251d381cda96bf02c086c3202c83a5200032
   category: main
   optional: false
 - name: libtiff
@@ -10961,67 +8955,53 @@ package:
     __osx: '>=11.0'
     lerc: '>=4.0.0,<5.0a0'
     libcxx: '>=18'
-    libdeflate: '>=1.22,<1.23.0a0'
+    libdeflate: '>=1.23,<1.24.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     liblzma: '>=5.6.3,<6.0a0'
     libwebp-base: '>=1.4.0,<2.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-ha962b0a_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-h551f018_3.conda
   hash:
-    md5: 8e14b5225c593f099a21971568e6d7b4
-    sha256: d9e6835fd189b85eb90dbfdcc51f5375decbf5bb53130042f49bbd6bfb0b24be
-  category: main
-  optional: false
-- name: libudev1
-  version: '257.2'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libcap: '>=2.71,<2.72.0a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.2-h9a4d06a_0.conda
-  hash:
-    md5: f8ff68da999a4f1c57b1d523b18de1cc
-    sha256: d1558209de4908c12dd9119ce01d39d0d0052c5a20123957ed49b5ab21cb2ee8
+    md5: a5d084a957563e614ec0c0196d890654
+    sha256: 91417846157e04992801438a496b151df89604b2e7c6775d6f701fcd0cbed5ae
   category: main
   optional: false
 - name: libutf8proc
-  version: 2.8.0
+  version: 2.10.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-hf23e847_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.10.0-h4c51ac1_0.conda
   hash:
-    md5: b1aa0faa95017bca11369bd080487ec4
-    sha256: 104cf5b427fc914fec63e55f685a39480abeb4beb34bdbc77dea084c8f5a55cb
+    md5: aeccfff2806ae38430638ffbb4be9610
+    sha256: 8e41563ee963bf8ded06da45f4e70bf42f913cb3c2e79364eb3218deffa3cd74
   category: main
   optional: false
 - name: libutf8proc
-  version: 2.8.0
+  version: 2.10.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-he670073_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.10.0-h777c5d8_0.conda
   hash:
-    md5: a7ce895b33370269f03650fa30b7c53d
-    sha256: 2b4c4c2a6051433e5c39943b8886a89fc74543f3b5d8286e5a39c7373f5f6cec
+    md5: 0c9c79979aeba96d102b0628fe361c56
+    sha256: cbac7991d6ede019fd744b9b386bb8f973ad2500c8cdcef4425e1334400125d0
   category: main
   optional: false
 - name: libutf8proc
-  version: 2.8.0
+  version: 2.10.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-hc098a78_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.10.0-hda25de7_0.conda
   hash:
-    md5: ed89b8bf0d74d23ce47bcf566dd36608
-    sha256: 7807a98522477a8bf12460402845224f607ab6e1e73ac316b667169f5143cfe5
+    md5: 5f741aed1d8d393586a5fdcaaa87f45c
+    sha256: aca3ef31d3dff5cefd3790742a5ee6548f1cf0201d0e8cee08b01da503484eb6
   category: main
   optional: false
 - name: libuuid
@@ -11131,24 +9111,6 @@ package:
     sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   category: main
   optional: false
-- name: libxkbcommon
-  version: 1.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-    libxcb: '>=1.17.0,<2.0a0'
-    libxml2: '>=2.13.5,<3.0a0'
-    xkeyboard-config: ''
-    xorg-libxau: '>=1.0.12,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.8.0-hc4a0caf_0.conda
-  hash:
-    md5: f1656760dbf05f47f962bfdc59fc3416
-    sha256: 583203155abcfb03938d8473afbf129156b5b30301a0f796c8ecca8c5b7b2ed2
-  category: dev
-  optional: true
 - name: libxml2
   version: 2.13.5
   manager: conda
@@ -11312,40 +9274,43 @@ package:
   category: main
   optional: false
 - name: lz4-c
-  version: 1.9.4
+  version: 1.10.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
   hash:
-    md5: 318b08df404f9c9be5712aaa5a6f0bb0
-    sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
+    md5: 9de5350a85c4a20c685259b889aa6393
+    sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
   category: main
   optional: false
 - name: lz4-c
-  version: 1.9.4
+  version: 1.10.0
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=14.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+    __osx: '>=10.13'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.10.0-h240833e_1.conda
   hash:
-    md5: aa04f7143228308662696ac24023f991
-    sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+    md5: d6b9bd7e356abd7e3a633d59b753495a
+    sha256: 8da3c9d4b596e481750440c0250a7e18521e7f69a47e1c8415d568c847c08a1c
   category: main
   optional: false
 - name: lz4-c
-  version: 1.9.4
+  version: 1.10.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=14.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+    __osx: '>=11.0'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
   hash:
-    md5: 45505bec548634f7d05e02fb25262cb9
-    sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+    md5: 01511afc6cc1909c5303cf31be17b44f
+    sha256: 94d3e2a485dab8bdfdd4837880bde3dd0d701e2b97d6134b8806b7c8e69c8652
   category: main
   optional: false
 - name: lzo
@@ -11882,233 +9847,87 @@ package:
   category: main
   optional: false
 - name: moto
-  version: 4.2.14
+  version: 5.0.28
   manager: conda
   platform: linux-64
   dependencies:
     aws-xray-sdk: '!=0.96,>=0.93'
     boto3: '>=1.9.201'
-    botocore: '>=1.12.201'
-    cfn-lint: '>=0.40.0'
+    botocore: '>=1.14.0,!=1.35.45,!=1.35.46'
     cryptography: '>=3.3.1'
-    docker-py: '>=2.5.1'
     flask: '!=2.2.0,!=2.2.1'
-    flask_cors: ''
-    graphql-core: ''
-    idna: '>=2.5,<4'
-    importlib_metadata: ''
+    flask-cors: ''
     jinja2: '>=2.10.1'
+    joserfc: ''
     jsondiff: '>=1.1.2'
-    openapi-spec-validator: '>=0.2.8'
+    openapi-spec-validator: '>=0.6.0'
     pyparsing: '>=3.0.7'
-    python: '>=3.3'
-    python-dateutil: '>=2.1,<3.0.0'
-    python-jose: '>=3.1.0,<4.0.0'
-    pytz: ''
-    pyyaml: '>=5.1'
+    python: '>=3.9'
+    python-dateutil: <3.0.0,>=2.1
     requests: '>=2.5'
-    responses: '>=0.9.0'
-    setuptools: ''
-    sshpubkeys: '>=3.1.0'
+    responses: '>=0.15.0'
     werkzeug: '>=0.5,!=2.2.0,!=2.2.1'
     xmltodict: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/moto-4.2.14-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/moto-5.0.28-pyhd8ed1ab_0.conda
   hash:
-    md5: 6e68c67781a43d8400b7a10f6f532725
-    sha256: 51380f1bcf262799a3ea19c17efdaa9821dd956032627dd585bf439c837bea59
+    md5: cf2930ba850f7ea05a056f579fb5d0e3
+    sha256: 51e84ed5e2accb8a26331bac8043be6565d877ec7a774477ac6cd991e2ef629c
   category: dev
   optional: true
 - name: moto
-  version: 4.2.14
+  version: 5.0.28
   manager: conda
   platform: osx-64
   dependencies:
-    setuptools: ''
-    pytz: ''
-    importlib_metadata: ''
     xmltodict: ''
-    graphql-core: ''
-    flask_cors: ''
-    python-dateutil: '>=2.1,<3.0.0'
-    pyyaml: '>=5.1'
-    python: '>=3.3'
+    flask-cors: ''
+    joserfc: ''
+    python: '>=3.9'
     jinja2: '>=2.10.1'
     requests: '>=2.5'
     cryptography: '>=3.3.1'
-    idna: '>=2.5,<4'
     boto3: '>=1.9.201'
     aws-xray-sdk: '!=0.96,>=0.93'
     jsondiff: '>=1.1.2'
-    responses: '>=0.9.0'
-    docker-py: '>=2.5.1'
-    botocore: '>=1.12.201'
-    python-jose: '>=3.1.0,<4.0.0'
-    sshpubkeys: '>=3.1.0'
     flask: '!=2.2.0,!=2.2.1'
     pyparsing: '>=3.0.7'
     werkzeug: '>=0.5,!=2.2.0,!=2.2.1'
-    openapi-spec-validator: '>=0.2.8'
-    cfn-lint: '>=0.40.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/moto-4.2.14-pyhd8ed1ab_0.conda
+    python-dateutil: <3.0.0,>=2.1
+    responses: '>=0.15.0'
+    openapi-spec-validator: '>=0.6.0'
+    botocore: '>=1.14.0,!=1.35.45,!=1.35.46'
+  url: https://conda.anaconda.org/conda-forge/noarch/moto-5.0.28-pyhd8ed1ab_0.conda
   hash:
-    md5: 6e68c67781a43d8400b7a10f6f532725
-    sha256: 51380f1bcf262799a3ea19c17efdaa9821dd956032627dd585bf439c837bea59
+    md5: cf2930ba850f7ea05a056f579fb5d0e3
+    sha256: 51e84ed5e2accb8a26331bac8043be6565d877ec7a774477ac6cd991e2ef629c
   category: dev
   optional: true
 - name: moto
-  version: 4.2.14
+  version: 5.0.28
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
-    pytz: ''
-    importlib_metadata: ''
     xmltodict: ''
-    graphql-core: ''
-    flask_cors: ''
-    python-dateutil: '>=2.1,<3.0.0'
-    pyyaml: '>=5.1'
-    python: '>=3.3'
+    flask-cors: ''
+    joserfc: ''
+    python: '>=3.9'
     jinja2: '>=2.10.1'
     requests: '>=2.5'
     cryptography: '>=3.3.1'
-    idna: '>=2.5,<4'
     boto3: '>=1.9.201'
     aws-xray-sdk: '!=0.96,>=0.93'
     jsondiff: '>=1.1.2'
-    responses: '>=0.9.0'
-    docker-py: '>=2.5.1'
-    botocore: '>=1.12.201'
-    python-jose: '>=3.1.0,<4.0.0'
-    sshpubkeys: '>=3.1.0'
     flask: '!=2.2.0,!=2.2.1'
     pyparsing: '>=3.0.7'
     werkzeug: '>=0.5,!=2.2.0,!=2.2.1'
-    openapi-spec-validator: '>=0.2.8'
-    cfn-lint: '>=0.40.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/moto-4.2.14-pyhd8ed1ab_0.conda
+    python-dateutil: <3.0.0,>=2.1
+    responses: '>=0.15.0'
+    openapi-spec-validator: '>=0.6.0'
+    botocore: '>=1.14.0,!=1.35.45,!=1.35.46'
+  url: https://conda.anaconda.org/conda-forge/noarch/moto-5.0.28-pyhd8ed1ab_0.conda
   hash:
-    md5: 6e68c67781a43d8400b7a10f6f532725
-    sha256: 51380f1bcf262799a3ea19c17efdaa9821dd956032627dd585bf439c837bea59
-  category: dev
-  optional: true
-- name: mpc
-  version: 1.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    gmp: '>=6.3.0,<7.0a0'
-    libgcc: '>=13'
-    mpfr: '>=4.2.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.3.1-h24ddda3_1.conda
-  hash:
-    md5: aa14b9a5196a6d8dd364164b7ce56acf
-    sha256: 1bf794ddf2c8b3a3e14ae182577c624fa92dea975537accff4bc7e5fea085212
-  category: dev
-  optional: true
-- name: mpc
-  version: 1.3.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    gmp: '>=6.3.0,<7.0a0'
-    mpfr: '>=4.2.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h9d8efa1_1.conda
-  hash:
-    md5: 0520855aaae268ea413d6bc913f1384c
-    sha256: dcf91571da6c2f0db96d43a1b639047def05a0e1b6436d42c9129ab14af47b10
-  category: dev
-  optional: true
-- name: mpc
-  version: 1.3.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    gmp: '>=6.3.0,<7.0a0'
-    mpfr: '>=4.2.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h8f1351a_1.conda
-  hash:
-    md5: a5635df796b71f6ca400fc7026f50701
-    sha256: 2700899ad03302a1751dbf2bca135407e470dd83ac897ab91dd8675d4300f158
-  category: dev
-  optional: true
-- name: mpfr
-  version: 4.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    gmp: '>=6.3.0,<7.0a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.1-h90cbb55_3.conda
-  hash:
-    md5: 2eeb50cab6652538eee8fc0bc3340c81
-    sha256: f25d2474dd557ca66c6231c8f5ace5af312efde1ba8290a6ea5e1732a4e669c0
-  category: dev
-  optional: true
-- name: mpfr
-  version: 4.2.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/mpfr-4.2.1-haed47dc_3.conda
-  hash:
-    md5: d511e58aaaabfc23136880d9956fa7a6
-    sha256: dddb6721dff05b8dfb654c532725330231fcb81ff1e27d885ee0cdcc9fccf1c4
-  category: dev
-  optional: true
-- name: mpfr
-  version: 4.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-hb693164_3.conda
-  hash:
-    md5: 4e4ea852d54cc2b869842de5044662fb
-    sha256: 4463e4e2aba7668e37a1b8532859191b4477a6f3602a5d6b4d64ad4c4baaeac5
-  category: dev
-  optional: true
-- name: mpmath
-  version: 1.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 3585aa87c43ab15b167b574cd73b057b
-    sha256: 7d7aa3fcd6f42b76bd711182f3776a02bef09a68c5f117d66b712a6d81368692
-  category: dev
-  optional: true
-- name: mpmath
-  version: 1.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 3585aa87c43ab15b167b574cd73b057b
-    sha256: 7d7aa3fcd6f42b76bd711182f3776a02bef09a68c5f117d66b712a6d81368692
-  category: dev
-  optional: true
-- name: mpmath
-  version: 1.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 3585aa87c43ab15b167b574cd73b057b
-    sha256: 7d7aa3fcd6f42b76bd711182f3776a02bef09a68c5f117d66b712a6d81368692
+    md5: cf2930ba850f7ea05a056f579fb5d0e3
+    sha256: 51e84ed5e2accb8a26331bac8043be6565d877ec7a774477ac6cd991e2ef629c
   category: dev
   optional: true
 - name: msgpack-python
@@ -12170,8 +9989,8 @@ package:
   hash:
     md5: 5b5e3267d915a107eca793d52e1b780a
     sha256: b05bc8252a6e957bf4a776ed5e0e61d1ba88cdc46ccb55890c72cc58b10371f4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: multidict
   version: 6.1.0
   manager: conda
@@ -12184,8 +10003,8 @@ package:
   hash:
     md5: 47e51ecdee53dfc456f02ad633aa43bf
     sha256: 326c92cd8e4bc85294f2f0b5cdf97d90e96158c2881915256e99f8bc07559960
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: multidict
   version: 6.1.0
   manager: conda
@@ -12198,8 +10017,8 @@ package:
   hash:
     md5: 0048335516fed938e4dd2c457b4c5b9b
     sha256: 482fd09fb798090dc8cce2285fa69f43b1459099122eac2fb112d9b922b9f916
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: munkres
   version: 1.1.4
   manager: conda
@@ -12289,45 +10108,45 @@ package:
   category: dev
   optional: true
 - name: mypy-boto3-s3
-  version: 1.36.9
+  version: 1.36.15
   manager: conda
   platform: linux-64
   dependencies:
     boto3: ''
     python: '>=3.9'
     typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.36.9-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.36.15-pyhd8ed1ab_0.conda
   hash:
-    md5: 7c2ae5ac33152d95ffa4650fc32d2e66
-    sha256: c8cdb36240ab01860d1105002d82fbd5ed562ad2cd67a542a3ad229da4f35312
+    md5: b203c583fba8db4d84b0c48fa447fffd
+    sha256: 3863d876ddde4fa66726928c11626b9eb6c648b91baa6ee92281d521f365ddb6
   category: dev
   optional: true
 - name: mypy-boto3-s3
-  version: 1.36.9
+  version: 1.36.15
   manager: conda
   platform: osx-64
   dependencies:
     boto3: ''
     typing-extensions: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.36.9-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.36.15-pyhd8ed1ab_0.conda
   hash:
-    md5: 7c2ae5ac33152d95ffa4650fc32d2e66
-    sha256: c8cdb36240ab01860d1105002d82fbd5ed562ad2cd67a542a3ad229da4f35312
+    md5: b203c583fba8db4d84b0c48fa447fffd
+    sha256: 3863d876ddde4fa66726928c11626b9eb6c648b91baa6ee92281d521f365ddb6
   category: dev
   optional: true
 - name: mypy-boto3-s3
-  version: 1.36.9
+  version: 1.36.15
   manager: conda
   platform: osx-arm64
   dependencies:
     boto3: ''
     typing-extensions: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.36.9-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.36.15-pyhd8ed1ab_0.conda
   hash:
-    md5: 7c2ae5ac33152d95ffa4650fc32d2e66
-    sha256: c8cdb36240ab01860d1105002d82fbd5ed562ad2cd67a542a3ad229da4f35312
+    md5: b203c583fba8db4d84b0c48fa447fffd
+    sha256: 3863d876ddde4fa66726928c11626b9eb6c648b91baa6ee92281d521f365ddb6
   category: dev
   optional: true
 - name: mypy_boto3_cloudformation
@@ -12923,55 +10742,58 @@ package:
   category: main
   optional: false
 - name: numpy
-  version: 1.26.4
+  version: 2.1.3
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
+    libgcc: '>=13'
     liblapack: '>=3.9.0,<4.0a0'
-    libstdcxx-ng: '>=12'
+    libstdcxx: '>=13'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py312h58c1407_0.conda
   hash:
-    md5: d8285bea2a350f63fab23bf460221f3f
-    sha256: fe3459c75cf84dcef6ef14efcc4adb0ade66038ddd27cadb894f34f4797687d8
+    md5: dfdbc12e6d81889ba4c494a23f23eba8
+    sha256: e4c14f71588a5627a6935d3e7d9ca78a8387229ec8ebc91616b0988ce57ba0dc
   category: main
   optional: false
 - name: numpy
-  version: 1.26.4
+  version: 2.1.3
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
-    libcxx: '>=16'
+    libcxx: '>=18'
     liblapack: '>=3.9.0,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py312he3a82b2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.1.3-py312hfc93d17_0.conda
   hash:
-    md5: 96c61a21c4276613748dba069554846b
-    sha256: 6152b73fba3e227afa4952df8753128fc9669bbaf142ee8f9972bf9df3bf8856
+    md5: 011118baf131914d1cb48e07317f0946
+    sha256: 2f120e958da2d6ab7e4785a42515b4f65f70422b8b722e1a75654962fcfb26e9
   category: main
   optional: false
 - name: numpy
-  version: 1.26.4
+  version: 2.1.3
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
-    libcxx: '>=16'
+    libcxx: '>=18'
     liblapack: '>=3.9.0,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py312h94ee1e1_0.conda
   hash:
-    md5: d83fc83d589e2625a3451c9a7e21047c
-    sha256: c8841d6d6f61fd70ca80682efbab6bdb8606dc77c68d8acabfbd7c222054f518
+    md5: a2af54c86582e08718805c69af737897
+    sha256: cd287b6c270ee8af77d200c46d56fdfe1e2a9deeff68044439718b8d073214dd
   category: main
   optional: false
 - name: openapi-schema-validator
@@ -13160,61 +10982,61 @@ package:
   category: main
   optional: false
 - name: orc
-  version: 2.0.2
+  version: 2.0.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
     snappy: '>=1.2.1,<1.3.0a0'
     tzdata: ''
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.2-he039a57_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-h12ee42a_2.conda
   hash:
-    md5: 5e7bb9779cc5c200e63475eb2538d382
-    sha256: cfc92e5b6be25e5ebee117cd54336ce71a0115c251974c379f4765b35d7466fe
+    md5: 4f6f9f3f80354ad185e276c120eac3f0
+    sha256: dff5cc8023905782c86b3459055f26d4b97890e403b0698477c9fed15d8669cc
   category: main
   optional: false
 - name: orc
-  version: 2.0.2
+  version: 2.0.3
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcxx: '>=17'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libcxx: '>=18'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
     snappy: '>=1.2.1,<1.3.0a0'
     tzdata: ''
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.2-hb8ce1e1_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.3-h85ea3fe_2.conda
   hash:
-    md5: 4943ece8238f5b0385cad55b50544f8a
-    sha256: 3a068269489e5ab1447148be4d63f64a479450cdb107feb69ba21e1542a2afbe
+    md5: 9b413c1921a9139e11035146f974d5b7
+    sha256: d1f0a40fe5ee1cedfce64a233d7824d7cfd631cc1926efd76b3b3dd24038fa61
   category: main
   optional: false
 - name: orc
-  version: 2.0.2
+  version: 2.0.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=17'
-    libprotobuf: '>=5.28.2,<5.28.3.0a0'
+    libcxx: '>=18'
+    libprotobuf: '>=5.28.3,<5.28.4.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
     snappy: '>=1.2.1,<1.3.0a0'
     tzdata: ''
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.2-hcb3c8b3_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.3-h0ff2369_2.conda
   hash:
-    md5: 3d2c62c12889872216f673c452d23186
-    sha256: 70d5045cbccfb472578b5b9e9e200b7dd122486e5e9a93e9424967f53d838352
+    md5: 24b1897c0d24afbb70704ba998793b78
+    sha256: cca330695f3bdb8c0e46350c29cd4af3345865544e36f1d7c9ba9190ad22f5f4
   category: main
   optional: false
 - name: packaging
@@ -13353,118 +11175,6 @@ package:
     sha256: 4061dd7c87a3b28d612d14be51f369cfbf7cf6341c104034f641962c39e76374
   category: dev
   optional: true
-- name: pango
-  version: 1.56.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cairo: '>=1.18.2,<2.0a0'
-    fontconfig: '>=2.15.0,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=10.2.0,<11.0a0'
-    libexpat: '>=2.6.4,<3.0a0'
-    libgcc: '>=13'
-    libglib: '>=2.82.2,<3.0a0'
-    libpng: '>=1.6.45,<1.7.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.1-h861ebed_0.conda
-  hash:
-    md5: 59e660508a4de9401543303d5f576aeb
-    sha256: 20e5e280859a7803e8b5a09f18a7e43b56d1b8e61e4888c1a24cbb0d5b9cabd3
-  category: dev
-  optional: true
-- name: pango
-  version: 1.56.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    cairo: '>=1.18.2,<2.0a0'
-    fontconfig: '>=2.15.0,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=10.2.0,<11.0a0'
-    libexpat: '>=2.6.4,<3.0a0'
-    libglib: '>=2.82.2,<3.0a0'
-    libpng: '>=1.6.45,<1.7.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pango-1.56.1-hf94f63b_0.conda
-  hash:
-    md5: 3888a31896ccefaa6aa608ff13fd527c
-    sha256: 2f8ec6dff342ef4417b9ab608a33cd1aac9167e778096c3ef0db997087c0e726
-  category: dev
-  optional: true
-- name: pango
-  version: 1.56.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    cairo: '>=1.18.2,<2.0a0'
-    fontconfig: '>=2.15.0,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=10.2.0,<11.0a0'
-    libexpat: '>=2.6.4,<3.0a0'
-    libglib: '>=2.82.2,<3.0a0'
-    libpng: '>=1.6.45,<1.7.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.56.1-h73f1e88_0.conda
-  hash:
-    md5: d90e7fdeb40d3e1739f3d2da0c15edf0
-    sha256: 1f032cd6e70a07071f2839e79a07976b3d66c1c742e5bc5276ac91a4f738babb
-  category: dev
-  optional: true
-- name: paramiko
-  version: 3.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    bcrypt: '>=3.2'
-    cryptography: '>=3.3'
-    pynacl: '>=1.5'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.5.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4e6bea7eee94bb9d8a599385215719f9
-    sha256: 1499e558d31536707fdd7d0b569dbe29ae6e3aa8f2fdce9ea6f3df3ce4c1aaf1
-  category: dev
-  optional: true
-- name: paramiko
-  version: 3.5.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-    cryptography: '>=3.3'
-    bcrypt: '>=3.2'
-    pynacl: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.5.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4e6bea7eee94bb9d8a599385215719f9
-    sha256: 1499e558d31536707fdd7d0b569dbe29ae6e3aa8f2fdce9ea6f3df3ce4c1aaf1
-  category: dev
-  optional: true
-- name: paramiko
-  version: 3.5.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-    cryptography: '>=3.3'
-    bcrypt: '>=3.2'
-    pynacl: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.5.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4e6bea7eee94bb9d8a599385215719f9
-    sha256: 1499e558d31536707fdd7d0b569dbe29ae6e3aa8f2fdce9ea6f3df3ce4c1aaf1
-  category: dev
-  optional: true
 - name: parso
   version: 0.8.4
   manager: conda
@@ -13607,45 +11317,6 @@ package:
   hash:
     md5: 617f15191456cc6a13db418a275435e5
     sha256: 9f64009cdf5b8e529995f18e03665b03f5d07c0b17445b8badef45bde76249ee
-  category: dev
-  optional: true
-- name: pbr
-  version: 6.1.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    pip: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pbr-6.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 80ef57db70bcc25593f8de5fc4fd8b14
-    sha256: 2b8ef8612692a02b9ff556c749c8c0d3958ee364c678422d9f232293a208e6a3
-  category: dev
-  optional: true
-- name: pbr
-  version: 6.1.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    pip: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pbr-6.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 80ef57db70bcc25593f8de5fc4fd8b14
-    sha256: 2b8ef8612692a02b9ff556c749c8c0d3958ee364c678422d9f232293a208e6a3
-  category: dev
-  optional: true
-- name: pbr
-  version: 6.1.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    pip: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pbr-6.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 80ef57db70bcc25593f8de5fc4fd8b14
-    sha256: 2b8ef8612692a02b9ff556c749c8c0d3958ee364c678422d9f232293a208e6a3
   category: dev
   optional: true
 - name: pcre2
@@ -13878,46 +11549,6 @@ package:
     sha256: 094fa4c825f8b9e8403e0c0b569c3d50892325acdac1010ff43cc3ac65bf62cd
   category: main
   optional: false
-- name: pixman
-  version: 0.44.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.44.2-h29eaf8c_0.conda
-  hash:
-    md5: 5e2a7acfa2c24188af39e7944e1b3604
-    sha256: 747c58db800d5583fee78e76240bf89cbaeedf7ab1ef339c2990602332b9c4be
-  category: dev
-  optional: true
-- name: pixman
-  version: 0.44.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.44.2-h1fd1274_0.conda
-  hash:
-    md5: 9d3ed4c1a6e21051bf4ce53851acdc96
-    sha256: 7e5a9823e7e759355b954037f97d4aa53c26db1d73408571e749f8375b363743
-  category: dev
-  optional: true
-- name: pixman
-  version: 0.44.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.44.2-h2f9eb0b_0.conda
-  hash:
-    md5: fa8e429fdb9e5b757281f69b8cc4330b
-    sha256: 28855d4cb2d9fc9a6bd9196dadbaecd6868ec706394cec2f88824a61ba4b1bc0
-  category: dev
-  optional: true
 - name: pkginfo
   version: 1.12.0
   manager: conda
@@ -14063,7 +11694,7 @@ package:
   category: main
   optional: false
 - name: pre-commit
-  version: 3.8.0
+  version: 4.1.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -14073,14 +11704,14 @@ package:
     python: '>=3.9'
     pyyaml: '>=5.1'
     virtualenv: '>=20.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.1.0-pyha770c72_0.conda
   hash:
-    md5: 004cff3a7f6fafb0a041fb575de85185
-    sha256: c2b964c86b2cd00e494093d751b1f8697b3c4bf924ff70648387af161444cc82
+    md5: 5353f5eb201a9415b12385e35ed1148d
+    sha256: b260b4b47956b654232f698be1b757935268830a808040aff2006d08953e9e32
   category: dev
   optional: true
 - name: pre-commit
-  version: 3.8.0
+  version: 4.1.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -14090,14 +11721,14 @@ package:
     nodeenv: '>=0.11.1'
     cfgv: '>=2.0.0'
     virtualenv: '>=20.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.1.0-pyha770c72_0.conda
   hash:
-    md5: 004cff3a7f6fafb0a041fb575de85185
-    sha256: c2b964c86b2cd00e494093d751b1f8697b3c4bf924ff70648387af161444cc82
+    md5: 5353f5eb201a9415b12385e35ed1148d
+    sha256: b260b4b47956b654232f698be1b757935268830a808040aff2006d08953e9e32
   category: dev
   optional: true
 - name: pre-commit
-  version: 3.8.0
+  version: 4.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -14107,10 +11738,10 @@ package:
     nodeenv: '>=0.11.1'
     cfgv: '>=2.0.0'
     virtualenv: '>=20.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.1.0-pyha770c72_0.conda
   hash:
-    md5: 004cff3a7f6fafb0a041fb575de85185
-    sha256: c2b964c86b2cd00e494093d751b1f8697b3c4bf924ff70648387af161444cc82
+    md5: 5353f5eb201a9415b12385e35ed1148d
+    sha256: b260b4b47956b654232f698be1b757935268830a808040aff2006d08953e9e32
   category: dev
   optional: true
 - name: proj
@@ -14165,6 +11796,55 @@ package:
     sha256: c6289d6f1a13f28ff3754ac0cb2553f7e7bc4a3102291115f62a04995d0421eb
   category: main
   optional: false
+- name: prometheus-cpp
+  version: 1.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
+  hash:
+    md5: a83f6a2fdc079e643237887a37460668
+    sha256: 013669433eb447548f21c3c6b16b2ed64356f726b5f77c1b39d5ba17a8a4b8bc
+  category: main
+  optional: false
+- name: prometheus-cpp
+  version: 1.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.13'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=18'
+    libzlib: '>=1.3.1,<2.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/prometheus-cpp-1.3.0-h7802330_0.conda
+  hash:
+    md5: f36107fa2557e63421a46676371c4226
+    sha256: af754a477ee2681cb7d5d77c621bd590d25fe1caf16741841fc2d176815fc7de
+  category: main
+  optional: false
+- name: prometheus-cpp
+  version: 1.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcurl: '>=8.10.1,<9.0a0'
+    libcxx: '>=18'
+    libzlib: '>=1.3.1,<2.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
+  hash:
+    md5: 7172339b49c94275ba42fec3eaeda34f
+    sha256: 851a77ae1a8e90db9b9f3c4466abea7afb52713c3d98ceb0d37ba6ff27df2eff
+  category: main
+  optional: false
 - name: prompt-toolkit
   version: 3.0.50
   manager: conda
@@ -14217,8 +11897,8 @@ package:
   hash:
     md5: 349635694b4df27336bc15a49e9220e9
     sha256: 6d5ff6490c53e14591b70924711fe7bd70eb7fbeeeb1cbd9ed2f6d794ec8c4eb
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: propcache
   version: 0.2.1
   manager: conda
@@ -14231,8 +11911,8 @@ package:
   hash:
     md5: e712bcabf1db361f1350b638be66caca
     sha256: 04cd2c807af8ae2921e54c372620bb6d3391a7ad59c0aa566e4d21be0e558ae1
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: propcache
   version: 0.2.1
   manager: conda
@@ -14245,8 +11925,8 @@ package:
   hash:
     md5: 83678928c58c9ae76778a435b6c7a94a
     sha256: 96145760baad111d7ae4213ea8f8cc035cf33b001f5ff37d92268e4d28b0941d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: psutil
   version: 6.1.1
   manager: conda
@@ -14400,120 +12080,111 @@ package:
   category: dev
   optional: true
 - name: pyarrow
-  version: 14.0.2
+  version: 19.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libarrow-acero: 19.0.0.*
+    libarrow-dataset: 19.0.0.*
+    libarrow-substrait: 19.0.0.*
+    libparquet: 19.0.0.*
+    pyarrow-core: 19.0.0
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-19.0.0-py312h7900ff3_0.conda
+  hash:
+    md5: 14f86e63b5c214dd9fb34e5472d4bafc
+    sha256: 7d98e626ec65b882341482ad15ecb7a670ee41dbaf375aa660ba8b7d0a940504
+  category: main
+  optional: false
+- name: pyarrow
+  version: 19.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libarrow-acero: 19.0.0.*
+    libarrow-dataset: 19.0.0.*
+    libarrow-substrait: 19.0.0.*
+    libparquet: 19.0.0.*
+    pyarrow-core: 19.0.0
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-19.0.0-py312hb401068_0.conda
+  hash:
+    md5: 46269f7788706c13825bceb5caa445af
+    sha256: bc6b0407f671cc4cac5534404e43e6b566c51e934f7edc232c2dcefa86c5cefd
+  category: main
+  optional: false
+- name: pyarrow
+  version: 19.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libarrow-acero: 19.0.0.*
+    libarrow-dataset: 19.0.0.*
+    libarrow-substrait: 19.0.0.*
+    libparquet: 19.0.0.*
+    pyarrow-core: 19.0.0
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-19.0.0-py312h1f38498_0.conda
+  hash:
+    md5: bd5e025292ff1127aa1534b59e55c4d0
+    sha256: 9d693901833c2ff4e5d67e1f2f6df50f699e1cec2f580c26d42299654830855a
+  category: main
+  optional: false
+- name: pyarrow-core
+  version: 19.0.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libarrow: 14.0.2
-    libarrow-acero: 14.0.2
-    libarrow-dataset: 14.0.2
-    libarrow-flight: 14.0.2
-    libarrow-flight-sql: 14.0.2
-    libarrow-gandiva: 14.0.2
-    libarrow-substrait: 14.0.2
+    libarrow: 19.0.0.*
     libgcc: '>=13'
-    libparquet: 14.0.2
     libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.2-py312h259ed4e_52_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-19.0.0-py312h01725c0_0_cpu.conda
   hash:
-    md5: b12befeffdaa069676e2fd94d10105a2
-    sha256: e769886476363ee9533e0b9fe49e77b933058bf08006131a3bb59d12e87a80c7
+    md5: 7ab1143b9ac1af5cc4a630706f643627
+    sha256: 81178d0de0ac851a0a78e09c81ad92274cf770a38b28acdf53a0cfb2122d15aa
   category: main
   optional: false
-- name: pyarrow
-  version: 14.0.2
+- name: pyarrow-core
+  version: 19.0.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libarrow: 14.0.2
-    libarrow-acero: 14.0.2
-    libarrow-dataset: 14.0.2
-    libarrow-flight: 14.0.2
-    libarrow-flight-sql: 14.0.2
-    libarrow-gandiva: 14.0.2
-    libarrow-substrait: 14.0.2
-    libcxx: '>=17'
-    libparquet: 14.0.2
+    libarrow: 19.0.0.*
+    libcxx: '>=18'
     libzlib: '>=1.3.1,<2.0a0'
-    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.2-py312h91a4995_52_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-19.0.0-py312h5157fe3_0_cpu.conda
   hash:
-    md5: afb29320cd7556b6302e6050b356ee1e
-    sha256: 7b4c46f797568a707ec8ea1b9f61f3ae32a878103d9db445f6448c9283e3a32f
+    md5: 9f4b2523494990ef7e999df1280b15f5
+    sha256: 3854ddf565c8677536e090503df15b87d767df04dc994ee5f5efee69bf9cef64
   category: main
   optional: false
-- name: pyarrow
-  version: 14.0.2
+- name: pyarrow-core
+  version: 19.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libarrow: 14.0.2
-    libarrow-acero: 14.0.2
-    libarrow-dataset: 14.0.2
-    libarrow-flight: 14.0.2
-    libarrow-flight-sql: 14.0.2
-    libarrow-gandiva: 14.0.2
-    libarrow-substrait: 14.0.2
-    libcxx: '>=17'
-    libparquet: 14.0.2
+    libarrow: 19.0.0.*
+    libcxx: '>=18'
     libzlib: '>=1.3.1,<2.0a0'
-    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.2-py312h6acbf39_52_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-19.0.0-py312hc40f475_0_cpu.conda
   hash:
-    md5: fe61482d72c9bbe0785236d51a60d4b9
-    sha256: e421fd42755a1168e55c341996d8f700d79c43db2f360f622a0564d9bd6f236b
+    md5: df502157843a7b1d90af04803767be15
+    sha256: 6303fe1c3e6d36273b72f0eeb3f19897d2376d57fe8c757f55dcbfbaa5cd6840
   category: main
   optional: false
-- name: pyasn1
-  version: 0.6.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda
-  hash:
-    md5: 09bb17ed307ad6ab2fd78d32372fdd4e
-    sha256: d06051df66e9ab753683d7423fcef873d78bb0c33bd112c3d5be66d529eddf06
-  category: dev
-  optional: true
-- name: pyasn1
-  version: 0.6.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda
-  hash:
-    md5: 09bb17ed307ad6ab2fd78d32372fdd4e
-    sha256: d06051df66e9ab753683d7423fcef873d78bb0c33bd112c3d5be66d529eddf06
-  category: dev
-  optional: true
-- name: pyasn1
-  version: 0.6.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda
-  hash:
-    md5: 09bb17ed307ad6ab2fd78d32372fdd4e
-    sha256: d06051df66e9ab753683d7423fcef873d78bb0c33bd112c3d5be66d529eddf06
-  category: dev
-  optional: true
 - name: pybind11-abi
   version: '4'
   manager: conda
@@ -14756,51 +12427,6 @@ package:
     sha256: cfa7201f890d5d08ce29ff70e65a96787d5793a1718776733666b44bbd4a1205
   category: main
   optional: false
-- name: pydot
-  version: 3.0.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    graphviz: '>=2.38.0'
-    pyparsing: '>=3.0.9'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydot-3.0.4-py312h7900ff3_0.conda
-  hash:
-    md5: 331fc9a56a16f02592f193c8109e4543
-    sha256: 59227fbb547dc4c5405514fd550ea51f3ea0efc0317108bcab5b7e82973e7aa9
-  category: dev
-  optional: true
-- name: pydot
-  version: 3.0.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    graphviz: '>=2.38.0'
-    pyparsing: '>=3.0.9'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pydot-3.0.4-py312hb401068_0.conda
-  hash:
-    md5: 9132b851f4d0a88e932fdc1b5c5784e9
-    sha256: 8c48772d194c4c33d935511e3506a170c99ef00b8fbdbbb9e6fb83c420f31ad3
-  category: dev
-  optional: true
-- name: pydot
-  version: 3.0.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    graphviz: '>=2.38.0'
-    pyparsing: '>=3.0.9'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydot-3.0.4-py312h81bd7bf_0.conda
-  hash:
-    md5: 0ac88e19c9d768bfd792188b2b277a91
-    sha256: d8175dcd1cd1645eac285324daa0ceb04485181f25fc8b05e5a4f1f0c77dbbca
-  category: dev
-  optional: true
 - name: pyflakes
   version: 3.2.0
   manager: conda
@@ -14909,58 +12535,6 @@ package:
     sha256: 50bd91767686bfe769e50a5a1b883e238d944a6163fea43e7c0beaac54ca674f
   category: main
   optional: false
-- name: pynacl
-  version: 1.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cffi: '>=1.4.1'
-    libgcc: '>=13'
-    libsodium: '>=1.0.20,<1.0.21.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.5.0-py312h66e93f0_4.conda
-  hash:
-    md5: c47ede9450b5347c1933ccb552fca707
-    sha256: 9b3849d530055c1dff2a068628a4570f55d02156d78ec00b8efbc37af396aee9
-  category: dev
-  optional: true
-- name: pynacl
-  version: 1.5.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    cffi: '>=1.4.1'
-    libsodium: '>=1.0.20,<1.0.21.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/pynacl-1.5.0-py312hb553811_4.conda
-  hash:
-    md5: 88be5bbe28b39b591eb61520d12658d0
-    sha256: 32d959bd5b7e403fd38abc1137000d1106502cb90e6ef58c71e0301ac15b6803
-  category: dev
-  optional: true
-- name: pynacl
-  version: 1.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    cffi: '>=1.4.1'
-    libsodium: '>=1.0.20,<1.0.21.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pynacl-1.5.0-py312h024a12e_4.conda
-  hash:
-    md5: 7febc246a29d77449bdb3e7a18382788
-    sha256: 1cadc99e88105400acb41c4297d43026bf3aaaa386c72a4e2a7512c2ea70f4be
-  category: dev
-  optional: true
 - name: pynvml
   version: 11.4.1
   manager: conda
@@ -15177,7 +12751,7 @@ package:
   category: main
   optional: false
 - name: pytest
-  version: 7.4.4
+  version: 8.3.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -15185,49 +12759,49 @@ package:
     exceptiongroup: '>=1.0.0rc8'
     iniconfig: ''
     packaging: ''
-    pluggy: '>=0.12,<2.0'
-    python: '>=3.7'
-    tomli: '>=1.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.4-pyhd8ed1ab_0.conda
+    pluggy: <2,>=1.5
+    python: '>=3.9'
+    tomli: '>=1'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
   hash:
-    md5: a9d145de8c5f064b5fa68fb34725d9f4
-    sha256: 8979721b7f86b183d21103f3ec2734783847d317c1b754f462f407efc7c60886
+    md5: 799ed216dc6af62520f32aa39bc1c2bb
+    sha256: 75245ca9d0cbd6d38bb45ec02430189a9d4c21c055c5259739d738a2298d61b3
   category: dev
   optional: true
 - name: pytest
-  version: 7.4.4
+  version: 8.3.4
   manager: conda
   platform: osx-64
   dependencies:
     packaging: ''
     colorama: ''
     iniconfig: ''
-    python: '>=3.7'
+    python: '>=3.9'
     exceptiongroup: '>=1.0.0rc8'
-    tomli: '>=1.0.0'
-    pluggy: '>=0.12,<2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.4-pyhd8ed1ab_0.conda
+    tomli: '>=1'
+    pluggy: <2,>=1.5
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
   hash:
-    md5: a9d145de8c5f064b5fa68fb34725d9f4
-    sha256: 8979721b7f86b183d21103f3ec2734783847d317c1b754f462f407efc7c60886
+    md5: 799ed216dc6af62520f32aa39bc1c2bb
+    sha256: 75245ca9d0cbd6d38bb45ec02430189a9d4c21c055c5259739d738a2298d61b3
   category: dev
   optional: true
 - name: pytest
-  version: 7.4.4
+  version: 8.3.4
   manager: conda
   platform: osx-arm64
   dependencies:
     packaging: ''
     colorama: ''
     iniconfig: ''
-    python: '>=3.7'
+    python: '>=3.9'
     exceptiongroup: '>=1.0.0rc8'
-    tomli: '>=1.0.0'
-    pluggy: '>=0.12,<2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.4-pyhd8ed1ab_0.conda
+    tomli: '>=1'
+    pluggy: <2,>=1.5
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
   hash:
-    md5: a9d145de8c5f064b5fa68fb34725d9f4
-    sha256: 8979721b7f86b183d21103f3ec2734783847d317c1b754f462f407efc7c60886
+    md5: 799ed216dc6af62520f32aa39bc1c2bb
+    sha256: 75245ca9d0cbd6d38bb45ec02430189a9d4c21c055c5259739d738a2298d61b3
   category: dev
   optional: true
 - name: pytest-recording
@@ -15388,54 +12962,6 @@ package:
     sha256: a50052536f1ef8516ed11a844f9413661829aa083304dc624c5925298d078d79
   category: main
   optional: false
-- name: python-jose
-  version: 3.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cryptography: ''
-    ecdsa: '!=0.15'
-    pyasn1: ''
-    python: '>=3.9'
-    rsa: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/python-jose-3.3.0-pyhff2d567_2.conda
-  hash:
-    md5: 45fd78d27f93da0514b7ff45bc037c86
-    sha256: c40bf694bae8c8e5fcdbfa1c43229080783ed96118204e1b59315f31862bda51
-  category: dev
-  optional: true
-- name: python-jose
-  version: 3.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    cryptography: ''
-    pyasn1: ''
-    rsa: ''
-    python: '>=3.9'
-    ecdsa: '!=0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-jose-3.3.0-pyhff2d567_2.conda
-  hash:
-    md5: 45fd78d27f93da0514b7ff45bc037c86
-    sha256: c40bf694bae8c8e5fcdbfa1c43229080783ed96118204e1b59315f31862bda51
-  category: dev
-  optional: true
-- name: python-jose
-  version: 3.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    cryptography: ''
-    pyasn1: ''
-    rsa: ''
-    python: '>=3.9'
-    ecdsa: '!=0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-jose-3.3.0-pyhff2d567_2.conda
-  hash:
-    md5: 45fd78d27f93da0514b7ff45bc037c86
-    sha256: c40bf694bae8c8e5fcdbfa1c43229080783ed96118204e1b59315f31862bda51
-  category: dev
-  optional: true
 - name: python-tzdata
   version: '2025.1'
   manager: conda
@@ -15541,45 +13067,6 @@ package:
     sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
   category: main
   optional: false
-- name: pywin32-on-windows
-  version: 0.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh1179c8e_3.tar.bz2
-  hash:
-    md5: 2807a0becd1d986fe1ef9b7f8135f215
-    sha256: 6502696aaef571913b22a808b15c185bd8ea4aabb952685deb29e6a6765761cb
-  category: dev
-  optional: true
-- name: pywin32-on-windows
-  version: 0.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __unix: ''
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh1179c8e_3.tar.bz2
-  hash:
-    md5: 2807a0becd1d986fe1ef9b7f8135f215
-    sha256: 6502696aaef571913b22a808b15c185bd8ea4aabb952685deb29e6a6765761cb
-  category: dev
-  optional: true
-- name: pywin32-on-windows
-  version: 0.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: ''
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh1179c8e_3.tar.bz2
-  hash:
-    md5: 2807a0becd1d986fe1ef9b7f8135f215
-    sha256: 6502696aaef571913b22a808b15c185bd8ea4aabb952685deb29e6a6765761cb
-  category: dev
-  optional: true
 - name: pyyaml
   version: 6.0.2
   manager: conda
@@ -15831,23 +13318,6 @@ package:
     sha256: be6174970193cb4d0ffa7d731a93a4c9542881dbc7ab24e74b460ef312161169
   category: main
   optional: false
-- name: rdma-core
-  version: '55.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libnl: '>=3.11.0,<4.0a0'
-    libstdcxx: '>=13'
-    libsystemd0: '>=256.9'
-    libudev1: '>=256.9'
-  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-55.0-h5888daf_0.conda
-  hash:
-    md5: fd94951ea305bdfe6fb3939db3fb7ce2
-    sha256: 3715a51f1ea6e3765f19b6db90a7edb77a3b5aa201a4f09cbd51a678e8609a88
-  category: main
-  optional: false
 - name: re2
   version: 2024.07.02
   manager: conda
@@ -15964,49 +13434,6 @@ package:
   hash:
     md5: 9140f1c09dd5489549c6a33931b943c7
     sha256: e20909f474a6cece176dfc0dc1addac265deb5fa92ea90e975fbca48085b20c3
-  category: dev
-  optional: true
-- name: regex
-  version: 2024.11.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/regex-2024.11.6-py312h66e93f0_0.conda
-  hash:
-    md5: 647770db979b43f9c9ca25dcfa7dc4e4
-    sha256: fcb5687d3ec5fff580b64b8fb649d9d65c999a91a5c3108a313ecdd2de99f06b
-  category: dev
-  optional: true
-- name: regex
-  version: 2024.11.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/regex-2024.11.6-py312h01d7ebd_0.conda
-  hash:
-    md5: 05befb3ed0af9933089d2a1d495482ff
-    sha256: 315237ccf38ce31f97eff2efecbea22aaed940803933ae234f1e6cb815237128
-  category: dev
-  optional: true
-- name: regex
-  version: 2024.11.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2024.11.6-py312hea69d52_0.conda
-  hash:
-    md5: e73cda1f18846b608284bd784f061eac
-    sha256: dcdec32f2c7dd37986baa692bedf9db126ad34e92e5e9b64f707cba3d04d2525
   category: dev
   optional: true
 - name: reproc
@@ -16354,45 +13781,6 @@ package:
     sha256: 0a8b50bf22400004a706ba160d7cb31f82b8d8c328a59aec73a9e0d3372d1964
   category: dev
   optional: true
-- name: rsa
-  version: '4.9'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    pyasn1: '>=0.1.3'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_1.conda
-  hash:
-    md5: 91def14612d11100329d53a75993a4d5
-    sha256: 210ff0e3aaa8ce8e9d45a5fd578ce7b2d5bcd7d3054dc779c3a159b8f72104d6
-  category: dev
-  optional: true
-- name: rsa
-  version: '4.9'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-    pyasn1: '>=0.1.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_1.conda
-  hash:
-    md5: 91def14612d11100329d53a75993a4d5
-    sha256: 210ff0e3aaa8ce8e9d45a5fd578ce7b2d5bcd7d3054dc779c3a159b8f72104d6
-  category: dev
-  optional: true
-- name: rsa
-  version: '4.9'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-    pyasn1: '>=0.1.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_1.conda
-  hash:
-    md5: 91def14612d11100329d53a75993a4d5
-    sha256: 210ff0e3aaa8ce8e9d45a5fd578ce7b2d5bcd7d3054dc779c3a159b8f72104d6
-  category: dev
-  optional: true
 - name: ruamel.yaml
   version: 0.18.10
   manager: conda
@@ -16483,62 +13871,59 @@ package:
   category: main
   optional: false
 - name: s2n
-  version: 1.5.7
+  version: 1.5.11
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.7-hd3e8b83_0.conda
+    openssl: '>=3.4.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.11-h072c03f_0.conda
   hash:
-    md5: b0de6ca344b9255f4adb98e419e130ad
-    sha256: faf555b03adea3b5f9affb2307c8324deab88d0be7dd3ca14704dd018905d0d6
+    md5: 5e8060d52f676a40edef0006a75c718f
+    sha256: cfdd98c8f9a1e5b6f9abce5dac6d590cc9fe541a08466c9e4a26f90e00b569e3
   category: main
   optional: false
 - name: s3fs
-  version: 2024.12.0
+  version: 0.4.2
   manager: conda
   platform: linux-64
   dependencies:
-    aiobotocore: '>=2.5.4,<3.0.0'
-    aiohttp: ''
-    fsspec: 2024.12.0
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.12.0-pyhd8ed1ab_0.conda
+    boto3: ''
+    fsspec: '>=0.6.0'
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
   hash:
-    md5: d91e140ebbb494372695d7b5ac829c09
-    sha256: e231ad3a9172af66c3ff984e7dd06e9fde4c898f2930f2c8043e5d7b641485a2
+    md5: ead328eb12f01d88706126ba061e7a69
+    sha256: 7a4cb574ff7edf773e5e4c396733dcb08ffcfd6e4f8b27e5b84b35fd4666ef5b
   category: main
   optional: false
 - name: s3fs
-  version: 2024.12.0
+  version: 0.4.2
   manager: conda
   platform: osx-64
   dependencies:
-    aiohttp: ''
-    python: '>=3.9'
-    aiobotocore: '>=2.5.4,<3.0.0'
-    fsspec: 2024.12.0
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.12.0-pyhd8ed1ab_0.conda
+    boto3: ''
+    python: '>=3.5'
+    fsspec: '>=0.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
   hash:
-    md5: d91e140ebbb494372695d7b5ac829c09
-    sha256: e231ad3a9172af66c3ff984e7dd06e9fde4c898f2930f2c8043e5d7b641485a2
+    md5: ead328eb12f01d88706126ba061e7a69
+    sha256: 7a4cb574ff7edf773e5e4c396733dcb08ffcfd6e4f8b27e5b84b35fd4666ef5b
   category: main
   optional: false
 - name: s3fs
-  version: 2024.12.0
+  version: 0.4.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    aiohttp: ''
-    python: '>=3.9'
-    aiobotocore: '>=2.5.4,<3.0.0'
-    fsspec: 2024.12.0
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.12.0-pyhd8ed1ab_0.conda
+    boto3: ''
+    python: '>=3.5'
+    fsspec: '>=0.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
   hash:
-    md5: d91e140ebbb494372695d7b5ac829c09
-    sha256: e231ad3a9172af66c3ff984e7dd06e9fde4c898f2930f2c8043e5d7b641485a2
+    md5: ead328eb12f01d88706126ba061e7a69
+    sha256: 7a4cb574ff7edf773e5e4c396733dcb08ffcfd6e4f8b27e5b84b35fd4666ef5b
   category: main
   optional: false
 - name: s3transfer
@@ -16580,48 +13965,6 @@ package:
     sha256: fdc3c7853ceca4979f83a8943cab79c89642365cea46113243555bbe98ae13cb
   category: main
   optional: false
-- name: sarif-om
-  version: 1.0.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    attrs: ''
-    pbr: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/sarif-om-1.0.4-pyhd8ed1ab_1.conda
-  hash:
-    md5: 6c4dcc5be71a1ff181eab2031c5d2a9d
-    sha256: 6b959a918f2f33c9e66e0cd88db722ffedcbb94f9be44329dbbb6a439ba658c6
-  category: dev
-  optional: true
-- name: sarif-om
-  version: 1.0.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    attrs: ''
-    pbr: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/sarif-om-1.0.4-pyhd8ed1ab_1.conda
-  hash:
-    md5: 6c4dcc5be71a1ff181eab2031c5d2a9d
-    sha256: 6b959a918f2f33c9e66e0cd88db722ffedcbb94f9be44329dbbb6a439ba658c6
-  category: dev
-  optional: true
-- name: sarif-om
-  version: 1.0.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    attrs: ''
-    pbr: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/sarif-om-1.0.4-pyhd8ed1ab_1.conda
-  hash:
-    md5: 6c4dcc5be71a1ff181eab2031c5d2a9d
-    sha256: 6b959a918f2f33c9e66e0cd88db722ffedcbb94f9be44329dbbb6a439ba658c6
-  category: dev
-  optional: true
 - name: scalene
   version: 1.5.41
   manager: conda
@@ -17268,48 +14611,6 @@ package:
     sha256: 6c1609abe16ed39dd099eb7e32e2f3228105ab81bdd8da65700d46ee0984013e
   category: main
   optional: false
-- name: sshpubkeys
-  version: 3.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cryptography: '>=2.1.4'
-    ecdsa: '>=0.13'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/sshpubkeys-3.3.1-pyhd8ed1ab_1.conda
-  hash:
-    md5: cef6c96c700c6312bd63186e4c0504d4
-    sha256: 951ab5d6174f511ad0480efe260eefb8ba42fd22d203c42d7929e40f8e1c54dd
-  category: dev
-  optional: true
-- name: sshpubkeys
-  version: 3.3.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-    cryptography: '>=2.1.4'
-    ecdsa: '>=0.13'
-  url: https://conda.anaconda.org/conda-forge/noarch/sshpubkeys-3.3.1-pyhd8ed1ab_1.conda
-  hash:
-    md5: cef6c96c700c6312bd63186e4c0504d4
-    sha256: 951ab5d6174f511ad0480efe260eefb8ba42fd22d203c42d7929e40f8e1c54dd
-  category: dev
-  optional: true
-- name: sshpubkeys
-  version: 3.3.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-    cryptography: '>=2.1.4'
-    ecdsa: '>=0.13'
-  url: https://conda.anaconda.org/conda-forge/noarch/sshpubkeys-3.3.1-pyhd8ed1ab_1.conda
-  hash:
-    md5: cef6c96c700c6312bd63186e4c0504d4
-    sha256: 951ab5d6174f511ad0480efe260eefb8ba42fd22d203c42d7929e40f8e1c54dd
-  category: dev
-  optional: true
 - name: stack_data
   version: 0.6.3
   manager: conda
@@ -17395,54 +14696,6 @@ package:
     sha256: ab876ed8bdd20e22a868dcb8d03e9ce9bbba7762d7e652d49bfff6af768a5b8f
   category: main
   optional: false
-- name: sympy
-  version: 1.13.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-    cpython: ''
-    gmpy2: '>=2.0.8'
-    mpmath: '>=0.19'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.13.3-pyh2585a3b_105.conda
-  hash:
-    md5: 254cd5083ffa04d96e3173397a3d30f4
-    sha256: 929d939c5a8bcdc10a17501890918da68cf14a5883b36fddf77b8f0fbf040be2
-  category: dev
-  optional: true
-- name: sympy
-  version: 1.13.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __unix: ''
-    cpython: ''
-    python: '>=3.9'
-    mpmath: '>=0.19'
-    gmpy2: '>=2.0.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.13.3-pyh2585a3b_105.conda
-  hash:
-    md5: 254cd5083ffa04d96e3173397a3d30f4
-    sha256: 929d939c5a8bcdc10a17501890918da68cf14a5883b36fddf77b8f0fbf040be2
-  category: dev
-  optional: true
-- name: sympy
-  version: 1.13.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: ''
-    cpython: ''
-    python: '>=3.9'
-    mpmath: '>=0.19'
-    gmpy2: '>=2.0.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.13.3-pyh2585a3b_105.conda
-  hash:
-    md5: 254cd5083ffa04d96e3173397a3d30f4
-    sha256: 929d939c5a8bcdc10a17501890918da68cf14a5883b36fddf77b8f0fbf040be2
-  category: dev
-  optional: true
 - name: threadpoolctl
   version: 3.5.0
   manager: conda
@@ -18231,24 +15484,6 @@ package:
     sha256: c4b1ae8a2931fe9b274c44af29c5475a85b37693999f8c792dad0f8c6734b1de
   category: main
   optional: false
-- name: ucx
-  version: 1.17.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-    libgcc: ''
-    libgcc-ng: '>=12'
-    libstdcxx: ''
-    libstdcxx-ng: '>=12'
-    rdma-core: '>=55.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.17.0-h53fb5aa_4.conda
-  hash:
-    md5: ba6c7ec20d51a27f60699f2125f00fef
-    sha256: 8041718faf0625dfdd943e162e1eb3f30cf2687b01489b1f94c895acb0c8b204
-  category: main
-  optional: false
 - name: ukkonen
   version: 1.0.1
   manager: conda
@@ -18423,51 +15658,48 @@ package:
   category: main
   optional: false
 - name: vcrpy
-  version: 6.0.2
+  version: 7.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
+    python: '>=3.10'
     pyyaml: ''
-    urllib3: <2
     wrapt: ''
     yarl: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/vcrpy-6.0.2-pyhd8ed1ab_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/vcrpy-7.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: fb56617ac2deabbb6be5ec9169c913a4
-    sha256: d35e14231bcb56e7f0acb27b401c27f9e52201b85ae2cc3d17178d160174e275
+    md5: aa22e07764d199bc239fe61c994c06d6
+    sha256: 6128f3416e18f1ea9245c63bba63ac47ea24f823f97770707a36ed11f8435701
   category: dev
   optional: true
 - name: vcrpy
-  version: 6.0.2
+  version: 7.0.0
   manager: conda
   platform: osx-64
   dependencies:
     pyyaml: ''
     wrapt: ''
     yarl: ''
-    python: '>=3.9'
-    urllib3: <2
-  url: https://conda.anaconda.org/conda-forge/noarch/vcrpy-6.0.2-pyhd8ed1ab_2.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/vcrpy-7.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: fb56617ac2deabbb6be5ec9169c913a4
-    sha256: d35e14231bcb56e7f0acb27b401c27f9e52201b85ae2cc3d17178d160174e275
+    md5: aa22e07764d199bc239fe61c994c06d6
+    sha256: 6128f3416e18f1ea9245c63bba63ac47ea24f823f97770707a36ed11f8435701
   category: dev
   optional: true
 - name: vcrpy
-  version: 6.0.2
+  version: 7.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     pyyaml: ''
     wrapt: ''
     yarl: ''
-    python: '>=3.9'
-    urllib3: <2
-  url: https://conda.anaconda.org/conda-forge/noarch/vcrpy-6.0.2-pyhd8ed1ab_2.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/vcrpy-7.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: fb56617ac2deabbb6be5ec9169c913a4
-    sha256: d35e14231bcb56e7f0acb27b401c27f9e52201b85ae2cc3d17178d160174e275
+    md5: aa22e07764d199bc239fe61c994c06d6
+    sha256: 6128f3416e18f1ea9245c63bba63ac47ea24f823f97770707a36ed11f8435701
   category: dev
   optional: true
 - name: virtualenv
@@ -18515,22 +15747,6 @@ package:
     sha256: f09a9f2034669762ae875858253d472588f03689843e5f0b8ddc5cc48a1d0e50
   category: main
   optional: false
-- name: wayland
-  version: 1.23.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libexpat: '>=2.6.2,<3.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libgcc-ng: '>=13'
-    libstdcxx-ng: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
-  hash:
-    md5: 0a732427643ae5e0486a727927791da1
-    sha256: 0884b2023a32d2620192cf2e2fc6784b8d1e31cf9f137e49e00802d4daf7d1c1
-  category: dev
-  optional: true
 - name: wcwidth
   version: 0.2.13
   manager: conda
@@ -18603,42 +15819,6 @@ package:
     sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
   category: main
   optional: false
-- name: websocket-client
-  version: 1.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 84f8f77f0a9c6ef401ee96611745da8f
-    sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
-  category: dev
-  optional: true
-- name: websocket-client
-  version: 1.8.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 84f8f77f0a9c6ef401ee96611745da8f
-    sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
-  category: dev
-  optional: true
-- name: websocket-client
-  version: 1.8.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 84f8f77f0a9c6ef401ee96611745da8f
-    sha256: 1dd84764424ffc82030c19ad70607e6f9e3b9cb8e633970766d697185652053e
-  category: dev
-  optional: true
 - name: werkzeug
   version: 3.1.3
   manager: conda
@@ -18727,8 +15907,8 @@ package:
   hash:
     md5: 669e63af87710f8d52fdec9d4d63b404
     sha256: ed3a1700ecc5d38c7e7dc7d2802df1bc1da6ba3d6f6017448b8ded0affb4ae00
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: wrapt
   version: 1.17.2
   manager: conda
@@ -18741,8 +15921,8 @@ package:
   hash:
     md5: 6a860c98c6aea375eea574693a98d409
     sha256: 476ea998d7279d9f71ff7b2e30408e69e5a0b921090c07a124f3f52ff7d3424b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: wrapt
   version: 1.17.2
   manager: conda
@@ -18755,8 +15935,8 @@ package:
   hash:
     md5: e49608c832fcf438f70cbcae09c3adc5
     sha256: 6a3e68b57de29802e8703d1791dcacb7613bfdc17bbb087c6b2ea2796e6893ef
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: x265
   version: '3.5'
   manager: conda
@@ -18838,20 +16018,6 @@ package:
     sha256: 863a7c2a991a4399d362d42c285ebc20748a4ea417647ebd3a171e2220c7457d
   category: main
   optional: false
-- name: xkeyboard-config
-  version: '2.43'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
-  hash:
-    md5: f725c7425d6d7c15e31f3b99a88ea02f
-    sha256: 0d89b5873515a1f05d311f37ea4e087bbccc0418afa38f2f6189e97280db3179
-  category: dev
-  optional: true
 - name: xmltodict
   version: 0.14.2
   manager: conda
@@ -18886,48 +16052,6 @@ package:
   hash:
     md5: 96ef17b8734b174d35346da0762f0137
     sha256: 7f6f4551da59ec3612783905c67ce825f2f067481bf79cb161ab2665ae2068a1
-  category: dev
-  optional: true
-- name: xorg-libice
-  version: 1.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
-  hash:
-    md5: fb901ff28063514abb6046c9ec2c4a45
-    sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
-  category: dev
-  optional: true
-- name: xorg-libsm
-  version: 1.2.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libuuid: '>=2.38.1,<3.0a0'
-    xorg-libice: '>=1.1.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.5-he73a12e_0.conda
-  hash:
-    md5: 4c3e9fab69804ec6077697922d70c6e2
-    sha256: 760f43df6c2ce8cbbbcb8f2f3b7fc0f306716c011e28d1d340f3dfa8ccf29185
-  category: dev
-  optional: true
-- name: xorg-libx11
-  version: 1.8.11
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libxcb: '>=1.17.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.11-h4f16b4b_0.conda
-  hash:
-    md5: b6eb6d0cb323179af168df8fe16fb0a1
-    sha256: a0e7fca9e341dc2455b20cd320fc1655e011f7f5f28367ecf8617cccd4bb2821
   category: dev
   optional: true
 - name: xorg-libxau
@@ -18967,53 +16091,6 @@ package:
     sha256: f33e6f013fc36ebc200f09ddead83468544cb5c353a3b50499b07b8c34e28a8d
   category: main
   optional: false
-- name: xorg-libxcomposite
-  version: 0.4.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-    xorg-libxfixes: '>=6.0.1,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.6-hb9d3cd8_2.conda
-  hash:
-    md5: d3c295b50f092ab525ffe3c2aa4b7413
-    sha256: 753f73e990c33366a91fd42cc17a3d19bb9444b9ca5ff983605fa9e953baf57f
-  category: dev
-  optional: true
-- name: xorg-libxcursor
-  version: 1.2.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-    xorg-libxfixes: '>=6.0.1,<7.0a0'
-    xorg-libxrender: '>=0.9.11,<0.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
-  hash:
-    md5: 2ccd714aa2242315acaf0a67faea780b
-    sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
-  category: dev
-  optional: true
-- name: xorg-libxdamage
-  version: 1.1.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-    xorg-libxext: '>=1.3.6,<2.0a0'
-    xorg-libxfixes: '>=6.0.1,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
-  hash:
-    md5: b5fcc7172d22516e1f965490e65e33a4
-    sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
-  category: dev
-  optional: true
 - name: xorg-libxdmcp
   version: 1.1.5
   manager: conda
@@ -19051,112 +16128,6 @@ package:
     sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
   category: main
   optional: false
-- name: xorg-libxext
-  version: 1.3.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
-  hash:
-    md5: febbab7d15033c913d53c7a2c102309d
-    sha256: da5dc921c017c05f38a38bd75245017463104457b63a1ce633ed41f214159c14
-  category: dev
-  optional: true
-- name: xorg-libxfixes
-  version: 6.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
-  hash:
-    md5: 4bdb303603e9821baf5fe5fdff1dc8f8
-    sha256: 2fef37e660985794617716eb915865ce157004a4d567ed35ec16514960ae9271
-  category: dev
-  optional: true
-- name: xorg-libxi
-  version: 1.8.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-    xorg-libxext: '>=1.3.6,<2.0a0'
-    xorg-libxfixes: '>=6.0.1,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
-  hash:
-    md5: 17dcc85db3c7886650b8908b183d6876
-    sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
-  category: dev
-  optional: true
-- name: xorg-libxinerama
-  version: 1.1.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-    xorg-libxext: '>=1.3.6,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
-  hash:
-    md5: 5e2eb9bf77394fc2e5918beefec9f9ab
-    sha256: 1b9141c027f9d84a9ee5eb642a0c19457c788182a5a73c5a9083860ac5c20a8c
-  category: dev
-  optional: true
-- name: xorg-libxrandr
-  version: 1.5.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-    xorg-libxext: '>=1.3.6,<2.0a0'
-    xorg-libxrender: '>=0.9.11,<0.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
-  hash:
-    md5: 2de7f99d6581a4a7adbff607b5c278ca
-    sha256: ac0f037e0791a620a69980914a77cb6bb40308e26db11698029d6708f5aa8e0d
-  category: dev
-  optional: true
-- name: xorg-libxrender
-  version: 0.9.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
-  hash:
-    md5: 96d57aba173e878a2089d5638016dc5e
-    sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
-  category: dev
-  optional: true
-- name: xorg-libxtst
-  version: 1.2.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-    xorg-libxext: '>=1.3.6,<2.0a0'
-    xorg-libxi: '>=1.7.10,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
-  hash:
-    md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
-    sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
-  category: dev
-  optional: true
 - name: xyzservices
   version: 2025.1.0
   manager: conda
@@ -19191,135 +16162,6 @@ package:
   hash:
     md5: fdf07e281a9e5e10fc75b2dd444136e9
     sha256: 9978c22319e85026d5a4134944f73bac820c948ca6b6c32af6b6985b5221cd8a
-  category: main
-  optional: false
-- name: xz
-  version: 5.6.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    liblzma: 5.6.4
-    liblzma-devel: 5.6.4
-    xz-gpl-tools: 5.6.4
-    xz-tools: 5.6.4
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.6.4-hbcc6ac9_0.conda
-  hash:
-    md5: bb511c87804cf7220246a3a6efc45c22
-    sha256: 91fc251034fa5199919680aa50299296d89da54b2d066fb6e6a60461c17c0c4a
-  category: main
-  optional: false
-- name: xz
-  version: 5.6.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    liblzma: 5.6.4
-    liblzma-devel: 5.6.4
-    xz-gpl-tools: 5.6.4
-    xz-tools: 5.6.4
-  url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.6.4-h357f2ed_0.conda
-  hash:
-    md5: 702db4b35cffa4f94b94414066ffbb2b
-    sha256: 6412811e1592b530e84ea5030dedd7088fbe3258fdad9e60253d681b5be367a2
-  category: main
-  optional: false
-- name: xz
-  version: 5.6.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    liblzma: 5.6.4
-    liblzma-devel: 5.6.4
-    xz-gpl-tools: 5.6.4
-    xz-tools: 5.6.4
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.6.4-h9a6d368_0.conda
-  hash:
-    md5: b6e676c2c7fde19f56e052acb6acc540
-    sha256: 0ca773e9d3af963414ac9d78c699c5048902bd336fbc989480c5e8a297cfcd10
-  category: main
-  optional: false
-- name: xz-gpl-tools
-  version: 5.6.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    liblzma: 5.6.4
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.6.4-hbcc6ac9_0.conda
-  hash:
-    md5: 246840b451f7a66bd68869e56b066dd5
-    sha256: 300fc4e5993a36c979e61b1a38d00f0c23c0c56d5989be537cbc7bd8658254ed
-  category: main
-  optional: false
-- name: xz-gpl-tools
-  version: 5.6.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    liblzma: 5.6.4
-  url: https://conda.anaconda.org/conda-forge/osx-64/xz-gpl-tools-5.6.4-h357f2ed_0.conda
-  hash:
-    md5: bbe2c5315d02654eb195bdf012bad66c
-    sha256: 57430768c0f26413dadec7fa4ac203984372a67e906a271f68777d1ad0085d20
-  category: main
-  optional: false
-- name: xz-gpl-tools
-  version: 5.6.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    liblzma: 5.6.4
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.6.4-h9a6d368_0.conda
-  hash:
-    md5: a2580f5af9e67d0e44a97c015eea94d3
-    sha256: a380a32a392df8e9c03399197d3e3c6da1b98873b8733b8a9e22d3689a775471
-  category: main
-  optional: false
-- name: xz-tools
-  version: 5.6.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    liblzma: 5.6.4
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.6.4-hb9d3cd8_0.conda
-  hash:
-    md5: a098f9f949af52610fdceb8e35b57513
-    sha256: 57506a312d8cfbee98217fb382822bd49794ea6318dd4e0413a0d588dc6f4f69
-  category: main
-  optional: false
-- name: xz-tools
-  version: 5.6.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    liblzma: 5.6.4
-  url: https://conda.anaconda.org/conda-forge/osx-64/xz-tools-5.6.4-hd471939_0.conda
-  hash:
-    md5: 479783497192d1ad6671cbd0080f6dcb
-    sha256: 5361cadd518a24a19b009cfea1c113bea979b040858a15bbbd3a58c4d4f9774a
-  category: main
-  optional: false
-- name: xz-tools
-  version: 5.6.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    liblzma: 5.6.4
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.6.4-h39f12f2_0.conda
-  hash:
-    md5: e0ecdb9bfea05d0a763453071e375fc6
-    sha256: 4f18cc820f63ad3783c38763eb84132db00940d3291c0d03dc66ec8582e0cf84
   category: main
   optional: false
 - name: yaml
@@ -19409,8 +16251,8 @@ package:
   hash:
     md5: 6822c49f294d4355f19d314b8b6063d8
     sha256: 6b054c93dd19fd7544af51b41a8eacca2ab62271f6c0c5a2a0cffe80dc37a0ce
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: yarl
   version: 1.18.3
   manager: conda
@@ -19426,8 +16268,8 @@ package:
   hash:
     md5: c9c69a722e1cb1250608ed6c58bd2215
     sha256: 0aa40f238e282d8b0a549732722ec655b752ff1bf6c0e0b5248aba16cc57a527
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: yarl
   version: 1.18.3
   manager: conda
@@ -19443,8 +16285,8 @@ package:
   hash:
     md5: 092d3b40acc67c470f379049be343a7a
     sha256: 48821d23567ca0f853eee6f7812c74392867e123798b5b3c44f58758d8eb580e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: zeromq
   version: 4.3.5
   manager: conda
@@ -19656,434 +16498,39 @@ package:
     sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
   category: main
   optional: false
-- name: backcall
-  version: 0.2.0
-  manager: pip
-  platform: linux-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/4c/1c/ff6546b6c12603d8dd1070aa3c3d273ad4c07f5771689a7b69a550e8c951/backcall-0.2.0-py2.py3-none-any.whl
-  hash:
-    sha256: fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255
-  category: main
-  optional: false
-- name: backcall
-  version: 0.2.0
-  manager: pip
-  platform: osx-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/4c/1c/ff6546b6c12603d8dd1070aa3c3d273ad4c07f5771689a7b69a550e8c951/backcall-0.2.0-py2.py3-none-any.whl
-  hash:
-    sha256: fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255
-  category: main
-  optional: false
-- name: backcall
-  version: 0.2.0
-  manager: pip
-  platform: osx-arm64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/4c/1c/ff6546b6c12603d8dd1070aa3c3d273ad4c07f5771689a7b69a550e8c951/backcall-0.2.0-py2.py3-none-any.whl
-  hash:
-    sha256: fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255
-  category: main
-  optional: false
-- name: boto3
-  version: 1.34.162
-  manager: pip
-  platform: linux-64
-  dependencies:
-    botocore: '>=1.34.162,<1.35.0'
-    jmespath: '>=0.7.1,<2.0.0'
-    s3transfer: '>=0.10.0,<0.11.0'
-  url: https://files.pythonhosted.org/packages/65/41/faa5081761be3bac3999f912996c14c4dc9d06eab86c234bd6441f54bd64/boto3-1.34.162-py3-none-any.whl
-  hash:
-    sha256: d6f6096bdab35a0c0deff469563b87d184a28df7689790f7fe7be98502b7c590
-  category: main
-  optional: false
-- name: boto3
-  version: 1.34.162
-  manager: pip
-  platform: osx-64
-  dependencies:
-    botocore: '>=1.34.162,<1.35.0'
-    jmespath: '>=0.7.1,<2.0.0'
-    s3transfer: '>=0.10.0,<0.11.0'
-  url: https://files.pythonhosted.org/packages/65/41/faa5081761be3bac3999f912996c14c4dc9d06eab86c234bd6441f54bd64/boto3-1.34.162-py3-none-any.whl
-  hash:
-    sha256: d6f6096bdab35a0c0deff469563b87d184a28df7689790f7fe7be98502b7c590
-  category: main
-  optional: false
-- name: boto3
-  version: 1.34.162
-  manager: pip
-  platform: osx-arm64
-  dependencies:
-    botocore: '>=1.34.162,<1.35.0'
-    jmespath: '>=0.7.1,<2.0.0'
-    s3transfer: '>=0.10.0,<0.11.0'
-  url: https://files.pythonhosted.org/packages/65/41/faa5081761be3bac3999f912996c14c4dc9d06eab86c234bd6441f54bd64/boto3-1.34.162-py3-none-any.whl
-  hash:
-    sha256: d6f6096bdab35a0c0deff469563b87d184a28df7689790f7fe7be98502b7c590
-  category: main
-  optional: false
-- name: botocore
-  version: 1.34.162
-  manager: pip
-  platform: linux-64
-  dependencies:
-    jmespath: '>=0.7.1,<2.0.0'
-    python-dateutil: '>=2.1,<3.0.0'
-    urllib3: '>=1.25.4,<2.2.0 || >2.2.0,<3'
-  url: https://files.pythonhosted.org/packages/bc/47/e35f788047c91110f48703a6254e5c84e33111b3291f7b57a653ca00accf/botocore-1.34.162-py3-none-any.whl
-  hash:
-    sha256: 2d918b02db88d27a75b48275e6fb2506e9adaaddbec1ffa6a8a0898b34e769be
-  category: main
-  optional: false
-- name: botocore
-  version: 1.34.162
-  manager: pip
-  platform: osx-64
-  dependencies:
-    jmespath: '>=0.7.1,<2.0.0'
-    python-dateutil: '>=2.1,<3.0.0'
-    urllib3: '>=1.25.4,<2.2.0 || >2.2.0,<3'
-  url: https://files.pythonhosted.org/packages/bc/47/e35f788047c91110f48703a6254e5c84e33111b3291f7b57a653ca00accf/botocore-1.34.162-py3-none-any.whl
-  hash:
-    sha256: 2d918b02db88d27a75b48275e6fb2506e9adaaddbec1ffa6a8a0898b34e769be
-  category: main
-  optional: false
-- name: botocore
-  version: 1.34.162
-  manager: pip
-  platform: osx-arm64
-  dependencies:
-    jmespath: '>=0.7.1,<2.0.0'
-    python-dateutil: '>=2.1,<3.0.0'
-    urllib3: '>=1.25.4,<2.2.0 || >2.2.0,<3'
-  url: https://files.pythonhosted.org/packages/bc/47/e35f788047c91110f48703a6254e5c84e33111b3291f7b57a653ca00accf/botocore-1.34.162-py3-none-any.whl
-  hash:
-    sha256: 2d918b02db88d27a75b48275e6fb2506e9adaaddbec1ffa6a8a0898b34e769be
-  category: main
-  optional: false
-- name: chroma-py
-  version: 0.1.0.dev1
-  manager: pip
-  platform: linux-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/23/3c/39d07abb9d4bcda64d9c50a4fda2ecfee4d76a436bd590d232a4e1a5ad43/chroma-py-0.1.0.dev1.tar.gz
-  hash:
-    sha256: 0dc1135332e2ed6e74d7b355c8afa7b85c193a7d5af1cb8b6f79c9e2645912b2
-  category: main
-  optional: false
-- name: chroma-py
-  version: 0.1.0.dev1
-  manager: pip
-  platform: osx-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/23/3c/39d07abb9d4bcda64d9c50a4fda2ecfee4d76a436bd590d232a4e1a5ad43/chroma-py-0.1.0.dev1.tar.gz
-  hash:
-    sha256: 0dc1135332e2ed6e74d7b355c8afa7b85c193a7d5af1cb8b6f79c9e2645912b2
-  category: main
-  optional: false
-- name: chroma-py
-  version: 0.1.0.dev1
-  manager: pip
-  platform: osx-arm64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/23/3c/39d07abb9d4bcda64d9c50a4fda2ecfee4d76a436bd590d232a4e1a5ad43/chroma-py-0.1.0.dev1.tar.gz
-  hash:
-    sha256: 0dc1135332e2ed6e74d7b355c8afa7b85c193a7d5af1cb8b6f79c9e2645912b2
-  category: main
-  optional: false
-- name: colour
-  version: 0.1.5
-  manager: pip
-  platform: linux-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/74/46/e81907704ab203206769dee1385dc77e1407576ff8f50a0681d0a6b541be/colour-0.1.5-py2.py3-none-any.whl
-  hash:
-    sha256: 33f6db9d564fadc16e59921a56999b79571160ce09916303d35346dddc17978c
-  category: main
-  optional: false
-- name: colour
-  version: 0.1.5
-  manager: pip
-  platform: osx-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/74/46/e81907704ab203206769dee1385dc77e1407576ff8f50a0681d0a6b541be/colour-0.1.5-py2.py3-none-any.whl
-  hash:
-    sha256: 33f6db9d564fadc16e59921a56999b79571160ce09916303d35346dddc17978c
-  category: main
-  optional: false
-- name: colour
-  version: 0.1.5
-  manager: pip
-  platform: osx-arm64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/74/46/e81907704ab203206769dee1385dc77e1407576ff8f50a0681d0a6b541be/colour-0.1.5-py2.py3-none-any.whl
-  hash:
-    sha256: 33f6db9d564fadc16e59921a56999b79571160ce09916303d35346dddc17978c
-  category: main
-  optional: false
-- name: configparser
-  version: 6.0.1
-  manager: pip
-  platform: linux-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/bf/c1/c9d33f208bf25164ec315a571a9c0a6b71a5d38f364426db987cec12a152/configparser-6.0.1-py3-none-any.whl
-  hash:
-    sha256: 5a0da275bea56f871abaa9e0806331791e9d8ae2938e8b8797b99ab3e8e192c4
-  category: main
-  optional: false
-- name: configparser
-  version: 6.0.1
-  manager: pip
-  platform: osx-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/bf/c1/c9d33f208bf25164ec315a571a9c0a6b71a5d38f364426db987cec12a152/configparser-6.0.1-py3-none-any.whl
-  hash:
-    sha256: 5a0da275bea56f871abaa9e0806331791e9d8ae2938e8b8797b99ab3e8e192c4
-  category: main
-  optional: false
-- name: configparser
-  version: 6.0.1
-  manager: pip
-  platform: osx-arm64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/bf/c1/c9d33f208bf25164ec315a571a9c0a6b71a5d38f364426db987cec12a152/configparser-6.0.1-py3-none-any.whl
-  hash:
-    sha256: 5a0da275bea56f871abaa9e0806331791e9d8ae2938e8b8797b99ab3e8e192c4
-  category: main
-  optional: false
-- name: geojson
-  version: 3.1.0
-  manager: pip
-  platform: linux-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/8e/1b/4f57660aa148d3e3043d048b7e1ab87dfeb85204d0fdb5b4e19c08202162/geojson-3.1.0-py3-none-any.whl
-  hash:
-    sha256: 68a9771827237adb8c0c71f8527509c8f5bef61733aa434cefc9c9d4f0ebe8f3
-  category: main
-  optional: false
-- name: geojson
-  version: 3.1.0
-  manager: pip
-  platform: osx-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/8e/1b/4f57660aa148d3e3043d048b7e1ab87dfeb85204d0fdb5b4e19c08202162/geojson-3.1.0-py3-none-any.whl
-  hash:
-    sha256: 68a9771827237adb8c0c71f8527509c8f5bef61733aa434cefc9c9d4f0ebe8f3
-  category: main
-  optional: false
-- name: geojson
-  version: 3.1.0
-  manager: pip
-  platform: osx-arm64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/8e/1b/4f57660aa148d3e3043d048b7e1ab87dfeb85204d0fdb5b4e19c08202162/geojson-3.1.0-py3-none-any.whl
-  hash:
-    sha256: 68a9771827237adb8c0c71f8527509c8f5bef61733aa434cefc9c9d4f0ebe8f3
-  category: main
-  optional: false
-- name: ipython
-  version: 8.11.0
-  manager: pip
-  platform: linux-64
-  dependencies:
-    backcall: '*'
-    decorator: '*'
-    jedi: '>=0.16'
-    matplotlib-inline: '*'
-    pickleshare: '*'
-    prompt-toolkit: '>=3.0.30,<3.0.37 || >3.0.37,<3.1.0'
-    pygments: '>=2.4.0'
-    stack-data: '*'
-    traitlets: '>=5'
-    pexpect: '>4.3'
-  url: https://files.pythonhosted.org/packages/ac/91/23e08c442657cf493598b0222008437c9e0aef0709a8fd65a5d5d68ffa21/ipython-8.11.0-py3-none-any.whl
-  hash:
-    sha256: 5b54478e459155a326bf5f42ee4f29df76258c0279c36f21d71ddb560f88b156
-  category: main
-  optional: false
-- name: ipython
-  version: 8.11.0
-  manager: pip
-  platform: osx-64
-  dependencies:
-    backcall: '*'
-    decorator: '*'
-    jedi: '>=0.16'
-    matplotlib-inline: '*'
-    pickleshare: '*'
-    prompt-toolkit: '>=3.0.30,<3.0.37 || >3.0.37,<3.1.0'
-    pygments: '>=2.4.0'
-    stack-data: '*'
-    traitlets: '>=5'
-    pexpect: '>4.3'
-    appnope: '*'
-  url: https://files.pythonhosted.org/packages/ac/91/23e08c442657cf493598b0222008437c9e0aef0709a8fd65a5d5d68ffa21/ipython-8.11.0-py3-none-any.whl
-  hash:
-    sha256: 5b54478e459155a326bf5f42ee4f29df76258c0279c36f21d71ddb560f88b156
-  category: main
-  optional: false
-- name: ipython
-  version: 8.11.0
-  manager: pip
-  platform: osx-arm64
-  dependencies:
-    backcall: '*'
-    decorator: '*'
-    jedi: '>=0.16'
-    matplotlib-inline: '*'
-    pickleshare: '*'
-    prompt-toolkit: '>=3.0.30,<3.0.37 || >3.0.37,<3.1.0'
-    pygments: '>=2.4.0'
-    stack-data: '*'
-    traitlets: '>=5'
-    pexpect: '>4.3'
-    appnope: '*'
-  url: https://files.pythonhosted.org/packages/ac/91/23e08c442657cf493598b0222008437c9e0aef0709a8fd65a5d5d68ffa21/ipython-8.11.0-py3-none-any.whl
-  hash:
-    sha256: 5b54478e459155a326bf5f42ee4f29df76258c0279c36f21d71ddb560f88b156
-  category: main
-  optional: false
 - name: maap-py
-  version: 3.1.5
+  version: 0.0.0
   manager: pip
   platform: linux-64
-  dependencies:
-    backoff: '>=2.2,<3.0'
-    boto3: '>=1.34.41,<1.35.0'
-    configparser: '>=6.0,<7.0'
-    importlib-resources: '>=6.0,<7.0'
-    ipython: 8.11.0
-    mapboxgl: '>=0.10,<1.0'
-    pyyaml: '>=6.0,<7.0'
-    requests: '>=2.31,<3.0'
+  dependencies: {}
   url: git+https://github.com/MAAP-Project/maap-py.git@1887545b4faa03f4e3a6ffcf25e3b170894d3a75
-  hash:
-    sha256: 1887545b4faa03f4e3a6ffcf25e3b170894d3a75
+  hash: {}
   category: main
   source:
     type: url
     url: git+https://github.com/MAAP-Project/maap-py.git@1887545b4faa03f4e3a6ffcf25e3b170894d3a75
   optional: false
 - name: maap-py
-  version: 3.1.5
+  version: 0.0.0
   manager: pip
   platform: osx-64
-  dependencies:
-    backoff: '>=2.2,<3.0'
-    boto3: '>=1.34.41,<1.35.0'
-    configparser: '>=6.0,<7.0'
-    importlib-resources: '>=6.0,<7.0'
-    ipython: 8.11.0
-    mapboxgl: '>=0.10,<1.0'
-    pyyaml: '>=6.0,<7.0'
-    requests: '>=2.31,<3.0'
+  dependencies: {}
   url: git+https://github.com/MAAP-Project/maap-py.git@1887545b4faa03f4e3a6ffcf25e3b170894d3a75
-  hash:
-    sha256: 1887545b4faa03f4e3a6ffcf25e3b170894d3a75
+  hash: {}
   category: main
   source:
     type: url
     url: git+https://github.com/MAAP-Project/maap-py.git@1887545b4faa03f4e3a6ffcf25e3b170894d3a75
   optional: false
 - name: maap-py
-  version: 3.1.5
+  version: 0.0.0
   manager: pip
   platform: osx-arm64
-  dependencies:
-    backoff: '>=2.2,<3.0'
-    boto3: '>=1.34.41,<1.35.0'
-    configparser: '>=6.0,<7.0'
-    importlib-resources: '>=6.0,<7.0'
-    ipython: 8.11.0
-    mapboxgl: '>=0.10,<1.0'
-    pyyaml: '>=6.0,<7.0'
-    requests: '>=2.31,<3.0'
+  dependencies: {}
   url: git+https://github.com/MAAP-Project/maap-py.git@1887545b4faa03f4e3a6ffcf25e3b170894d3a75
-  hash:
-    sha256: 1887545b4faa03f4e3a6ffcf25e3b170894d3a75
+  hash: {}
   category: main
   source:
     type: url
     url: git+https://github.com/MAAP-Project/maap-py.git@1887545b4faa03f4e3a6ffcf25e3b170894d3a75
-  optional: false
-- name: mapboxgl
-  version: 0.10.2
-  manager: pip
-  platform: linux-64
-  dependencies:
-    jinja2: '*'
-    geojson: '*'
-    chroma-py: '*'
-    colour: '*'
-    matplotlib: '*'
-  url: https://files.pythonhosted.org/packages/4f/e1/cdaa6c2f6d3a7a29b0b9a675dcfc25f4c481d577d137da8c769f13014ce5/mapboxgl-0.10.2-py2.py3-none-any.whl
-  hash:
-    sha256: 19a81d16d66da49ba4a55a7a28eb2f1fd8d07f2885f6b3a6d386769eefab17ae
-  category: main
-  optional: false
-- name: mapboxgl
-  version: 0.10.2
-  manager: pip
-  platform: osx-64
-  dependencies:
-    jinja2: '*'
-    geojson: '*'
-    chroma-py: '*'
-    colour: '*'
-    matplotlib: '*'
-  url: https://files.pythonhosted.org/packages/4f/e1/cdaa6c2f6d3a7a29b0b9a675dcfc25f4c481d577d137da8c769f13014ce5/mapboxgl-0.10.2-py2.py3-none-any.whl
-  hash:
-    sha256: 19a81d16d66da49ba4a55a7a28eb2f1fd8d07f2885f6b3a6d386769eefab17ae
-  category: main
-  optional: false
-- name: mapboxgl
-  version: 0.10.2
-  manager: pip
-  platform: osx-arm64
-  dependencies:
-    jinja2: '*'
-    geojson: '*'
-    chroma-py: '*'
-    colour: '*'
-    matplotlib: '*'
-  url: https://files.pythonhosted.org/packages/4f/e1/cdaa6c2f6d3a7a29b0b9a675dcfc25f4c481d577d137da8c769f13014ce5/mapboxgl-0.10.2-py2.py3-none-any.whl
-  hash:
-    sha256: 19a81d16d66da49ba4a55a7a28eb2f1fd8d07f2885f6b3a6d386769eefab17ae
-  category: main
-  optional: false
-- name: s3transfer
-  version: 0.10.4
-  manager: pip
-  platform: linux-64
-  dependencies:
-    botocore: '>=1.33.2,<2.0a.0'
-  url: https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl
-  hash:
-    sha256: 244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e
-  category: main
-  optional: false
-- name: s3transfer
-  version: 0.10.4
-  manager: pip
-  platform: osx-64
-  dependencies:
-    botocore: '>=1.33.2,<2.0a.0'
-  url: https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl
-  hash:
-    sha256: 244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e
-  category: main
-  optional: false
-- name: s3transfer
-  version: 0.10.4
-  manager: pip
-  platform: osx-arm64
-  dependencies:
-    botocore: '>=1.33.2,<2.0a.0'
-  url: https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl
-  hash:
-    sha256: 244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e
-  category: main
   optional: false

--- a/docs/MAAP_USAGE.md
+++ b/docs/MAAP_USAGE.md
@@ -143,9 +143,9 @@ optional inputs:
   the output format.  Supported formats inferred from file extensions are as
   follows:
 
+  - FlatGeobuf: `.fgb`
   - GPKG (GeoPackage): `.gpkg`
   - (Geo)Parquet: `.parquet`
-  - FlatGeobuf: `.fgb`
 
   > _Added in version 0.6.0_
 

--- a/docs/MAAP_USAGE.md
+++ b/docs/MAAP_USAGE.md
@@ -145,13 +145,7 @@ optional inputs:
 
   - GPKG (GeoPackage): `.gpkg`
   - (Geo)Parquet: `.parquet`
-  - Feather (V2): `.feather`
   - FlatGeobuf: `.fgb`
-  - GeoJSON: `.json`, `.geojson`
-  - GeoJSONSeq: `.geojsonl`, `.geojsons`
-  - GML: `.gml`, `.xml`
-  - MapInfo File: `.mid`, `.mif`, `.tab`
-  - ESRI Shapefile: `.dbf`, `.shp`
 
   > _Added in version 0.6.0_
 

--- a/docs/MAAP_USAGE.md
+++ b/docs/MAAP_USAGE.md
@@ -133,26 +133,30 @@ optional inputs:
 
   > _Added in version 0.6.0_
 
-- `output` (_optional_): Name to use for the output file.  This can also include
-  a path, which will be relative to the standard DPS output directory for a job.
-  **Default:** the output file will be named the same as the name of the AOI
-  file, but with a suffix of `"_subset.gpkg"`.
+- `output` (_optional_): Name to use for the output file.  This may include a
+  path, which will be relative to the standard DPS output directory for a job.
+  **Default:** when a value is not supplied, the output file will be named the
+  same as the name of the AOI file, but with a suffix of `"_subset.gpkg"`
+  (GeoPackage format).
 
-  When explicitly specifying a name, it does not need to include an extension,
-  because a `.gpkg` extension will be added automatically.  If an extension is
-  supplied, it will be replaced with `.gpkg`.
+  When a value is supplied, it must include a file extension in order to infer
+  the output format.  Supported formats inferred from file extensions are as
+  follows:
 
-  Examples showing how the value specified for `output` is mapped to a final
-  output file:
-
-  - Unspecified -> `myaoi.gpkg`, where `myaoi.geojson` is the name of the AOI
-    file
-  - `myoutput` -> `myoutput.gpkg`
-  - `myoutput.gpkg` -> `myoutput.gpkg`
-  - `myoutput.h5` -> `myoutput.gpkg`
-  - `mypath/myoutput` -> `mypath/myoutput.gpkg`
+  - GPKG (GeoPackage): `.gpkg`
+  - (Geo)Parquet: `.parquet`
+  - Feather (V2): `.feather`
+  - FlatGeobuf: `.fgb`
+  - GeoJSON: `.json`, `.geojson`
+  - GeoJSONSeq: `.geojsonl`, `.geojsons`
+  - GML: `.gml`, `.xml`
+  - MapInfo File: `.mid`, `.mif`, `.tab`
+  - ESRI Shapefile: `.dbf`, `.shp`
 
   > _Added in version 0.6.0_
+
+  > _Changed in version 0.10.0_: Output formats other than GeoPackage (`.gpkg`)
+  are now supported.
 
 - `fsspec_kwargs` (_optional_; default:
   `'{"default_cache_type": "all", "default_block_size": 8388608`): JSON object

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,26 +5,24 @@ channels:
 # Non-standard, but recognized by conda-lock
 category: dev
 dependencies:
-  - backoff~=2.2
-  - black~=24.0
-  # boto*-stubs constraints should align with boto3 constraint in environment.yml
-  - boto3-stubs~=1.33
-  - boto3-stubs-essential~=1.33
-  - botocore-stubs~=1.33
-  - contextily~=1.3
-  - flake8~=7.0
-  - ipykernel~=6.23
-  - isort~=5.13
-  - moto~=4.1
-  - mypy~=1.2
-  # pandas-stubs constraint should align with pandas constraint in environment.yml
-  - pandas-stubs~=2.0
-  - pre-commit~=3.3
-  - pytest~=7.3
-  - pytest-recording~=0.13
-  - vcrpy~=6.0
-  - shellcheck~=0.9
-  - types-requests~=2.30
+  - backoff
+  - black
+  - boto3-stubs
+  - boto3-stubs-essential
+  - botocore-stubs
+  - contextily
+  - flake8
+  - ipykernel
+  - isort
+  - moto
+  - mypy
+  - pandas-stubs
+  - pre-commit
+  - pytest
+  - pytest-recording
+  - vcrpy
+  - shellcheck
+  - types-requests
 platforms:
   - linux-64
   - osx-64

--- a/environment.yml
+++ b/environment.yml
@@ -9,27 +9,27 @@ channels:
 dependencies:
   - python~=3.12.0
 
-  - boto3~=1.33
-  - bottleneck~=1.3 # pandas performance
-  - conda~=24.0
-  - conda-lock~=2.0
-  - fsspec~=2024.6 # keep in sync w/s3fs version
-  - geopandas~=1.0
-  - h5py~=3.9
-  - numba~=0.56 # pandas performance
-  - numexpr~=2.8 # pandas performance
-  - pandas~=2.0
-  - pip~=24.0
-  - pyarrow~=14.0 # parquet support in pandas
-  - pydantic~=2.0
-  - returns~=0.20
-  - s3fs~=2024.6 # keep in sync w/fsspec
-  - scalene~=1.5 # CPU+mem profiling
-  - shapely~=2.0
-  - typer~=0.9 # CLI
+  - boto3
+  - bottleneck # pandas performance
+  - conda
+  - conda-lock
+  - fsspec
+  - geopandas
+  - h5py
+  - numba # pandas performance
+  - numexpr # pandas performance
+  - pandas
+  - pip
+  - pyarrow # parquet support in pandas
+  - pydantic
+  - returns
+  - s3fs
+  - scalene # CPU+mem profiling
+  - shapely
+  - typer # CLI
 
   - pip:
-      - git+https://github.com/MAAP-Project/maap-py.git@v4.0.0
+      - maap-py
 
 platforms:
   - linux-64

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
 # https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#performance-dependencies-recommended
 
 dependencies:
-  - python~=3.12.0
+  - python ~=3.12.0
 
   - boto3
   - bottleneck # pandas performance
@@ -23,13 +23,14 @@ dependencies:
   - pyarrow # parquet support in pandas
   - pydantic
   - returns
-  - s3fs
+  # Oddly, when completely unpinned, a very old version of s3fs is installed
+  - s3fs >=2025.1.0
   - scalene # CPU+mem profiling
   - shapely
   - typer # CLI
 
   - pip:
-      - maap-py
+      - maap-py >=4.0
 
 platforms:
   - linux-64

--- a/src/gedi_subset/gedi_utils.py
+++ b/src/gedi_subset/gedi_utils.py
@@ -3,6 +3,7 @@ import logging
 import os
 import os.path
 import warnings
+from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Sequence, Union, cast
 
 import h5py
@@ -59,6 +60,46 @@ def gdf_to_parquet(
 def gdf_read_parquet(path: Union[str, os.PathLike[str]]) -> IOResultE[gpd.GeoDataFrame]:
     """Read a Parquet object from a file path and return it as a GeoDataFrame."""
     return impure_safe(gpd.read_parquet)(path)
+
+
+def gdf_reformat(path: Union[str, os.PathLike[str]], suffix: str) -> None:
+    """
+    Convert a GeoDataFrame written in one format to another format.
+
+    Do nothing if the `suffix` property of the path is the same as the specified
+    suffix.  Otherwise, read the GeoDataFrame at the specified path and write it
+    back out next to the original file, but with the specified suffix, and then
+    remove the original file.
+
+    Parameters
+    ----------
+    path:
+        Path to an existing GeoDataFrame written to the filesystem.
+    suffix:
+        Desired format, expressed as a destination file suffix, including a
+        leading dot (`.`), just like the `suffix` property of a `Path` includes.
+        Supported values: ".parquet", ".feather", or any suffix supported by
+        `GeoDataFrame.to_file`, which will use the suffix to guess the
+        appropriate driver.
+    """
+    src_path = path if isinstance(path, Path) else Path(path)
+    dst_path = src_path.with_suffix(suffix)
+
+    # No need to waste time when the file is already in the desired format
+    if src_path.suffix == suffix:
+        return
+
+    gdf: gpd.GeoDataFrame = gpd.read_file(path)
+
+    if suffix == ".parquet":
+        gdf.to_parquet(dst_path)
+    elif suffix == ".feather":
+        gdf.to_feather(dst_path)
+    else:
+        # Let to_file guess the appropriate driver based upon the file suffix
+        gdf.to_file(dst_path)
+
+    os.remove(path)
 
 
 def get_geo_boundary(iso: str, level: int) -> gpd.GeoDataFrame:

--- a/src/gedi_subset/gedi_utils.py
+++ b/src/gedi_subset/gedi_utils.py
@@ -78,9 +78,7 @@ def gdf_reformat(path: Union[str, os.PathLike[str]], suffix: str) -> None:
     suffix:
         Desired format, expressed as a destination file suffix, including a
         leading dot (`.`), just like the `suffix` property of a `Path` includes.
-        Supported values: ".parquet", ".feather", or any suffix supported by
-        `GeoDataFrame.to_file`, which will use the suffix to guess the
-        appropriate driver.
+        Supported values: ".fgb", ".gpkg", ".parquet".
     """
     src_path = path if isinstance(path, Path) else Path(path)
     dst_path = src_path.with_suffix(suffix)
@@ -93,11 +91,13 @@ def gdf_reformat(path: Union[str, os.PathLike[str]], suffix: str) -> None:
 
     if suffix == ".parquet":
         gdf.to_parquet(dst_path)
-    elif suffix == ".feather":
-        gdf.to_feather(dst_path)
-    else:
-        # Let to_file guess the appropriate driver based upon the file suffix
+    elif suffix.lower() in {".fgb", ".gpkg"}:
         gdf.to_file(dst_path)
+    else:
+        raise ValueError(
+            "Unsupported output format."
+            f" Expected '.fgb', '.gpkg', or '.parquet': {dst_path}"
+        )
 
     os.remove(path)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import geopandas as gpd
 import h5py
 import pytest
 from maap.maap import MAAP
-from moto import mock_s3
+from moto import mock_aws
 from mypy_boto3_s3.client import S3Client
 
 
@@ -22,7 +22,7 @@ def aws_credentials() -> None:
 
 @pytest.fixture(scope="function")
 def s3(aws_credentials) -> Iterable[S3Client]:
-    with mock_s3():
+    with mock_aws():
         yield boto3.client("s3", region_name="us-east-1")
 
 


### PR DESCRIPTION
Allow user to specify the following output formats by supplying the appropriate output filename extension:

  - GPKG (GeoPackage): `.gpkg`
  - (Geo)Parquet: `.parquet`
  - Feather (V2): `.feather`
  - FlatGeobuf: `.fgb`
  - GeoJSON: `.json`, `.geojson`
  - GeoJSONSeq: `.geojsonl`, `.geojsons`
  - GML: `.gml`, `.xml`
  - MapInfo File: `.mid`, `.mif`, `.tab`
  - ESRI Shapefile: `.dbf`, `.shp`

To test this, you can do the following **in the MAAP**:

1. clone this repo, if you haven't already done so
2. cd into the cloned repo dir
3. checkout this PR's branch (alternate-output-formats)
4. run `bin/create` (with no args) to create the conda env
5. run `bin/install` (with no args) to install dependencies
6. run the subsetter on a small number of granules:

    conda run --no-capture-output -n gedi_subset python src/gedi_subset/subset.py --aoi /projects/shared-buckets/dschuck/iso3/GAB-ADM0.geojson --doi L4A --lat lat_lowestmode --lon lon_lowestmode --columns agbd --output /tmp/GAB-ADM0.parquet --limit 10

7. check the result (this only confirms a parquet file was written and can be read, not the validity of the contents):

    conda run --no-capture-output -n gedi_subset python -c 'import geopandas as gpd; print(gpd.read_parquet("/tmp/GAB-ADM0.parquet").head())'

8. remove the output file: `rm /tmp/GAB-ADM0.parquet`

Fixes #97