### PR TITLE
Add failure tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Add "requester pays" flag for reading granule data files from S3
   ([#138](https://github.com/MAAP-Project/gedi-subsetter/issues/138))
+- Add `tolerated_failure_percentage` input to control percentage of individual
+  granule failures to tolerate before failing a job.  Default tolerance is 0
+  (i.e., fail fast), thus any single failure will immediately fail the job.
+  ([#62](https://github.com/MAAP-Project/gedi-subsetter/issues/62))
 
 ## [0.11.0] (2025-04-25)
 

--- a/algorithm_config.yaml
+++ b/algorithm_config.yaml
@@ -62,6 +62,11 @@ inputs:
         using the AOI file name (without the extension) with the suffix "_subset.gpkg".
       required: false
       default: ""
+    - name: tolerated_failure_percentage
+      description: Integral percentage of individual granule subset failures tolerated
+        before causing job failure.
+      required: false
+      default: ""
     - name: fsspec_kwargs
       description: "JSON object representing keyword arguments to pass to the
         fsspec.core.url_to_fs function when reading granule data files.  See

--- a/bin/subset.sh
+++ b/bin/subset.sh
@@ -25,7 +25,7 @@ else
     aoi="$(ls "${input_dir}"/*)"
 
     n_actual=${#}
-    n_expected=12
+    n_expected=13
 
     if test ${n_actual} -ne ${n_expected}; then
         echo "Expected ${n_expected} inputs, but got ${n_actual}:$(printf " '%b'" "$@")" >&2
@@ -43,10 +43,11 @@ else
     [[ -n "${8}" ]] && args+=(--limit "${8}")
     # always specify output dir, even if user doesn't specify output file
     args+=(--output "${output_dir}/${9}")
-    [[ -n "${10}" ]] && args+=(--fsspec-kwargs "${10}")
-    [[ -n "${11}" ]] && args+=(--processes "${11}")
+    [[ -n "${10}" ]] && args+=(--tolerated-failure-percentage "${10}")
+    [[ -n "${11}" ]] && args+=(--fsspec-kwargs "${11}")
+    [[ -n "${12}" ]] && args+=(--processes "${12}")
     # Split the last argument into an array of arguments to pass to scalene.
-    IFS=' ' read -ra scalene_args <<<"${12}"
+    IFS=' ' read -ra scalene_args <<<"${13}"
 
     command=("${subset_py}" "${args[@]}")
 

--- a/docs/MAAP_USAGE.md
+++ b/docs/MAAP_USAGE.md
@@ -156,6 +156,13 @@ optional inputs:
   > _Changed in version 0.10.0_: Output formats other than GeoPackage (`.gpkg`)
   are now supported.
 
+- `tolerated_failure_percentage` (_optional_; default: 0): Integral percentage
+  of individual granule subset failures to tolerate before failing a job.
+  Default tolerance is 0 (i.e., fail fast), thus any single granule failure will
+  immediately fail the job.
+
+  > _Added in version 0.12.0_
+
 - `fsspec_kwargs` (_optional_; default:
   `'{"default_cache_type": "mmap", "default_block_size": 5242880, "requester_pays": true}'`
   JSON object representing keyword arguments to pass to the [fsspec.url_to_fs]


### PR DESCRIPTION
@wildintellect, I wanted to get this done before SciPy so that it is available for Amelia sooner rather than later, since she recently commented on the issue.

This adds a `tolerated_failure_percentage` input to allow control over the percentage of individual granule subset failures will cause the job to fail, defaulting to 0 (i.e., no failures allowed).

For those who wish to allow perhaps a small percentage of (possible transient) failures, they can set this to some value greater than 0 (up to 100, obviously).

If you approve this today, I'll cut the 0.12 release today as well, so Amelia can use it next week. (I'll keep an eye on emails.)

Fixes #62