### PR TITLE
Prepare release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+## [0.12.0] (2025-07-03)
+
 ### Changed
 
 - Add "requester pays" flag for reading granule data files from S3
@@ -256,4 +258,5 @@ The format is based on [Keep a Changelog], and this project adheres to
 [0.9.0]: https://github.com/MAAP-Project/gedi-subsetter/releases/tag/0.9.0
 [0.10.0]: https://github.com/MAAP-Project/gedi-subsetter/releases/tag/0.10.0
 [0.11.0]: https://github.com/MAAP-Project/gedi-subsetter/releases/tag/0.11.0
-[Unreleased]: https://github.com/MAAP-Project/gedi-subsetter/compare/0.11.0...HEAD
+[0.12.0]: https://github.com/MAAP-Project/gedi-subsetter/releases/tag/0.12.0
+[Unreleased]: https://github.com/MAAP-Project/gedi-subsetter/compare/0.12.0...HEAD

--- a/algorithm_config.yaml
+++ b/algorithm_config.yaml
@@ -1,6 +1,6 @@
 algorithm_description: Subset GEDI L1B, L2A, L2B, L4A, or L4C granules within an area of interest (AOI)
 algorithm_name: gedi-subset
-algorithm_version: 0.11.0
+algorithm_version: 0.12.0
 repository_url: https://github.com/MAAP-Project/gedi-subsetter.git
 docker_container_url: mas.maap-project.org/root/maap-workspaces/custom_images/maap_base:v4.2.0
 disk_space: 20GB


### PR DESCRIPTION
The changes in this release were deployed and tested in DPS originally from the fail-fast branch, both success and failure scenarios.